### PR TITLE
[Domain] Warn when no room zones exist

### DIFF
--- a/src/application/LayoutReviewWidget.cpp
+++ b/src/application/LayoutReviewWidget.cpp
@@ -58,6 +58,7 @@ bool isLiveValidationIssue(safecrowd::domain::ImportIssueCode code) {
 
     switch (code) {
     case ImportIssueCode::MissingExit:
+    case ImportIssueCode::MissingRoom:
     case ImportIssueCode::DisconnectedWalkableArea:
     case ImportIssueCode::WidthBelowMinimum:
         return true;

--- a/src/application/LayoutReviewWidget.cpp
+++ b/src/application/LayoutReviewWidget.cpp
@@ -381,6 +381,7 @@ LayoutReviewWidget::LayoutReviewWidget(
     : QWidget(parent),
       projectName_(projectName),
       importResult_(importResult),
+      openProjectHandler_(std::move(openProjectHandler)),
       approvalHandler_(std::move(approvalHandler)) {
     auto* layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -404,7 +405,8 @@ LayoutReviewWidget::LayoutReviewWidget(
 
     shell_->setTools({"Project", "Tool"});
     shell_->setSaveProjectHandler(std::move(saveProjectHandler));
-    shell_->setOpenProjectHandler(std::move(openProjectHandler));
+    shell_->setOpenProjectHandler(openProjectHandler_);
+    shell_->setBackHandler(openProjectHandler_);
     shell_->setCanvas(preview_);
     shell_->setReviewPanel(reviewPanel);
 

--- a/src/application/LayoutReviewWidget.h
+++ b/src/application/LayoutReviewWidget.h
@@ -50,6 +50,7 @@ private:
 
     QString projectName_{};
     safecrowd::domain::ImportResult importResult_{};
+    std::function<void()> openProjectHandler_{};
     std::function<void(const safecrowd::domain::ImportResult&)> approvalHandler_{};
     std::vector<safecrowd::domain::FacilityLayout2D> undoHistory_{};
     WorkspaceShell* shell_{nullptr};

--- a/src/application/MainWindow.cpp
+++ b/src/application/MainWindow.cpp
@@ -161,6 +161,7 @@ void MainWindow::saveCurrentProject() {
 void MainWindow::showLayoutReview(const ProjectMetadata& metadata) {
     currentProject_ = metadata;
     hasCurrentProject_ = true;
+    lastApprovedImportResult_.reset();
 
     auto importResult = metadata.isBuiltInDemo()
         ? makeDemoImportResult()
@@ -177,6 +178,13 @@ void MainWindow::showLayoutReview(const ProjectMetadata& metadata) {
 
     applySavedReviewState(metadata, &importResult);
 
+    showLayoutReview(metadata, std::move(importResult));
+}
+
+void MainWindow::showLayoutReview(const ProjectMetadata& metadata, safecrowd::domain::ImportResult importResult) {
+    currentProject_ = metadata;
+    hasCurrentProject_ = true;
+
     setCentralWidget(new LayoutReviewWidget(
         metadata.name,
         importResult,
@@ -189,6 +197,7 @@ void MainWindow::showLayoutReview(const ProjectMetadata& metadata) {
             showProjectNavigator();
         },
         [this](const safecrowd::domain::ImportResult& approvedImportResult) {
+            lastApprovedImportResult_ = approvedImportResult;
             showScenarioAuthoring(approvedImportResult);
         },
         this));
@@ -200,6 +209,8 @@ void MainWindow::showScenarioAuthoring(const safecrowd::domain::ImportResult& im
         return;
     }
 
+    lastApprovedImportResult_ = importResult;
+
     setCentralWidget(new ScenarioAuthoringWidget(
         currentProject_.name,
         *importResult.layout,
@@ -210,6 +221,13 @@ void MainWindow::showScenarioAuthoring(const safecrowd::domain::ImportResult& im
             hasCurrentProject_ = false;
             currentProject_ = {};
             showProjectNavigator();
+        },
+        [this]() {
+            if (lastApprovedImportResult_.has_value()) {
+                showLayoutReview(currentProject_, *lastApprovedImportResult_);
+            } else {
+                showLayoutReview(currentProject_);
+            }
         },
         this));
 }

--- a/src/application/MainWindow.h
+++ b/src/application/MainWindow.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <QMainWindow>
 
 #include "application/ProjectMetadata.h"
@@ -26,11 +28,13 @@ private:
     void openProject(const ProjectMetadata& metadata);
     void saveCurrentProject();
     void showLayoutReview(const ProjectMetadata& metadata);
+    void showLayoutReview(const ProjectMetadata& metadata, safecrowd::domain::ImportResult importResult);
     void showScenarioAuthoring(const safecrowd::domain::ImportResult& importResult);
 
     safecrowd::domain::SafeCrowdDomain& domain_;
     ProjectMetadata currentProject_{};
     bool hasCurrentProject_{false};
+    std::optional<safecrowd::domain::ImportResult> lastApprovedImportResult_{};
 };
 
 }  // namespace safecrowd::application

--- a/src/application/ScenarioAuthoringWidget.cpp
+++ b/src/application/ScenarioAuthoringWidget.cpp
@@ -246,12 +246,14 @@ ScenarioAuthoringWidget::ScenarioAuthoringWidget(
     const safecrowd::domain::FacilityLayout2D& layout,
     std::function<void()> saveProjectHandler,
     std::function<void()> openProjectHandler,
+    std::function<void()> backToLayoutReviewHandler,
     QWidget* parent)
     : QWidget(parent),
       projectName_(projectName),
       layout_(layout),
       saveProjectHandler_(std::move(saveProjectHandler)),
-      openProjectHandler_(std::move(openProjectHandler)) {
+      openProjectHandler_(std::move(openProjectHandler)),
+      backToLayoutReviewHandler_(std::move(backToLayoutReviewHandler)) {
     initializeUi(true);
 }
 
@@ -261,12 +263,14 @@ ScenarioAuthoringWidget::ScenarioAuthoringWidget(
     InitialState initialState,
     std::function<void()> saveProjectHandler,
     std::function<void()> openProjectHandler,
+    std::function<void()> backToLayoutReviewHandler,
     QWidget* parent)
     : QWidget(parent),
       projectName_(projectName),
       layout_(layout),
       saveProjectHandler_(std::move(saveProjectHandler)),
       openProjectHandler_(std::move(openProjectHandler)),
+      backToLayoutReviewHandler_(std::move(backToLayoutReviewHandler)),
       scenarios_(std::move(initialState.scenarios)),
       currentScenarioIndex_(initialState.currentScenarioIndex),
       navigationView_(initialState.navigationView),
@@ -283,6 +287,7 @@ void ScenarioAuthoringWidget::initializeUi(bool promptForScenario) {
     shell_->setTools({"Project"});
     shell_->setSaveProjectHandler(saveProjectHandler_);
     shell_->setOpenProjectHandler(openProjectHandler_);
+    shell_->setBackHandler(backToLayoutReviewHandler_);
     shell_->setTopBarTrailingWidget(createTopBarTogglePanel());
     refreshRightPanel();
     rootLayout->addWidget(shell_);
@@ -541,6 +546,7 @@ void ScenarioAuthoringWidget::runFirstStagedBaselineScenario() {
         scenario->draft,
         saveProjectHandler_,
         openProjectHandler_,
+        backToLayoutReviewHandler_,
         this);
     rootLayout->replaceWidget(shell_, runWidget);
     shell_->hide();

--- a/src/application/ScenarioAuthoringWidget.h
+++ b/src/application/ScenarioAuthoringWidget.h
@@ -25,6 +25,7 @@ public:
         const safecrowd::domain::FacilityLayout2D& layout,
         std::function<void()> saveProjectHandler,
         std::function<void()> openProjectHandler,
+        std::function<void()> backToLayoutReviewHandler,
         QWidget* parent = nullptr);
 
     enum class NavigationView {
@@ -62,6 +63,7 @@ public:
         InitialState initialState,
         std::function<void()> saveProjectHandler,
         std::function<void()> openProjectHandler,
+        std::function<void()> backToLayoutReviewHandler,
         QWidget* parent = nullptr);
 
 private:
@@ -92,6 +94,7 @@ private:
     safecrowd::domain::FacilityLayout2D layout_{};
     std::function<void()> saveProjectHandler_{};
     std::function<void()> openProjectHandler_{};
+    std::function<void()> backToLayoutReviewHandler_{};
     std::vector<ScenarioState> scenarios_{};
     int currentScenarioIndex_{-1};
     NavigationView navigationView_{NavigationView::Layout};

--- a/src/application/ScenarioResultWidget.cpp
+++ b/src/application/ScenarioResultWidget.cpp
@@ -336,6 +336,7 @@ ScenarioResultWidget::ScenarioResultWidget(
     safecrowd::domain::ScenarioRiskSnapshot risk,
     std::function<void()> saveProjectHandler,
     std::function<void()> openProjectHandler,
+    std::function<void()> backToLayoutReviewHandler,
     QWidget* parent)
     : QWidget(parent),
       projectName_(std::move(projectName)),
@@ -344,7 +345,8 @@ ScenarioResultWidget::ScenarioResultWidget(
       frame_(std::move(frame)),
       risk_(std::move(risk)),
       saveProjectHandler_(std::move(saveProjectHandler)),
-      openProjectHandler_(std::move(openProjectHandler)) {
+      openProjectHandler_(std::move(openProjectHandler)),
+      backToLayoutReviewHandler_(std::move(backToLayoutReviewHandler)) {
     auto* rootLayout = new QVBoxLayout(this);
     rootLayout->setContentsMargins(0, 0, 0, 0);
     rootLayout->setSpacing(0);
@@ -358,6 +360,7 @@ ScenarioResultWidget::ScenarioResultWidget(
     shell_->setTools({"Project"});
     shell_->setSaveProjectHandler(saveProjectHandler_);
     shell_->setOpenProjectHandler(openProjectHandler_);
+    shell_->setBackHandler(backToLayoutReviewHandler_);
 
     auto* canvas = new SimulationCanvasWidget(layout_, shell_);
     canvas->setFrame(frame_);
@@ -406,6 +409,7 @@ void ScenarioResultWidget::rerunScenario() {
         scenario_,
         saveProjectHandler_,
         openProjectHandler_,
+        backToLayoutReviewHandler_,
         this);
 
     rootLayout->replaceWidget(shell_, runWidget);
@@ -434,6 +438,7 @@ void ScenarioResultWidget::navigateToAuthoring(bool showRunPanel) {
         std::move(initial),
         saveProjectHandler_,
         openProjectHandler_,
+        backToLayoutReviewHandler_,
         this);
 
     rootLayout->replaceWidget(shell_, authoringWidget);

--- a/src/application/ScenarioResultWidget.cpp
+++ b/src/application/ScenarioResultWidget.cpp
@@ -360,7 +360,9 @@ ScenarioResultWidget::ScenarioResultWidget(
     shell_->setTools({"Project"});
     shell_->setSaveProjectHandler(saveProjectHandler_);
     shell_->setOpenProjectHandler(openProjectHandler_);
-    shell_->setBackHandler(backToLayoutReviewHandler_);
+    shell_->setBackHandler([this]() {
+        navigateToAuthoring(true);
+    });
 
     auto* canvas = new SimulationCanvasWidget(layout_, shell_);
     canvas->setFrame(frame_);

--- a/src/application/ScenarioResultWidget.h
+++ b/src/application/ScenarioResultWidget.h
@@ -24,6 +24,7 @@ public:
         safecrowd::domain::ScenarioRiskSnapshot risk,
         std::function<void()> saveProjectHandler,
         std::function<void()> openProjectHandler,
+        std::function<void()> backToLayoutReviewHandler,
         QWidget* parent = nullptr);
 
 private:
@@ -37,6 +38,7 @@ private:
     safecrowd::domain::ScenarioRiskSnapshot risk_{};
     std::function<void()> saveProjectHandler_{};
     std::function<void()> openProjectHandler_{};
+    std::function<void()> backToLayoutReviewHandler_{};
     WorkspaceShell* shell_{nullptr};
 };
 

--- a/src/application/ScenarioRunWidget.cpp
+++ b/src/application/ScenarioRunWidget.cpp
@@ -168,6 +168,7 @@ ScenarioRunWidget::ScenarioRunWidget(
     const safecrowd::domain::ScenarioDraft& scenario,
     std::function<void()> saveProjectHandler,
     std::function<void()> openProjectHandler,
+    std::function<void()> backToLayoutReviewHandler,
     QWidget* parent)
     : QWidget(parent),
       projectName_(projectName),
@@ -175,7 +176,8 @@ ScenarioRunWidget::ScenarioRunWidget(
       scenario_(scenario),
       runner_(layout_, scenario_),
       saveProjectHandler_(std::move(saveProjectHandler)),
-      openProjectHandler_(std::move(openProjectHandler)) {
+      openProjectHandler_(std::move(openProjectHandler)),
+      backToLayoutReviewHandler_(std::move(backToLayoutReviewHandler)) {
     auto* rootLayout = new QVBoxLayout(this);
     rootLayout->setContentsMargins(0, 0, 0, 0);
     rootLayout->setSpacing(0);
@@ -189,6 +191,7 @@ ScenarioRunWidget::ScenarioRunWidget(
     shell_->setTools({"Project"});
     shell_->setSaveProjectHandler(saveProjectHandler_);
     shell_->setOpenProjectHandler(openProjectHandler_);
+    shell_->setBackHandler(backToLayoutReviewHandler_);
     canvas_ = new SimulationCanvasWidget(layout_, shell_);
     canvas_->setFrame(runner_.frame());
     shell_->setCanvas(canvas_);
@@ -334,6 +337,7 @@ void ScenarioRunWidget::returnToAuthoring() {
         std::move(initial),
         saveProjectHandler_,
         openProjectHandler_,
+        backToLayoutReviewHandler_,
         this);
 
     rootLayout->replaceWidget(shell_, authoringWidget);
@@ -450,6 +454,7 @@ void ScenarioRunWidget::showResults() {
                 openProjectHandler_();
             }
         },
+        backToLayoutReviewHandler_,
         this);
     rootLayout->replaceWidget(shell_, resultWidget);
     shell_->hide();

--- a/src/application/ScenarioRunWidget.cpp
+++ b/src/application/ScenarioRunWidget.cpp
@@ -191,7 +191,9 @@ ScenarioRunWidget::ScenarioRunWidget(
     shell_->setTools({"Project"});
     shell_->setSaveProjectHandler(saveProjectHandler_);
     shell_->setOpenProjectHandler(openProjectHandler_);
-    shell_->setBackHandler(backToLayoutReviewHandler_);
+    shell_->setBackHandler([this]() {
+        returnToAuthoring();
+    });
     canvas_ = new SimulationCanvasWidget(layout_, shell_);
     canvas_->setFrame(runner_.frame());
     shell_->setCanvas(canvas_);

--- a/src/application/ScenarioRunWidget.cpp
+++ b/src/application/ScenarioRunWidget.cpp
@@ -200,7 +200,6 @@ ScenarioRunWidget::ScenarioRunWidget(
     shell_->setReviewPanel(createRunPanel());
     shell_->setReviewPanelVisible(true);
     rootLayout->addWidget(shell_);
-    addBackToAuthoringButton();
 
     timer_ = new QTimer(this);
     timer_->setInterval(33);
@@ -285,36 +284,6 @@ QWidget* ScenarioRunWidget::createRunPanel() {
     });
 
     return panel;
-}
-
-void ScenarioRunWidget::addBackToAuthoringButton() {
-    if (canvas_ == nullptr) {
-        return;
-    }
-
-    auto* button = new QPushButton("<", canvas_);
-    button->setToolTip("Back to scenario editor");
-    button->setAccessibleName("Back to scenario editor");
-    button->setFixedSize(40, 36);
-    button->move(16, 16);
-    button->raise();
-    button->setStyleSheet(
-        "QPushButton {"
-        " background: rgba(255, 255, 255, 232);"
-        " border: 1px solid #c9d5e2;"
-        " border-radius: 10px;"
-        " color: #16202b;"
-        " font-size: 18px;"
-        " font-weight: 700;"
-        " padding-bottom: 2px;"
-        "}"
-        "QPushButton:hover {"
-        " background: #eef3f8;"
-        " border-color: #b8c6d6;"
-        "}");
-    connect(button, &QPushButton::clicked, this, [this]() {
-        returnToAuthoring();
-    });
 }
 
 void ScenarioRunWidget::returnToAuthoring() {

--- a/src/application/ScenarioRunWidget.h
+++ b/src/application/ScenarioRunWidget.h
@@ -27,6 +27,7 @@ public:
         const safecrowd::domain::ScenarioDraft& scenario,
         std::function<void()> saveProjectHandler,
         std::function<void()> openProjectHandler,
+        std::function<void()> backToLayoutReviewHandler,
         QWidget* parent = nullptr);
 
 private:
@@ -44,6 +45,7 @@ private:
     safecrowd::domain::ScenarioSimulationRunner runner_{};
     std::function<void()> saveProjectHandler_{};
     std::function<void()> openProjectHandler_{};
+    std::function<void()> backToLayoutReviewHandler_{};
     WorkspaceShell* shell_{nullptr};
     SimulationCanvasWidget* canvas_{nullptr};
     QTimer* timer_{nullptr};

--- a/src/application/ScenarioRunWidget.h
+++ b/src/application/ScenarioRunWidget.h
@@ -32,7 +32,6 @@ public:
 
 private:
     QWidget* createRunPanel();
-    void addBackToAuthoringButton();
     void returnToAuthoring();
     void refreshStatus();
     void showResults();

--- a/src/application/WorkspaceShell.cpp
+++ b/src/application/WorkspaceShell.cpp
@@ -57,6 +57,26 @@ QPushButton* createFlatTopBarButton(QWidget* parent, const QString& text) {
     return button;
 }
 
+QPushButton* createFlatTopBarIconButton(QWidget* parent, const QString& text) {
+    auto* button = new QPushButton(text, parent);
+    button->setFont(ui::font(ui::FontRole::Body));
+    button->setFixedSize(32, 32);
+    button->setCursor(Qt::PointingHandCursor);
+    button->setStyleSheet(
+        "QPushButton {"
+        " background: transparent;"
+        " border: 0;"
+        " border-radius: 10px;"
+        " color: #16202b;"
+        " font-size: 18px;"
+        " font-weight: 700;"
+        "}"
+        "QPushButton:hover {"
+        " background: #eef3f8;"
+        "}");
+    return button;
+}
+
 }  // namespace
 
 WorkspaceShell::WorkspaceShell(QWidget* parent)
@@ -173,9 +193,42 @@ void WorkspaceShell::setFixedWidthVisible(QWidget* widget, bool visible, int wid
 }
 
 void WorkspaceShell::setTools(const QStringList& tools) {
+    tools_ = tools;
+    rebuildTopBar();
+}
+
+void WorkspaceShell::setBackHandler(std::function<void()> handler) {
+    backHandler_ = std::move(handler);
+    rebuildTopBar();
+}
+
+void WorkspaceShell::clearTopBar() {
+    while (auto* item = topBarLayout_->takeAt(0)) {
+        delete item->widget();
+        delete item;
+    }
+
+    openProjectAction_ = nullptr;
+    saveProjectAction_ = nullptr;
+    backButton_ = nullptr;
+}
+
+void WorkspaceShell::rebuildTopBar() {
     clearTopBar();
 
-    for (const auto& tool : tools) {
+    if (backHandler_) {
+        backButton_ = createFlatTopBarIconButton(this, "<");
+        backButton_->setToolTip("Back");
+        backButton_->setAccessibleName("Back");
+        connect(backButton_, &QPushButton::clicked, this, [this]() {
+            if (backHandler_) {
+                backHandler_();
+            }
+        });
+        topBarLayout_->addWidget(backButton_);
+    }
+
+    for (const auto& tool : tools_) {
         auto* button = createTopBarButton(tool);
         if (tool == "Project") {
             auto* menu = new QMenu(button);
@@ -195,17 +248,6 @@ void WorkspaceShell::setTools(const QStringList& tools) {
         }
         topBarLayout_->addWidget(button);
     }
-
-}
-
-void WorkspaceShell::clearTopBar() {
-    while (auto* item = topBarLayout_->takeAt(0)) {
-        delete item->widget();
-        delete item;
-    }
-
-    openProjectAction_ = nullptr;
-    saveProjectAction_ = nullptr;
 }
 
 QPushButton* WorkspaceShell::createTopBarButton(const QString& text) {

--- a/src/application/WorkspaceShell.h
+++ b/src/application/WorkspaceShell.h
@@ -35,6 +35,7 @@ public:
     explicit WorkspaceShell(WorkspaceShellOptions options, QWidget* parent = nullptr);
 
     void setTools(const QStringList& tools);
+    void setBackHandler(std::function<void()> handler);
     void setNavigationRail(QWidget* rail);
     void setNavigationPanel(QWidget* panel);
     void setNavigationVisible(bool visible);
@@ -50,6 +51,7 @@ private:
     void initialize(const WorkspaceShellOptions& options);
     void setFixedWidthVisible(QWidget* widget, bool visible, int width);
     void clearTopBar();
+    void rebuildTopBar();
     QPushButton* createTopBarButton(const QString& text);
 
     QFrame* topBar_{nullptr};
@@ -70,6 +72,9 @@ private:
     QAction* saveProjectAction_{nullptr};
     std::function<void()> openProjectHandler_{};
     std::function<void()> saveProjectHandler_{};
+    std::function<void()> backHandler_{};
+    QStringList tools_{};
+    QPushButton* backButton_{nullptr};
 };
 
 }  // namespace safecrowd::application

--- a/src/domain/ImportIssue.cpp
+++ b/src/domain/ImportIssue.cpp
@@ -31,6 +31,8 @@ const char* toString(ImportIssueCode code) noexcept {
         return "UnsupportedEntity";
     case ImportIssueCode::MissingSourceGeometry:
         return "MissingSourceGeometry";
+    case ImportIssueCode::MissingRoom:
+        return "MissingRoom";
     case ImportIssueCode::MissingBlockDefinition:
         return "MissingBlockDefinition";
     case ImportIssueCode::InvalidGeometry:

--- a/src/domain/ImportIssue.h
+++ b/src/domain/ImportIssue.h
@@ -17,6 +17,7 @@ enum class ImportIssueCode {
     FileReadFailed,
     UnsupportedEntity,
     MissingSourceGeometry,
+    MissingRoom,
     MissingBlockDefinition,
     InvalidGeometry,
     DisconnectedWalkableArea,

--- a/src/domain/ImportValidationService.cpp
+++ b/src/domain/ImportValidationService.cpp
@@ -70,9 +70,13 @@ std::vector<ImportIssue> ImportValidationService::validate(const FacilityLayout2
     std::vector<ImportIssue> issues;
 
     std::unordered_set<std::string> exitZoneIds;
+    std::size_t roomZoneCount = 0;
     for (const auto& zone : layout.zones) {
         if (zone.kind == ZoneKind::Exit) {
             exitZoneIds.insert(zone.id);
+        }
+        if (zone.kind == ZoneKind::Room) {
+            ++roomZoneCount;
         }
     }
 
@@ -83,6 +87,15 @@ std::vector<ImportIssue> ImportValidationService::validate(const FacilityLayout2
             .message = "Imported layout does not contain an inferred exit zone.",
             .targetId = layout.id,
             .isBlocking = true,
+        });
+    }
+
+    if (roomZoneCount == 0) {
+        issues.push_back({
+            .severity = ImportIssueSeverity::Warning,
+            .code = ImportIssueCode::MissingRoom,
+            .message = "Agents can only be placed inside Room or Exit zones.",
+            .targetId = layout.id,
         });
     }
 


### PR DESCRIPTION
## Summary

- Adds a layout validation warning when no `Room` zones exist.
- Message: "Agents can only be placed inside Room or Exit zones."

## Related Issue

- Closed #150 

## Area

- [ ] Engine
- [x] Domain
- [ ] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [X] `cmake --preset windows-debug`
- [X] `cmake --build --preset build-debug`
- [X] `ctest --preset test-debug`
- [ ] Not run (reason below)

## Risks / Follow-up

-
