### PR TITLE
[Application] polish layout review approval controls

### DIFF
--- a/src/application/LayoutReviewWidget.cpp
+++ b/src/application/LayoutReviewWidget.cpp
@@ -337,6 +337,7 @@ QWidget* createReviewPanel(
     QLabel** inspectorTitle,
     QLabel** inspectorDetail,
     QLabel** approvalStatus,
+    QPushButton** undoButton,
     QPushButton** approveButton,
     QWidget* parent) {
     auto* panel = new QWidget(parent);
@@ -367,9 +368,16 @@ QWidget* createReviewPanel(
     (*approvalStatus)->setStyleSheet(ui::mutedTextStyleSheet());
     layout->addWidget(*approvalStatus);
 
+    *undoButton = new QPushButton("Undo Last Edit", panel);
+    (*undoButton)->setFont(ui::font(ui::FontRole::Body));
+    (*undoButton)->setStyleSheet(ui::secondaryButtonStyleSheet());
+    (*undoButton)->setToolTip("Undo the last layout correction (Ctrl+Z)");
+    layout->addWidget(*undoButton);
+
     *approveButton = new QPushButton("Approve Layout", panel);
     (*approveButton)->setFont(ui::font(ui::FontRole::Body));
     (*approveButton)->setStyleSheet(ui::primaryButtonStyleSheet());
+    (*approveButton)->setToolTip("Resolve blocking issues before approval");
     layout->addWidget(*approveButton);
 
     return panel;
@@ -406,6 +414,7 @@ LayoutReviewWidget::LayoutReviewWidget(
         &inspectorTitleLabel_,
         &inspectorDetailLabel_,
         &approvalStatusLabel_,
+        &undoButton_,
         &approveButton_,
         shell_);
 
@@ -425,6 +434,9 @@ LayoutReviewWidget::LayoutReviewWidget(
         if (approvalHandler_) {
             approvalHandler_(importResult_);
         }
+    });
+    connect(undoButton_, &QPushButton::clicked, this, [this]() {
+        undoLastEdit();
     });
 
     auto* undoShortcut = new QShortcut(QKeySequence::Undo, this);
@@ -490,10 +502,20 @@ void LayoutReviewWidget::handlePreviewSelectionChanged(const PreviewSelection& s
 }
 
 void LayoutReviewWidget::refreshApprovalState() {
-    const auto hasBlocking = safecrowd::domain::hasBlockingImportIssue(importResult_.issues);
+    const auto blockingCount = std::count_if(importResult_.issues.begin(), importResult_.issues.end(), [](const auto& issue) {
+        return issue.blocksSimulation();
+    });
+    const auto hasBlocking = blockingCount > 0;
 
     if (approveButton_ != nullptr) {
         approveButton_->setEnabled(!hasBlocking);
+        approveButton_->setToolTip(hasBlocking
+            ? QString("Resolve %1 blocking issue(s) before approval").arg(static_cast<int>(blockingCount))
+            : QString("Approve layout and continue to Scenario Authoring"));
+    }
+
+    if (undoButton_ != nullptr) {
+        undoButton_->setEnabled(!undoHistory_.empty());
     }
 
     if (approvalStatusLabel_ == nullptr) {
@@ -501,7 +523,7 @@ void LayoutReviewWidget::refreshApprovalState() {
     }
 
     if (hasBlocking) {
-        approvalStatusLabel_->setText("Resolve blocking issues first");
+        approvalStatusLabel_->setText(QString("Resolve %1 blocking issue(s) first").arg(static_cast<int>(blockingCount)));
         return;
     }
 

--- a/src/application/LayoutReviewWidget.h
+++ b/src/application/LayoutReviewWidget.h
@@ -58,6 +58,7 @@ private:
     QLabel* inspectorTitleLabel_{nullptr};
     QLabel* inspectorDetailLabel_{nullptr};
     QLabel* approvalStatusLabel_{nullptr};
+    QPushButton* undoButton_{nullptr};
     QPushButton* approveButton_{nullptr};
     NavigationView navigationView_{NavigationView::Issues};
     QString selectedIssueTargetId_{};


### PR DESCRIPTION
## Summary

- Layout Review의 승인 가능 상태를 blocking issue 수와 함께 명확히 표시합니다.
- Undo 버튼과 Ctrl+Z 상태를 같은 흐름으로 노출해 승인 전 검토/수정 루프를 안정화합니다.
- Scenario Authoring으로 넘어가기 전 승인 UX를 Sprint 1 demo flow에 맞게 정리합니다.

## Related Issue

- Refs #117
- Part of #2

## Area

- [ ] Engine
- [ ] Domain
- [x] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [ ] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug`
- [x] `ctest --preset test-debug`
- [x] `cmake --build --preset build-no-app-debug`
- [x] `ctest --preset test-no-app-debug`
- [ ] Not run (reason below)

Verification was run on the integrated Sprint 1 stack after splitting this PR.

## Risks / Follow-up

- This PR intentionally stays within `src/application/` and does not change import/domain validation behavior.
- This is the first PR in a stacked series; following PRs build on this branch for authoring/run/result flow and docs sync.