### PR TITLE
[Engine] CommandBuffer 및 WorldCommands deferred mutation 구현

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(ecs_engine STATIC
     src/engine/EngineSystem.h
     src/engine/FrameClock.h
     src/engine/WorldQuery.h
+    src/engine/CommandBuffer.h
     src/engine/EntityRegistry.cpp
     src/engine/EngineRuntime.cpp
     src/engine/FrameClock.cpp
@@ -110,6 +111,7 @@ if (BUILD_TESTING)
         tests/DxfImportServiceTests.cpp
         tests/FacilityLayoutBuilderTests.cpp
         tests/WorldQueryTests.cpp
+        tests/CommandBufferTests.cpp
     )
 
     target_include_directories(safecrowd_tests

--- a/src/engine/CommandBuffer.h
+++ b/src/engine/CommandBuffer.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <functional>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "engine/EcsCore.h"
+
+namespace safecrowd::engine {
+
+class CommandBuffer {
+public:
+    template <typename... Ts>
+    void spawnEntity(Ts... components) {
+        commands_.push_back(
+            [comps = std::make_tuple(std::move(components)...)](EcsCore& core) mutable {
+                Entity e = core.createEntity();
+                std::apply([&](auto&... c) { (core.addComponent(e, std::move(c)), ...); }, comps);
+            });
+    }
+
+    void destroyEntity(Entity entity) {
+        commands_.emplace_back([entity](EcsCore& core) {
+            core.destroyEntity(entity);
+        });
+    }
+
+    template <typename T>
+    void addComponent(Entity entity, T component) {
+        commands_.emplace_back([entity, comp = std::move(component)](EcsCore& core) mutable {
+            core.addComponent(entity, std::move(comp));
+        });
+    }
+
+    template <typename T>
+    void removeComponent(Entity entity) {
+        commands_.emplace_back([entity](EcsCore& core) {
+            core.removeComponent<T>(entity);
+        });
+    }
+
+    void flush(EcsCore& core) {
+        for (auto& cmd : commands_) {
+            cmd(core);
+        }
+        commands_.clear();
+    }
+
+    [[nodiscard]] bool empty() const noexcept {
+        return commands_.empty();
+    }
+
+private:
+    std::vector<std::function<void(EcsCore&)>> commands_;
+};
+
+class WorldCommands {
+public:
+    explicit WorldCommands(CommandBuffer& buffer) : buffer_(buffer) {}
+
+    template <typename... Ts>
+    void spawnEntity(Ts... components) {
+        buffer_.spawnEntity(std::move(components)...);
+    }
+
+    void destroyEntity(Entity entity) {
+        buffer_.destroyEntity(entity);
+    }
+
+    template <typename T>
+    void addComponent(Entity entity, T component) {
+        buffer_.addComponent(entity, std::move(component));
+    }
+
+    template <typename T>
+    void removeComponent(Entity entity) {
+        buffer_.removeComponent<T>(entity);
+    }
+
+private:
+    CommandBuffer& buffer_;
+};
+
+}  // namespace safecrowd::engine

--- a/tests/CommandBufferTests.cpp
+++ b/tests/CommandBufferTests.cpp
@@ -1,0 +1,129 @@
+#include "TestSupport.h"
+
+#include "engine/CommandBuffer.h"
+
+namespace {
+
+struct Position {
+    float x{0.0f};
+    float y{0.0f};
+};
+
+struct Velocity {
+    float vx{0.0f};
+    float vy{0.0f};
+};
+
+}  // namespace
+
+SC_TEST(CommandBuffer_DestroyEntity_IsDeferred) {
+    safecrowd::engine::EcsCore core;
+    safecrowd::engine::CommandBuffer buffer;
+
+    const auto e = core.createEntity();
+    buffer.destroyEntity(e);
+
+    SC_EXPECT_TRUE(core.isAlive(e));
+
+    buffer.flush(core);
+
+    SC_EXPECT_TRUE(!core.isAlive(e));
+}
+
+SC_TEST(CommandBuffer_AddComponent_IsDeferred) {
+    safecrowd::engine::EcsCore core;
+    safecrowd::engine::CommandBuffer buffer;
+
+    const auto e = core.createEntity();
+    buffer.addComponent(e, Position{1.0f, 2.0f});
+
+    SC_EXPECT_TRUE(!core.hasComponent<Position>(e));
+
+    buffer.flush(core);
+
+    SC_EXPECT_TRUE(core.hasComponent<Position>(e));
+    SC_EXPECT_NEAR(core.getComponent<Position>(e).x, 1.0f, 1e-6);
+}
+
+SC_TEST(CommandBuffer_RemoveComponent_IsDeferred) {
+    safecrowd::engine::EcsCore core;
+    safecrowd::engine::CommandBuffer buffer;
+
+    const auto e = core.createEntity();
+    core.addComponent(e, Position{});
+    buffer.removeComponent<Position>(e);
+
+    SC_EXPECT_TRUE(core.hasComponent<Position>(e));
+
+    buffer.flush(core);
+
+    SC_EXPECT_TRUE(!core.hasComponent<Position>(e));
+}
+
+SC_TEST(CommandBuffer_Flush_AppliesCommandsInOrder) {
+    safecrowd::engine::EcsCore core;
+    safecrowd::engine::CommandBuffer buffer;
+
+    const auto e = core.createEntity();
+    buffer.addComponent(e, Position{});
+    buffer.removeComponent<Position>(e);
+
+    buffer.flush(core);
+
+    SC_EXPECT_TRUE(!core.hasComponent<Position>(e));
+}
+
+SC_TEST(CommandBuffer_Flush_ClearsBuffer) {
+    safecrowd::engine::EcsCore core;
+    safecrowd::engine::CommandBuffer buffer;
+
+    const auto e = core.createEntity();
+    buffer.destroyEntity(e);
+
+    SC_EXPECT_TRUE(!buffer.empty());
+
+    buffer.flush(core);
+
+    SC_EXPECT_TRUE(buffer.empty());
+}
+
+SC_TEST(CommandBuffer_SpawnEntity_CreatesEntityWithComponents) {
+    safecrowd::engine::EcsCore core;
+    safecrowd::engine::CommandBuffer buffer;
+
+    buffer.spawnEntity(Position{3.0f, 4.0f}, Velocity{1.0f, 0.0f});
+
+    SC_EXPECT_TRUE(buffer.empty() == false);
+
+    buffer.flush(core);
+
+    const auto result = [&] {
+        std::vector<safecrowd::engine::Entity> alive;
+        core.entityRegistry().eachAlive([&](safecrowd::engine::Entity entity, const safecrowd::engine::Signature&) {
+            if (core.hasComponent<Position>(entity) && core.hasComponent<Velocity>(entity)) {
+                alive.push_back(entity);
+            }
+        });
+        return alive;
+    }();
+
+    SC_EXPECT_EQ(result.size(), std::size_t{1});
+    SC_EXPECT_NEAR(core.getComponent<Position>(result[0]).x, 3.0f, 1e-6);
+    SC_EXPECT_NEAR(core.getComponent<Velocity>(result[0]).vx, 1.0f, 1e-6);
+}
+
+SC_TEST(WorldCommands_ForwardsToBuffer) {
+    safecrowd::engine::EcsCore core;
+    safecrowd::engine::CommandBuffer buffer;
+    safecrowd::engine::WorldCommands cmds{buffer};
+
+    const auto e = core.createEntity();
+    cmds.addComponent(e, Position{5.0f, 6.0f});
+
+    SC_EXPECT_TRUE(!core.hasComponent<Position>(e));
+
+    buffer.flush(core);
+
+    SC_EXPECT_TRUE(core.hasComponent<Position>(e));
+    SC_EXPECT_NEAR(core.getComponent<Position>(e).y, 6.0f, 1e-6);
+}


### PR DESCRIPTION
## Summary

- `CommandBuffer` 구현: `spawnEntity`, `destroyEntity`, `addComponent<T>`, `removeComponent<T>` 명령을 내부 큐에 누적하고 `flush(EcsCore&)`로 일괄 적용
- `WorldCommands` 구현: 시스템이 명령을 enqueue하는 `CommandBuffer` facade
- `CommandBufferTests` 추가: deferred 동작, flush 적용 순서, flush 후 초기화, `spawnEntity`, `WorldCommands` 전달 검증 (7개)
- `CMakeLists.txt`에 `CommandBuffer.h`, `CommandBufferTests.cpp` 등록

## Related Issue

- Closes #10

## Area

- [x] Engine
- [ ] Domain
- [ ] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [x] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug`
- [x] `ctest --preset test-debug`
- [ ] Not run (reason below)

`windows-debug-no-app` / `build-no-app-debug` / `test-no-app-debug` preset 기준 실행 — configure, build, test(1/1) 모두 통과.

## Risks / Follow-up

- `spawnEntity` 호출 시 entity 핸들을 즉시 반환하지 않음 — 같은 프레임 내에서 생성된 entity에 추가 명령을 체이닝할 수 없음. 필요 시 별도 이슈로 확장 가능
- `EngineWorld`와의 연결(시스템에 `WorldCommands` 노출)은 #12 범위