### PR TITLE
[Application] Sprint 1 Empty/Error 상태 보완

### DIFF
--- a/src/application/LayoutReviewWidget.cpp
+++ b/src/application/LayoutReviewWidget.cpp
@@ -494,6 +494,9 @@ void LayoutReviewWidget::refreshApprovalState() {
 
     if (approveButton_ != nullptr) {
         approveButton_->setEnabled(!hasBlocking);
+        approveButton_->setToolTip(hasBlocking
+            ? "Resolve all blocking issues in the Issues panel before approving"
+            : "Approve this layout and proceed to Scenario Authoring");
     }
 
     if (approvalStatusLabel_ == nullptr) {
@@ -501,7 +504,7 @@ void LayoutReviewWidget::refreshApprovalState() {
     }
 
     if (hasBlocking) {
-        approvalStatusLabel_->setText("Resolve blocking issues first");
+        approvalStatusLabel_->setText("Resolve blocking issues to approve");
         return;
     }
 

--- a/src/application/NewProjectWidget.cpp
+++ b/src/application/NewProjectWidget.cpp
@@ -77,7 +77,7 @@ NewProjectWidget::NewProjectWidget(QWidget* parent)
     layoutRow->setSpacing(12);
     auto* layoutBrowseButton = createOutlinedButton("Browse", this);
     layoutPathEdit_ = createTextInput(this);
-    layoutPathEdit_->setPlaceholderText("DXF file");
+    layoutPathEdit_->setPlaceholderText("Select a DXF file using Browse");
     layoutPathEdit_->setReadOnly(true);
     layoutPathEdit_->setStyleSheet(ui::textFieldStyleSheet(true));
     layoutPathEdit_->setMaximumWidth(760);
@@ -113,6 +113,7 @@ NewProjectWidget::NewProjectWidget(QWidget* parent)
     auto* cancelButton = createOutlinedButton("Cancel", this);
     auto* doneButton = createOutlinedButton("Done", this);
     doneButton->setStyleSheet(ui::primaryButtonStyleSheet());
+    doneButton->setToolTip("Project name, DXF layout file, and folder are all required");
     actionLayout->addWidget(cancelButton);
     actionLayout->addWidget(doneButton);
     cardLayout->addLayout(actionLayout);

--- a/src/application/ProjectListWidget.cpp
+++ b/src/application/ProjectListWidget.cpp
@@ -65,6 +65,11 @@ ProjectListWidget::ProjectListWidget(const QList<ProjectMetadata>& projects, QWi
         emptyLabel->setFont(ui::font(ui::FontRole::Body));
         emptyLabel->setStyleSheet(ui::mutedTextStyleSheet());
         layout->addWidget(emptyLabel);
+        auto* hintLabel = new QLabel("Use + New Project to create your first project.", this);
+        hintLabel->setFont(ui::font(ui::FontRole::Caption));
+        hintLabel->setStyleSheet(ui::subtleTextStyleSheet());
+        hintLabel->setWordWrap(true);
+        layout->addWidget(hintLabel);
     } else {
         for (const auto& project : projects) {
             addProjectRow(project);

--- a/src/application/ScenarioAuthoringWidget.cpp
+++ b/src/application/ScenarioAuthoringWidget.cpp
@@ -451,7 +451,16 @@ void ScenarioAuthoringWidget::refreshInspector() {
     }
     if (stageScenarioButton_ != nullptr) {
         stageScenarioButton_->setEnabled(hasScenario);
-        stageScenarioButton_->setText(hasScenario && scenario->stagedForRun ? "Staged for Run" : "Stage Scenario");
+        if (!hasScenario) {
+            stageScenarioButton_->setText("Stage Scenario");
+            stageScenarioButton_->setToolTip("Create a scenario first to enable staging");
+        } else if (scenario->stagedForRun) {
+            stageScenarioButton_->setText("Staged for Run");
+            stageScenarioButton_->setToolTip("Click to remove this scenario from the staged list");
+        } else {
+            stageScenarioButton_->setText("Stage Scenario");
+            stageScenarioButton_->setToolTip("Mark this scenario to be included in the next Run");
+        }
     }
 }
 
@@ -679,7 +688,8 @@ QWidget* ScenarioAuthoringWidget::createRunPanel() {
         return scenario.stagedForRun;
     });
     if (stagedCount == 0) {
-        lines << "No staged scenarios";
+        lines << "No scenarios staged for run.";
+        lines << "Select a scenario and click Stage Scenario to continue.";
     } else {
         lines << "Staged scenarios";
         for (const auto& scenario : scenarios_) {
@@ -698,6 +708,9 @@ QWidget* ScenarioAuthoringWidget::createRunPanel() {
     executeRunButton_->setFont(ui::font(ui::FontRole::Body));
     executeRunButton_->setStyleSheet(ui::primaryButtonStyleSheet());
     executeRunButton_->setEnabled(stagedCount > 0);
+    executeRunButton_->setToolTip(stagedCount > 0
+        ? "Start simulation for all staged scenarios"
+        : "Stage at least one baseline scenario before running");
     layout->addWidget(executeRunButton_);
     connect(executeRunButton_, &QPushButton::clicked, this, [this]() {
         runFirstStagedBaselineScenario();


### PR DESCRIPTION
## Summary

- ProjectListWidget: 저장된 프로젝트가 없을 때 "+ New Project" 사용을 안내하는 힌트 라벨 추가
- ScenarioAuthoringWidget Run 패널: 스테이징된 시나리오가 없을 때 다음 행동 안내 문구 추가, Run 버튼 비활성/활성 tooltip 추가
- ScenarioAuthoringWidget: Stage Scenario 버튼의 시나리오 미생성 / 스테이지 / 언스테이지 상태별 tooltip 추가
- LayoutReviewWidget: Approve Layout 버튼 비활성/활성 tooltip 추가, 상태 라벨 문구를 "Resolve blocking issues to approve"로 정리
- NewProjectWidget: DXF 입력 placeholder를 "Select a DXF file using Browse"로 명확화, Done 버튼에 필수 입력 tooltip 추가

Sprint 1 시연에서 사용자가 빈 화면, 비활성 버튼, 모호한 상태에서 다음 행동을 즉시 이해할 수 있도록 application-only 범위에서 보수적으로 문구만 보완했습니다. 비즈니스 로직 변경은 없습니다.

## Related Issue

- Closes #156

## Area

- [ ] Engine
- [ ] Domain
- [x] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [x] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug` (safecrowd_app.exe 컴파일/링크 성공; vcpkg Qt DLL 후처리 복사 단계만 환경 문제로 실패)
- [x] `ctest --preset test-debug` (safecrowd_tests 1/1 Passed)
- [ ] Not run (reason below)

추가로 CI 경로도 확인했습니다:
- `cmake --build --preset build-no-app-debug` 통과
- `ctest --preset test-no-app-debug` 통과 (1/1)

## Risks / Follow-up

- 문구/툴팁만 다듬은 application-only 변경이라 회귀 가능성은 낮습니다.
- "Stage Scenario" 토글 동작 자체는 변경하지 않고 텍스트와 tooltip만 갱신했습니다.
- Codex가 진행 중인 PR #151, #152, #153, #154와 같은 파일 일부를 수정하므로 머지 시 사소한 충돌이 발생할 수 있습니다. 충돌 해결 시 본 PR의 tooltip/문구를 우선 보존하면 됩니다.
- 추가 개선 후보: "No pedestrian placements yet" / "No operational events yet" 패널의 액션 카드는 PR #154가 이미 다루고 있어 본 PR에서는 제외했습니다.