### PR TITLE
[Application] Harden recent-project deletion flow

### DIFF
--- a/src/application/MainWindow.cpp
+++ b/src/application/MainWindow.cpp
@@ -198,24 +198,38 @@ void MainWindow::showProjectNavigator() {
     });
     navigator->setDeleteProjectHandler([this](const ProjectMetadata& metadata) {
         if (metadata.isBuiltInDemo()) {
-            QMessageBox::information(this, "Delete Project", "The built-in demo project cannot be deleted.");
+            QMessageBox info(QMessageBox::Information,
+                             "Delete Project",
+                             "The built-in demo project cannot be deleted.",
+                             QMessageBox::Ok,
+                             this);
+            info.setTextFormat(Qt::PlainText);
+            info.exec();
             return;
         }
 
-        const auto choice = QMessageBox::question(
-            this,
-            "Delete Project",
-            QString("Delete \"%1\" and its project folder?\n\n%2")
-                .arg(metadata.name, metadata.folderPath),
-            QMessageBox::Yes | QMessageBox::No,
-            QMessageBox::No);
-        if (choice != QMessageBox::Yes) {
+        QMessageBox confirm(QMessageBox::Question,
+                            "Delete Project",
+                            QString("Move \"%1\" to the recycle bin?\n\n%2\n\n"
+                                    "You can restore it from the recycle bin if you change your mind.")
+                                .arg(metadata.name, metadata.folderPath),
+                            QMessageBox::Yes | QMessageBox::No,
+                            this);
+        confirm.setTextFormat(Qt::PlainText);
+        confirm.setDefaultButton(QMessageBox::No);
+        if (confirm.exec() != QMessageBox::Yes) {
             return;
         }
 
         QString errorMessage;
         if (!ProjectPersistence::deleteProject(metadata, &errorMessage)) {
-            QMessageBox::warning(this, "Delete Project", errorMessage);
+            QMessageBox warning(QMessageBox::Warning,
+                                "Delete Project",
+                                errorMessage,
+                                QMessageBox::Ok,
+                                this);
+            warning.setTextFormat(Qt::PlainText);
+            warning.exec();
             return;
         }
 

--- a/src/application/ProjectPersistence.cpp
+++ b/src/application/ProjectPersistence.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 
 #include <QDateTime>
+#include <QDebug>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
@@ -10,6 +11,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QStandardPaths>
+#include <QStorageInfo>
 
 #include "domain/ImportValidationService.h"
 
@@ -26,6 +28,20 @@ bool isProjectManagedEntry(const QString& fileName) {
         || fileName.compare(kLayoutFileName, Qt::CaseInsensitive) == 0
         || fileName.compare(kReviewFileName, Qt::CaseInsensitive) == 0
         || fileName.compare(kWorkspaceFileName, Qt::CaseInsensitive) == 0;
+}
+
+QString normalizedFolderKey(const QString& folderPath) {
+    const auto canonical = QFileInfo(folderPath).canonicalFilePath();
+    const auto base = canonical.isEmpty() ? QDir(folderPath).absolutePath() : canonical;
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    return base.toLower();
+#else
+    return base;
+#endif
+}
+
+bool sameFolderPath(const QString& lhs, const QString& rhs) {
+    return normalizedFolderKey(lhs) == normalizedFolderKey(rhs);
 }
 
 QString projectFilePath(const QString& folderPath) {
@@ -96,10 +112,9 @@ void upsertRecentProject(const ProjectMetadata& metadata) {
     QJsonArray updated;
     updated.append(toJson(metadata));
 
-    const auto normalizedFolder = QDir(metadata.folderPath).absolutePath();
     for (const auto& value : projects) {
         const auto existing = fromJson(value.toObject());
-        if (QDir(existing.folderPath).absolutePath() == normalizedFolder) {
+        if (sameFolderPath(existing.folderPath, metadata.folderPath)) {
             continue;
         }
         updated.append(value);
@@ -119,10 +134,9 @@ void removeRecentProject(const QString& folderPath) {
     }
 
     QJsonArray updated;
-    const auto normalizedFolder = QDir(folderPath).absolutePath();
     for (const auto& value : document.object().value("projects").toArray()) {
         const auto existing = fromJson(value.toObject());
-        if (QDir(existing.folderPath).absolutePath() == normalizedFolder) {
+        if (sameFolderPath(existing.folderPath, folderPath)) {
             continue;
         }
         updated.append(value);
@@ -130,24 +144,40 @@ void removeRecentProject(const QString& folderPath) {
 
     QJsonObject root;
     root["projects"] = updated;
-    QString ignoredError;
-    writeJsonDocument(recentPath, QJsonDocument(root), &ignoredError);
+    QString writeError;
+    if (!writeJsonDocument(recentPath, QJsonDocument(root), &writeError)) {
+        qWarning() << "Failed to update recent projects list:" << writeError;
+    }
 }
 
 bool canDeleteProjectFolder(const QString& folderPath, QString* errorMessage) {
+    const auto setError = [errorMessage](const QString& message) {
+        if (errorMessage != nullptr) {
+            *errorMessage = message;
+        }
+    };
+
     QDir folder(folderPath);
     if (!folder.exists()) {
-        if (errorMessage != nullptr) {
-            *errorMessage = QString("Project folder does not exist: %1").arg(folderPath);
-        }
+        setError(QString("Project folder does not exist: %1").arg(folderPath));
         return false;
     }
 
     const QFileInfo folderInfo(folder.absolutePath());
-    if (folderInfo.absoluteFilePath() == QDir(folderInfo.absolutePath()).rootPath()) {
-        if (errorMessage != nullptr) {
-            *errorMessage = QString("Refusing to delete a drive root: %1").arg(folderPath);
-        }
+    if (folderInfo.isSymLink() || folderInfo.isJunction()) {
+        setError(QString("Refusing to delete a symbolic link or junction: %1").arg(folderPath));
+        return false;
+    }
+
+    if (QDir(folderInfo.absoluteFilePath()).isRoot()) {
+        setError(QString("Refusing to delete a drive root: %1").arg(folderPath));
+        return false;
+    }
+
+    const QStorageInfo storage(folderInfo.absoluteFilePath());
+    if (storage.isValid() && !storage.rootPath().isEmpty()
+        && QFileInfo(storage.rootPath()).absoluteFilePath() == folderInfo.absoluteFilePath()) {
+        setError(QString("Refusing to delete a volume root: %1").arg(folderPath));
         return false;
     }
 
@@ -155,12 +185,16 @@ bool canDeleteProjectFolder(const QString& folderPath, QString* errorMessage) {
         QDir::AllEntries | QDir::Hidden | QDir::System | QDir::NoDotAndDotDot,
         QDir::Name);
     for (const auto& entry : entries) {
+        if (entry.isSymLink() || entry.isJunction()) {
+            setError(QString(
+                "Refusing to delete project folder because it contains a link not created by SafeCrowd: %1")
+                .arg(entry.fileName()));
+            return false;
+        }
         if (!entry.isFile() || !isProjectManagedEntry(entry.fileName())) {
-            if (errorMessage != nullptr) {
-                *errorMessage = QString(
-                    "Refusing to delete project folder because it contains a file or folder not created by SafeCrowd: %1")
-                    .arg(entry.fileName());
-            }
+            setError(QString(
+                "Refusing to delete project folder because it contains a file or folder not created by SafeCrowd: %1")
+                .arg(entry.fileName()));
             return false;
         }
     }
@@ -1109,17 +1143,19 @@ ProjectMetadata ProjectPersistence::loadProject(const QString& folderPath) {
 }
 
 bool ProjectPersistence::deleteProject(const ProjectMetadata& metadata, QString* errorMessage) {
-    if (metadata.isBuiltInDemo()) {
+    const auto setError = [errorMessage](const QString& message) {
         if (errorMessage != nullptr) {
-            *errorMessage = "Built-in demo projects cannot be deleted.";
+            *errorMessage = message;
         }
+    };
+
+    if (metadata.isBuiltInDemo()) {
+        setError("Built-in demo projects cannot be deleted.");
         return false;
     }
 
     if (metadata.folderPath.isEmpty()) {
-        if (errorMessage != nullptr) {
-            *errorMessage = "Project folder is missing.";
-        }
+        setError("Project folder is missing.");
         return false;
     }
 
@@ -1131,9 +1167,7 @@ bool ProjectPersistence::deleteProject(const ProjectMetadata& metadata, QString*
 
     const auto loaded = loadProject(metadata.folderPath);
     if (!loaded.isValid()) {
-        if (errorMessage != nullptr) {
-            *errorMessage = "The selected folder does not contain a valid SafeCrowd project.";
-        }
+        setError("The selected folder does not contain a valid SafeCrowd project.");
         return false;
     }
 
@@ -1141,16 +1175,23 @@ bool ProjectPersistence::deleteProject(const ProjectMetadata& metadata, QString*
         return false;
     }
 
-    QDir folder(metadata.folderPath);
-    if (!folder.removeRecursively()) {
-        if (errorMessage != nullptr) {
-            *errorMessage = QString("Failed to delete project folder: %1").arg(metadata.folderPath);
-        }
-        return false;
+    const auto absoluteFolder = QFileInfo(metadata.folderPath).absoluteFilePath();
+    QString trashPath;
+    if (QFile::moveToTrash(absoluteFolder, &trashPath)) {
+        qInfo().noquote() << "Moved project folder to trash:" << absoluteFolder
+                          << "->" << (trashPath.isEmpty() ? QStringLiteral("(unknown)") : trashPath);
+        removeRecentProject(metadata.folderPath);
+        return true;
     }
 
-    removeRecentProject(metadata.folderPath);
-    return true;
+    qWarning().noquote() << "moveToTrash failed for" << absoluteFolder
+                         << "- aborting deletion to keep the operation reversible";
+    setError(QString(
+        "Failed to move the project folder to the recycle bin:\n%1\n\n"
+        "The project was not deleted. Please check folder permissions and try again, "
+        "or remove the folder manually.")
+        .arg(metadata.folderPath));
+    return false;
 }
 
 bool ProjectPersistence::loadProjectReview(const ProjectMetadata& metadata, safecrowd::domain::ImportResult* importResult) {


### PR DESCRIPTION
## Summary

- Move project deletion to the OS recycle bin (`QFile::moveToTrash`) so the action is reversible; refuse to fall back to permanent recursive removal on failure.
- Tighten `canDeleteProjectFolder` to reject symbolic links and Windows junctions (folder itself and any entry), and to detect drive/volume roots via `QDir::isRoot` + `QStorageInfo` rather than comparing against the system root.
- Share a canonical, case-insensitive folder-key helper between `removeRecentProject` and `upsertRecentProject` so Windows/macOS path casing no longer leaves stale recent entries; write failures are now logged via `qWarning` instead of silently swallowed.
- Use `Qt::PlainText` on the confirmation/warning dialogs in `MainWindow` so user-supplied project names and paths cannot be interpreted as rich text, and update the prompt to reflect the recycle-bin behaviour.

## Related Issue

- Closes #169

## Area

- [ ] Engine
- [ ] Domain
- [x] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [x] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug`
- [x] `ctest --preset test-debug`
- [ ] Not run (reason below)

`safecrowd_app.exe` and `safecrowd_tests.exe` build cleanly. `ctest` reports 1/1 passed locally.

Manual scenarios still recommended on a clean profile:

1. Create a SafeCrowd project, then delete it from the recent list — confirm it moves to the recycle bin and can be restored.
2. Verify deletion is refused for: a folder containing an unrelated file/subfolder, a folder that is a junction/symlink, and any drive/volume root mistakenly registered.
3. Verify the recent list updates correctly when the same folder is registered with different casing on Windows.

## Risks / Follow-up

- `QFile::moveToTrash` may fail on filesystems without a trash (e.g. some network shares). The new behaviour fails closed (no permanent delete); a future change could offer an explicit "permanent delete" path with extra confirmation if needed.
- TOCTOU between `canDeleteProjectFolder` and `moveToTrash` is unchanged but lower-risk now that deletion is reversible.