### PR TITLE
[Build] add no-app presets for engine/domain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,11 @@
 - Configure: `cmake --preset windows-debug`
 - Build: `cmake --build --preset build-debug`
 - Test: `ctest --preset test-debug`
+- Configure without app: `cmake --preset windows-debug-no-app`
+- Build engine only: `cmake --build --preset build-engine-debug`
+- Build engine + domain: `cmake --build --preset build-engine-domain-debug`
+- Build engine + domain + tests without app: `cmake --build --preset build-no-app-debug`
+- Test without app: `ctest --preset test-no-app-debug`
 - App target: `safecrowd_app`
 - UI dependency: Qt6 via `vcpkg.json` (`qtbase`)
 - If configure/build fails, check preset/Visual Studio selection and `vcpkg`/Qt availability before assuming the code change caused it.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,12 +18,33 @@
       }
     },
     {
+      "name": "windows-base-no-vcpkg",
+      "hidden": true,
+      "generator": "Visual Studio 17 2022",
+      "architecture": "x64",
+      "binaryDir": "${sourceDir}/build/vs2022/${presetName}"
+    },
+    {
       "name": "windows-debug",
       "inherits": "windows-base"
     },
     {
+      "name": "windows-debug-no-app",
+      "inherits": "windows-base-no-vcpkg",
+      "cacheVariables": {
+        "SAFECROWD_BUILD_APP": "OFF"
+      }
+    },
+    {
       "name": "windows-release",
       "inherits": "windows-base"
+    },
+    {
+      "name": "windows-release-no-app",
+      "inherits": "windows-base-no-vcpkg",
+      "cacheVariables": {
+        "SAFECROWD_BUILD_APP": "OFF"
+      }
     }
   ],
   "buildPresets": [
@@ -36,6 +57,54 @@
       "name": "build-release",
       "configurePreset": "windows-release",
       "configuration": "Release"
+    },
+    {
+      "name": "build-engine-debug",
+      "configurePreset": "windows-debug-no-app",
+      "configuration": "Debug",
+      "targets": [
+        "ecs_engine"
+      ]
+    },
+    {
+      "name": "build-engine-domain-debug",
+      "configurePreset": "windows-debug-no-app",
+      "configuration": "Debug",
+      "targets": [
+        "safecrowd_domain"
+      ]
+    },
+    {
+      "name": "build-no-app-debug",
+      "configurePreset": "windows-debug-no-app",
+      "configuration": "Debug",
+      "targets": [
+        "safecrowd_tests"
+      ]
+    },
+    {
+      "name": "build-engine-release",
+      "configurePreset": "windows-release-no-app",
+      "configuration": "Release",
+      "targets": [
+        "ecs_engine"
+      ]
+    },
+    {
+      "name": "build-engine-domain-release",
+      "configurePreset": "windows-release-no-app",
+      "configuration": "Release",
+      "targets": [
+        "safecrowd_domain"
+      ]
+    },
+    {
+      "name": "build-no-app-release",
+      "configurePreset": "windows-release-no-app",
+      "configuration": "Release",
+      "targets": [
+        "safecrowd_tests"
+      ]
     }
   ],
   "testPresets": [
@@ -50,6 +119,22 @@
     {
       "name": "test-release",
       "configurePreset": "windows-release",
+      "configuration": "Release",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "test-no-app-debug",
+      "configurePreset": "windows-debug-no-app",
+      "configuration": "Debug",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "test-no-app-release",
+      "configurePreset": "windows-release-no-app",
       "configuration": "Release",
       "output": {
         "outputOnFailure": true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,16 @@ cmake --build --preset build-debug
 ctest --preset test-debug
 ```
 
+Application layer를 제외한 빠른 검증이 필요하면 아래 프리셋을 사용합니다.
+
+```powershell
+cmake --preset windows-debug-no-app
+cmake --build --preset build-engine-debug
+cmake --build --preset build-engine-domain-debug
+cmake --build --preset build-no-app-debug
+ctest --preset test-no-app-debug
+```
+
 실행하지 못했다면 PR 본문에 이유를 남깁니다.
 
 ## 머지 규칙


### PR DESCRIPTION
## Summary

- add no-app presets for engine/domain

## Related Issue

- Closes #57 

## Area

- [ ] Engine
- [ ] Domain
- [ ] Application
- [ ] Docs
- [x] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [x] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug`
- [x] `ctest --preset test-debug`
- [x] Not run (reason below)

## Risks / Follow-up

- None
