### PR TITLE
[Domain] Prevent narrow-door wall sticking

### DIFF
--- a/src/application/LayoutPreviewWidget.cpp
+++ b/src/application/LayoutPreviewWidget.cpp
@@ -449,6 +449,12 @@ QPointF entryOutsideSample(const QRectF& rectangle, safecrowd::domain::StairEntr
 std::optional<std::vector<std::pair<safecrowd::domain::Point2D, safecrowd::domain::Point2D>>> barrierSegmentsAfterGap(
     const safecrowd::domain::Barrier2D& barrier,
     const safecrowd::domain::LineSegment2D& gap);
+bool spanOverlapsPolygonBoundary(
+    const safecrowd::domain::Polygon2D& polygon,
+    const safecrowd::domain::LineSegment2D& span);
+std::optional<QPointF> outsideSampleForBoundarySpan(
+    const safecrowd::domain::Polygon2D& polygon,
+    const safecrowd::domain::LineSegment2D& span);
 
 bool isVerticalLink(const safecrowd::domain::Connection2D& connection) {
     return connection.kind == safecrowd::domain::ConnectionKind::Stair
@@ -468,6 +474,23 @@ const safecrowd::domain::Zone2D* findZoneById(
         return zone.id == zoneId;
     });
     return it == layout.zones.end() ? nullptr : &(*it);
+}
+
+bool connectionVisibleOnFloor(
+    const safecrowd::domain::FacilityLayout2D& layout,
+    const safecrowd::domain::Connection2D& connection,
+    const QString& floorId) {
+    if (matchesFloor(connection.floorId, floorId)) {
+        return true;
+    }
+    if (!isVerticalLink(connection)) {
+        return false;
+    }
+
+    const auto* fromZone = findZoneById(layout, connection.fromZoneId);
+    const auto* toZone = findZoneById(layout, connection.toZoneId);
+    return (fromZone != nullptr && matchesFloor(fromZone->floorId, floorId))
+        || (toZone != nullptr && matchesFloor(toZone->floorId, floorId));
 }
 
 std::optional<std::size_t> findZoneIndexById(
@@ -517,8 +540,7 @@ std::optional<safecrowd::domain::LineSegment2D> stairEntrySpanForFloor(
     const safecrowd::domain::FacilityLayout2D& layout,
     const safecrowd::domain::Connection2D& connection,
     const std::string& floorId) {
-    const auto direction = stairEntryDirectionForFloor(layout, connection, floorId);
-    if (!direction.has_value()) {
+    if (!isVerticalLink(connection)) {
         return std::nullopt;
     }
 
@@ -526,6 +548,15 @@ std::optional<safecrowd::domain::LineSegment2D> stairEntrySpanForFloor(
     const auto* toZone = findZoneById(layout, connection.toZoneId);
     const auto* stairZone = fromZone != nullptr && fromZone->floorId == floorId ? fromZone : toZone;
     if (stairZone == nullptr || !isVerticalZone(*stairZone)) {
+        return std::nullopt;
+    }
+
+    if (spanOverlapsPolygonBoundary(stairZone->area, connection.centerSpan)) {
+        return connection.centerSpan;
+    }
+
+    const auto direction = stairEntryDirectionForFloor(layout, connection, floorId);
+    if (!direction.has_value()) {
         return std::nullopt;
     }
 
@@ -542,8 +573,7 @@ std::optional<QPointF> stairEntryOutsideSampleForFloor(
     const safecrowd::domain::FacilityLayout2D& layout,
     const safecrowd::domain::Connection2D& connection,
     const std::string& floorId) {
-    const auto direction = stairEntryDirectionForFloor(layout, connection, floorId);
-    if (!direction.has_value()) {
+    if (!isVerticalLink(connection)) {
         return std::nullopt;
     }
 
@@ -551,6 +581,15 @@ std::optional<QPointF> stairEntryOutsideSampleForFloor(
     const auto* toZone = findZoneById(layout, connection.toZoneId);
     const auto* stairZone = fromZone != nullptr && fromZone->floorId == floorId ? fromZone : toZone;
     if (stairZone == nullptr || !isVerticalZone(*stairZone)) {
+        return std::nullopt;
+    }
+
+    if (spanOverlapsPolygonBoundary(stairZone->area, connection.centerSpan)) {
+        return outsideSampleForBoundarySpan(stairZone->area, connection.centerSpan);
+    }
+
+    const auto direction = stairEntryDirectionForFloor(layout, connection, floorId);
+    if (!direction.has_value()) {
         return std::nullopt;
     }
 
@@ -712,6 +751,62 @@ bool pointInPolygon(const safecrowd::domain::Polygon2D& polygon, const QPointF& 
     }
 
     return true;
+}
+
+bool spanOverlapsPolygonBoundary(
+    const safecrowd::domain::Polygon2D& polygon,
+    const safecrowd::domain::LineSegment2D& span) {
+    const auto spanLength = std::hypot(span.end.x - span.start.x, span.end.y - span.start.y);
+    if (spanLength <= kGeometryEpsilon) {
+        return false;
+    }
+
+    const auto checkRing = [&](const auto& ring) {
+        if (ring.size() < 2) {
+            return false;
+        }
+        for (std::size_t index = 0; index < ring.size(); ++index) {
+            if (segmentsShareSpan(span, ring[index], ring[(index + 1) % ring.size()])) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    if (checkRing(polygon.outline)) {
+        return true;
+    }
+    return std::any_of(polygon.holes.begin(), polygon.holes.end(), checkRing);
+}
+
+std::optional<QPointF> outsideSampleForBoundarySpan(
+    const safecrowd::domain::Polygon2D& polygon,
+    const safecrowd::domain::LineSegment2D& span) {
+    const auto dx = span.end.x - span.start.x;
+    const auto dy = span.end.y - span.start.y;
+    const auto length = std::hypot(dx, dy);
+    if (length <= kGeometryEpsilon) {
+        return std::nullopt;
+    }
+
+    const QPointF center(
+        (span.start.x + span.end.x) * 0.5,
+        (span.start.y + span.end.y) * 0.5);
+    constexpr double sampleOffset = 0.45;
+    const QPointF normalA(-dy / length * sampleOffset, dx / length * sampleOffset);
+    const QPointF normalB(dy / length * sampleOffset, -dx / length * sampleOffset);
+    const QPointF sampleA = center + normalA;
+    const QPointF sampleB = center + normalB;
+    const bool sampleAInside = pointInPolygon(polygon, sampleA);
+    const bool sampleBInside = pointInPolygon(polygon, sampleB);
+
+    if (!sampleAInside && sampleBInside) {
+        return sampleA;
+    }
+    if (!sampleBInside && sampleAInside) {
+        return sampleB;
+    }
+    return std::nullopt;
 }
 
 double distanceToLineSegmentWorld(const QPointF& point, const safecrowd::domain::Point2D& start, const safecrowd::domain::Point2D& end) {
@@ -1970,7 +2065,7 @@ std::optional<QString> hitTestConnection(
     std::optional<QString> bestId;
 
     for (const auto& connection : layout.connections) {
-        if (!matchesFloor(connection.floorId, floorId)) {
+        if (!connectionVisibleOnFloor(layout, connection, floorId)) {
             continue;
         }
         const auto start = transform.map(connection.centerSpan.start);
@@ -2057,7 +2152,7 @@ bool selectedConnectionContainsContextPoint(
 
     for (const auto& connection : layout.connections) {
         const auto connectionId = QString::fromStdString(connection.id);
-        if (!selectedConnectionIds.contains(connectionId) || !matchesFloor(connection.floorId, floorId)) {
+        if (!selectedConnectionIds.contains(connectionId) || !connectionVisibleOnFloor(layout, connection, floorId)) {
             continue;
         }
 
@@ -2744,7 +2839,7 @@ void LayoutPreviewWidget::paintEvent(QPaintEvent* event) {
                 }
             }
             for (const auto& connection : importResult_.layout->connections) {
-                if (!matchesFloor(connection.floorId, currentFloorId())) {
+                if (!connectionVisibleOnFloor(*importResult_.layout, connection, currentFloorId())) {
                     continue;
                 }
                 const auto id = QString::fromStdString(connection.id);
@@ -4336,7 +4431,7 @@ void LayoutPreviewWidget::selectElementsInRect(const QRectF& screenRect, const L
         }
     }
     for (const auto& connection : layout.connections) {
-        if (!matchesFloor(connection.floorId, floorId)) {
+        if (!connectionVisibleOnFloor(layout, connection, floorId)) {
             continue;
         }
         if (strokedPathIntersectsRect(linePath(connection.centerSpan, transform), screenRect, kSelectionStrokeWidthPixels)) {

--- a/src/domain/ScenarioSimulationInternal.cpp
+++ b/src/domain/ScenarioSimulationInternal.cpp
@@ -376,6 +376,73 @@ std::vector<LineSegment2D> stairEntryBarrierSegments(const Zone2D& zone, StairEn
     return segments;
 }
 
+std::vector<LineSegment2D> barrierSegmentAfterConnectionGap(
+    const LineSegment2D& segment,
+    const LineSegment2D& gap) {
+    const auto segmentDelta = segment.end - segment.start;
+    const auto segmentLength = lengthOf(segmentDelta);
+    if (segmentLength <= kGeometryEpsilon) {
+        return {};
+    }
+
+    if (std::fabs(cross(segment.start, segment.end, gap.start)) > kGeometryEpsilon
+        || std::fabs(cross(segment.start, segment.end, gap.end)) > kGeometryEpsilon) {
+        return {segment};
+    }
+
+    const auto direction = segmentDelta * (1.0 / segmentLength);
+    auto gapStart = dot(gap.start - segment.start, direction);
+    auto gapEnd = dot(gap.end - segment.start, direction);
+    if (gapStart > gapEnd) {
+        std::swap(gapStart, gapEnd);
+    }
+
+    const auto overlapStart = std::max(0.0, gapStart);
+    const auto overlapEnd = std::min(segmentLength, gapEnd);
+    if (overlapEnd <= overlapStart + kGeometryEpsilon) {
+        return {segment};
+    }
+
+    std::vector<LineSegment2D> remaining;
+    if (overlapStart > kGeometryEpsilon) {
+        remaining.push_back({
+            .start = segment.start,
+            .end = segment.start + (direction * overlapStart),
+        });
+    }
+    if (overlapEnd < segmentLength - kGeometryEpsilon) {
+        remaining.push_back({
+            .start = segment.start + (direction * overlapEnd),
+            .end = segment.end,
+        });
+    }
+    return remaining;
+}
+
+std::vector<LineSegment2D> clipStairEntryBarrierSegment(
+    const LineSegment2D& segment,
+    const FacilityLayout2D& source,
+    const Zone2D& stairZone) {
+    std::vector<LineSegment2D> remaining{segment};
+    for (const auto& connection : source.connections) {
+        if (!isVerticalConnection(connection)
+            || (connection.fromZoneId != stairZone.id && connection.toZoneId != stairZone.id)) {
+            continue;
+        }
+
+        std::vector<LineSegment2D> next;
+        for (const auto& candidate : remaining) {
+            auto clipped = barrierSegmentAfterConnectionGap(candidate, connection.centerSpan);
+            next.insert(next.end(), clipped.begin(), clipped.end());
+        }
+        remaining = std::move(next);
+        if (remaining.empty()) {
+            break;
+        }
+    }
+    return remaining;
+}
+
 void appendStairEntryBarriers(FacilityLayout2D& filtered, const FacilityLayout2D& source, const std::string& floorId) {
     int suffix = 1;
     for (const auto& connection : source.connections) {
@@ -394,12 +461,14 @@ void appendStairEntryBarriers(FacilityLayout2D& filtered, const FacilityLayout2D
         }
 
         for (const auto& segment : stairEntryBarrierSegments(*stairZone, direction)) {
-            filtered.barriers.push_back({
-                .id = connection.id + "-entry-wall-" + std::to_string(suffix++),
-                .floorId = stairZone->floorId,
-                .geometry = {.vertices = {segment.start, segment.end}},
-                .blocksMovement = true,
-            });
+            for (const auto& clippedSegment : clipStairEntryBarrierSegment(segment, source, *stairZone)) {
+                filtered.barriers.push_back({
+                    .id = connection.id + "-entry-wall-" + std::to_string(suffix++),
+                    .floorId = stairZone->floorId,
+                    .geometry = {.vertices = {clippedSegment.start, clippedSegment.end}},
+                    .blocksMovement = true,
+                });
+            }
         }
     }
 }
@@ -995,7 +1064,7 @@ bool pointInsideClosedBarrier(const FacilityLayout2D& layout, const Point2D& poi
 }
 
 bool pointHasClearance(const FacilityLayout2D& layout, const Point2D& point, double clearance) {
-    if (!pointInAnyZone(layout, point) || pointInsideClosedBarrier(layout, point)) {
+    if ((!layout.zones.empty() && !pointInAnyZone(layout, point)) || pointInsideClosedBarrier(layout, point)) {
         return false;
     }
 
@@ -1371,18 +1440,29 @@ std::vector<Point2D> buildPath(const FacilityLayout2D& layout, const Point2D& st
     return path;
 }
 
-Point2D constrainedMove(const FacilityLayout2D& layout, const Point2D& from, const Point2D& to) {
-    if (!movementCrossesBarrier(layout, from, to)) {
+Point2D constrainedMove(const FacilityLayout2D& layout, const Point2D& from, const Point2D& to, double clearance) {
+    const auto effectiveClearance = std::max(0.0, clearance);
+    auto validDestination = [&](const Point2D& point) {
+        if (effectiveClearance > 0.0) {
+            return pointHasClearance(layout, point, effectiveClearance);
+        }
+        return (layout.zones.empty() || pointInAnyZone(layout, point)) && !pointInsideClosedBarrier(layout, point);
+    };
+    auto validMove = [&](const Point2D& candidate) {
+        return validDestination(candidate) && !movementCrossesBarrier(layout, from, candidate);
+    };
+
+    if (validMove(to)) {
         return to;
     }
 
     const Point2D xOnly{.x = to.x, .y = from.y};
-    if (!movementCrossesBarrier(layout, from, xOnly)) {
+    if (validMove(xOnly)) {
         return xOnly;
     }
 
     const Point2D yOnly{.x = from.x, .y = to.y};
-    if (!movementCrossesBarrier(layout, from, yOnly)) {
+    if (validMove(yOnly)) {
         return yOnly;
     }
 
@@ -1392,11 +1472,11 @@ Point2D constrainedMove(const FacilityLayout2D& layout, const Point2D& from, con
     for (int i = 0; i < 8; ++i) {
         const auto t = (low + high) * 0.5;
         const auto candidate = from + ((to - from) * t);
-        if (movementCrossesBarrier(layout, from, candidate)) {
-            high = t;
-        } else {
+        if (validMove(candidate)) {
             low = t;
             best = candidate;
+        } else {
+            high = t;
         }
     }
     return best;

--- a/src/domain/ScenarioSimulationInternal.h
+++ b/src/domain/ScenarioSimulationInternal.h
@@ -161,6 +161,6 @@ Point2D barrierSeparationVelocity(const FacilityLayout2D& layout, const Position
 bool movementCrossesBarrier(const FacilityLayout2D& layout, const Point2D& from, const Point2D& to);
 bool lineOfSightClear(const FacilityLayout2D& layout, const Point2D& from, const Point2D& to, double clearance);
 std::vector<Point2D> buildPath(const FacilityLayout2D& layout, const Point2D& start, const Point2D& goal, double clearance);
-Point2D constrainedMove(const FacilityLayout2D& layout, const Point2D& from, const Point2D& to);
+Point2D constrainedMove(const FacilityLayout2D& layout, const Point2D& from, const Point2D& to, double clearance = 0.0);
 
 }  // namespace safecrowd::domain::simulation_internal

--- a/src/domain/ScenarioSimulationMotionSystem.cpp
+++ b/src/domain/ScenarioSimulationMotionSystem.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <unordered_set>
@@ -94,8 +95,7 @@ public:
             const auto target = routeWaypointTarget(route, position.value);
             const auto distance = distanceBetween(position.value, target);
             if (distance <= kArrivalEpsilon) {
-                position.value = target;
-                advanceRouteWaypoint(route, target);
+                position.value = advanceRouteWaypoint(layoutCache, route, target);
                 velocity.value = {};
                 continue;
             }
@@ -159,10 +159,12 @@ public:
             const auto stepVelocity =
                 clampedToLength(plan.velocity, std::min(maxSpeed, remainingDistance / clampedDelta));
             const auto previousPosition = position.value;
+            const auto movementClearance = currentWaypointIsVertical(route) ? 0.0 : static_cast<double>(agent.radius);
             const auto nextPosition = constrainedMove(
                 cachedLayoutForFloor(layoutCache, route.currentFloorId),
                 previousPosition,
-                previousPosition + (stepVelocity * clampedDelta));
+                previousPosition + (stepVelocity * clampedDelta),
+                movementClearance);
             position.value = nextPosition;
             velocity.value = (nextPosition - previousPosition) * (1.0 / clampedDelta);
             updateDisplayFloor(route, nextPosition);
@@ -221,6 +223,105 @@ private:
             return connection != nullptr && connection->directionality == TravelDirection::Closed;
         }
         return false;
+    }
+
+    bool verticalPassageCrossed(
+        const ScenarioLayoutCacheResource& layoutCache,
+        const EvacuationRoute& route,
+        const Point2D& position) const {
+        if (route.nextWaypointIndex >= route.waypointPassages.size()
+            || route.nextWaypointIndex >= route.waypointFromZoneIds.size()
+            || route.nextWaypointIndex >= route.waypointZoneIds.size()) {
+            return false;
+        }
+
+        const auto& passage = route.waypointPassages[route.nextWaypointIndex];
+        if (lengthSquaredOf(passage) <= 1e-9) {
+            return false;
+        }
+
+        const auto* fromZone = findCachedZone(layoutCache, route.waypointFromZoneIds[route.nextWaypointIndex]);
+        const auto* toZone = findCachedZone(layoutCache, route.waypointZoneIds[route.nextWaypointIndex]);
+        if (fromZone == nullptr || toZone == nullptr) {
+            return false;
+        }
+
+        auto normal = normalizedOr(perpendicularLeft(passage.end - passage.start), {});
+        if (lengthOf(normal) <= 1e-9) {
+            return false;
+        }
+        const auto towardToZone = polygonCenter(toZone->area) - midpoint(passage);
+        if (lengthOf(towardToZone) <= kArrivalEpsilon) {
+            return false;
+        }
+        if (dot(normal, towardToZone) < 0.0) {
+            normal = normal * -1.0;
+        }
+
+        return dot(position - midpoint(passage), normal) > kPortalCrossingEpsilon;
+    }
+
+    Point2D verticalTransitionLandingPoint(
+        const ScenarioLayoutCacheResource& layoutCache,
+        const EvacuationRoute& route,
+        std::size_t reachedIndex,
+        const Point2D& reachedPoint) const {
+        if (reachedIndex >= route.waypointVerticalTransitions.size()
+            || !route.waypointVerticalTransitions[reachedIndex]
+            || reachedIndex >= route.waypointPassages.size()
+            || reachedIndex >= route.waypointFromZoneIds.size()
+            || reachedIndex >= route.waypointZoneIds.size()) {
+            return reachedPoint;
+        }
+
+        const auto* fromZone = findCachedZone(layoutCache, route.waypointFromZoneIds[reachedIndex]);
+        const auto* toZone = findCachedZone(layoutCache, route.waypointZoneIds[reachedIndex]);
+        if (fromZone == nullptr || toZone == nullptr) {
+            return reachedPoint;
+        }
+
+        const auto& passage = route.waypointPassages[reachedIndex];
+        if (lengthSquaredOf(passage) <= 1e-9) {
+            return reachedPoint;
+        }
+
+        const auto landingOnPassage = closestPointOnSegment(reachedPoint, passage.start, passage.end);
+        auto boundaryDistance = [](const Zone2D& zone, const Point2D& point) {
+            auto bestDistance = std::numeric_limits<double>::max();
+            if (zone.area.outline.size() < 2) {
+                return bestDistance;
+            }
+            for (std::size_t index = 0; index < zone.area.outline.size(); ++index) {
+                const auto& start = zone.area.outline[index];
+                const auto& end = zone.area.outline[(index + 1) % zone.area.outline.size()];
+                bestDistance = std::min(bestDistance, distanceBetween(point, closestPointOnSegment(point, start, end)));
+            }
+            return bestDistance;
+        };
+        if (pointInRing(toZone->area.outline, landingOnPassage)
+            && boundaryDistance(*toZone, landingOnPassage) > kArrivalEpsilon) {
+            return landingOnPassage;
+        }
+
+        const auto passageDirection = passage.end - passage.start;
+        auto normal = normalizedOr(perpendicularLeft(passageDirection), {});
+        if (lengthOf(normal) <= 1e-9) {
+            return reachedPoint;
+        }
+
+        const auto towardTargetZone = polygonCenter(toZone->area) - midpoint(passage);
+        if (dot(normal, towardTargetZone) < 0.0) {
+            normal = normal * -1.0;
+        }
+
+        for (const auto offset : {0.2, 0.45, 0.75, 1.1, 1.6}) {
+            const auto candidate = landingOnPassage + (normal * offset);
+            if (pointInRing(toZone->area.outline, candidate)) {
+                return candidate;
+            }
+        }
+
+        return reachedPoint;
     }
 
     RoutePlan routePlanToNearestExit(
@@ -299,17 +400,21 @@ private:
         return plan;
     }
 
-    void advanceRouteWaypoint(EvacuationRoute& route, const Point2D& reachedPoint) const {
+    Point2D advanceRouteWaypoint(
+        const ScenarioLayoutCacheResource& layoutCache,
+        EvacuationRoute& route,
+        const Point2D& reachedPoint) const {
         if (route.nextWaypointIndex >= route.waypoints.size()) {
-            return;
+            return reachedPoint;
         }
 
         const auto reachedIndex = route.nextWaypointIndex;
+        const auto advancedPoint = verticalTransitionLandingPoint(layoutCache, route, reachedIndex, reachedPoint);
         if (reachedIndex < route.waypointFloorIds.size() && !route.waypointFloorIds[reachedIndex].empty()) {
             route.currentFloorId = route.waypointFloorIds[reachedIndex];
         }
         route.displayFloorId = route.currentFloorId;
-        route.currentSegmentStart = reachedPoint;
+        route.currentSegmentStart = advancedPoint;
         ++route.nextWaypointIndex;
         if (route.nextWaypointIndex < route.waypoints.size()) {
             route.previousDistanceToWaypoint =
@@ -319,6 +424,7 @@ private:
         }
         route.stalledSeconds = 0.0;
         route.nextSegmentReplanSeconds = 0.0;
+        return advancedPoint;
     }
 
     bool waypointHasTransition(const EvacuationRoute& route) const {
@@ -377,13 +483,16 @@ private:
                 continue;
             }
 
-            const auto& position = query.get<Position>(entity);
+            auto& position = query.get<Position>(entity);
             const auto& agent = query.get<Agent>(entity);
             auto& route = query.get<EvacuationRoute>(entity);
             while (route.nextWaypointIndex < route.waypoints.size()) {
-                const auto& floorLayout = cachedLayoutForFloor(layoutCache, route.currentFloorId);
-                if (routePassageCrossed(floorLayout, route, position.value, agent.radius)) {
-                    advanceRouteWaypoint(route, position.value);
+                const bool verticalTransition = currentWaypointIsVertical(route);
+                const bool passageCrossed = verticalTransition
+                    ? verticalPassageCrossed(layoutCache, route, position.value)
+                    : routePassageCrossed(cachedLayoutForFloor(layoutCache, route.currentFloorId), route, position.value, agent.radius);
+                if (passageCrossed) {
+                    position.value = advanceRouteWaypoint(layoutCache, route, position.value);
                     continue;
                 }
 
@@ -393,24 +502,24 @@ private:
                 const auto distance = distanceToRouteWaypoint(route, position.value);
 
                 if (distance <= kArrivalEpsilon) {
-                    advanceRouteWaypoint(route, target);
+                    position.value = advanceRouteWaypoint(layoutCache, route, target);
                     continue;
                 }
 
                 if (segmentLengthSquared > 1e-9) {
                     const auto projection = dot(position.value - route.currentSegmentStart, segment);
-                    if (projection >= segmentLengthSquared - kWaypointCrossingEpsilon) {
-                        advanceRouteWaypoint(route, position.value);
+                    if (!verticalTransition && projection >= segmentLengthSquared - kWaypointCrossingEpsilon) {
+                        position.value = advanceRouteWaypoint(layoutCache, route, position.value);
                         continue;
                     }
-                    if (shouldAdvanceByBypassingWaypoint(
+                    if (!verticalTransition && shouldAdvanceByBypassingWaypoint(
                             route,
                             position,
                             agent,
                             segment,
                             segmentLengthSquared,
                             projection)) {
-                        advanceRouteWaypoint(route, position.value);
+                        position.value = advanceRouteWaypoint(layoutCache, route, position.value);
                         continue;
                     }
                 }
@@ -426,12 +535,13 @@ private:
                     route.stalledSeconds += deltaSeconds;
                 }
 
-                if (route.stalledSeconds >= kWaypointStallSeconds
+                if (!verticalTransition
+                    && route.stalledSeconds >= kWaypointStallSeconds
                     && route.nextWaypointIndex + 1 < route.waypoints.size()
                     && segmentLengthSquared > 1e-9) {
                     const auto projection = dot(position.value - route.currentSegmentStart, segment);
                     if (projection > segmentLengthSquared * 0.45) {
-                        advanceRouteWaypoint(route, position.value);
+                        position.value = advanceRouteWaypoint(layoutCache, route, position.value);
                         continue;
                     }
                 }
@@ -452,7 +562,7 @@ private:
                 continue;
             }
 
-            const auto& position = query.get<Position>(entity);
+            auto& position = query.get<Position>(entity);
             auto& route = query.get<EvacuationRoute>(entity);
             const auto currentZoneId = zoneAt(layoutCache, position.value, route.currentFloorId);
             while (!currentZoneId.empty() && route.nextWaypointIndex < route.waypointZoneIds.size()) {
@@ -468,7 +578,7 @@ private:
                 }
 
                 while (route.nextWaypointIndex <= matchedIndex && route.nextWaypointIndex < route.waypoints.size()) {
-                    advanceRouteWaypoint(route, position.value);
+                    position.value = advanceRouteWaypoint(layoutCache, route, position.value);
                 }
             }
         }
@@ -746,14 +856,20 @@ private:
                     if (agentCollisionFloorId(secondRoute) != firstCollisionFloorId) {
                         continue;
                     }
+                    const auto firstClearance =
+                        currentWaypointIsVertical(firstRoute) ? 0.0 : static_cast<double>(firstAgent.radius);
+                    const auto secondClearance =
+                        currentWaypointIsVertical(secondRoute) ? 0.0 : static_cast<double>(secondAgent.radius);
                     firstPosition.value = constrainedMove(
                         cachedLayoutForFloor(layoutCache, firstRoute.currentFloorId),
                         firstPosition.value,
-                        firstPosition.value + (direction * push));
+                        firstPosition.value + (direction * push),
+                        firstClearance);
                     secondPosition.value = constrainedMove(
                         cachedLayoutForFloor(layoutCache, secondRoute.currentFloorId),
                         secondPosition.value,
-                        secondPosition.value - (direction * push));
+                        secondPosition.value - (direction * push),
+                        secondClearance);
                 }
             }
         }

--- a/tests/ScenarioSimulationRunnerTests.cpp
+++ b/tests/ScenarioSimulationRunnerTests.cpp
@@ -1,10 +1,94 @@
 #include "TestSupport.h"
 
+#include <algorithm>
 #include <cmath>
 #include "domain/DemoLayouts.h"
 #include "domain/ScenarioSimulationRunner.h"
 
 namespace {
+
+bool testPointInRing(
+    const std::vector<safecrowd::domain::Point2D>& ring,
+    const safecrowd::domain::Point2D& point) {
+    if (ring.size() < 3) {
+        return false;
+    }
+
+    bool inside = false;
+    for (std::size_t i = 0, j = ring.size() - 1; i < ring.size(); j = i++) {
+        const auto& a = ring[i];
+        const auto& b = ring[j];
+        const auto intersects = ((a.y > point.y) != (b.y > point.y))
+            && (point.x < ((b.x - a.x) * (point.y - a.y) / ((b.y - a.y) == 0.0 ? 1e-9 : (b.y - a.y)) + a.x));
+        if (intersects) {
+            inside = !inside;
+        }
+    }
+    return inside;
+}
+
+bool agentInsideAnyZoneOnFrameFloor(
+    const safecrowd::domain::FacilityLayout2D& layout,
+    const safecrowd::domain::SimulationAgentFrame& agent) {
+    return std::any_of(layout.zones.begin(), layout.zones.end(), [&](const auto& zone) {
+        return (zone.floorId.empty() || zone.floorId == agent.floorId)
+            && testPointInRing(zone.area.outline, agent.position);
+    });
+}
+
+double testDistanceBetween(const safecrowd::domain::Point2D& lhs, const safecrowd::domain::Point2D& rhs) {
+    const auto dx = lhs.x - rhs.x;
+    const auto dy = lhs.y - rhs.y;
+    return std::sqrt((dx * dx) + (dy * dy));
+}
+
+safecrowd::domain::Point2D testClosestPointOnSegment(
+    const safecrowd::domain::Point2D& point,
+    const safecrowd::domain::Point2D& start,
+    const safecrowd::domain::Point2D& end) {
+    const auto dx = end.x - start.x;
+    const auto dy = end.y - start.y;
+    const auto lengthSquared = (dx * dx) + (dy * dy);
+    if (lengthSquared <= 1e-9) {
+        return start;
+    }
+
+    const auto t = std::clamp(((point.x - start.x) * dx + (point.y - start.y) * dy) / lengthSquared, 0.0, 1.0);
+    return {.x = start.x + (dx * t), .y = start.y + (dy * t)};
+}
+
+double testDistancePointToSegment(
+    const safecrowd::domain::Point2D& point,
+    const safecrowd::domain::Point2D& start,
+    const safecrowd::domain::Point2D& end) {
+    return testDistanceBetween(point, testClosestPointOnSegment(point, start, end));
+}
+
+bool agentKeepsBarrierClearance(
+    const safecrowd::domain::FacilityLayout2D& layout,
+    const safecrowd::domain::SimulationAgentFrame& agent,
+    double clearance) {
+    for (const auto& barrier : layout.barriers) {
+        if (!barrier.blocksMovement || barrier.geometry.vertices.size() < 2) {
+            continue;
+        }
+        if (!barrier.floorId.empty() && barrier.floorId != agent.floorId) {
+            continue;
+        }
+
+        const auto& vertices = barrier.geometry.vertices;
+        for (std::size_t index = 0; index + 1 < vertices.size(); ++index) {
+            if (testDistancePointToSegment(agent.position, vertices[index], vertices[index + 1]) + 1e-6 < clearance) {
+                return false;
+            }
+        }
+        if (barrier.geometry.closed
+            && testDistancePointToSegment(agent.position, vertices.back(), vertices.front()) + 1e-6 < clearance) {
+            return false;
+        }
+    }
+    return true;
+}
 
 safecrowd::domain::FacilityLayout2D blockedDoorLayout() {
     safecrowd::domain::FacilityLayout2D layout;
@@ -96,6 +180,55 @@ safecrowd::domain::FacilityLayout2D wideDoorToPassageLayout() {
         .toZoneId = "exit",
         .effectiveWidth = 2.0,
         .centerSpan = {{8.0, 1.0}, {8.0, 3.0}},
+    });
+    return layout;
+}
+
+safecrowd::domain::FacilityLayout2D narrowDoorCrowdLayout() {
+    safecrowd::domain::FacilityLayout2D layout;
+    layout.zones.push_back({
+        .id = "room",
+        .kind = safecrowd::domain::ZoneKind::Room,
+        .label = "Room",
+        .area = {.outline = {{0.0, 0.0}, {4.0, 0.0}, {4.0, 4.0}, {0.0, 4.0}}},
+    });
+    layout.zones.push_back({
+        .id = "passage",
+        .kind = safecrowd::domain::ZoneKind::Room,
+        .label = "Passage",
+        .area = {.outline = {{4.0, 0.0}, {7.0, 0.0}, {7.0, 4.0}, {4.0, 4.0}}},
+    });
+    layout.zones.push_back({
+        .id = "exit",
+        .kind = safecrowd::domain::ZoneKind::Exit,
+        .label = "Exit",
+        .area = {.outline = {{7.0, 1.0}, {9.0, 1.0}, {9.0, 3.0}, {7.0, 3.0}}},
+    });
+    layout.connections.push_back({
+        .id = "narrow-door",
+        .kind = safecrowd::domain::ConnectionKind::Doorway,
+        .fromZoneId = "room",
+        .toZoneId = "passage",
+        .effectiveWidth = 0.9,
+        .centerSpan = {{4.0, 1.55}, {4.0, 2.45}},
+    });
+    layout.connections.push_back({
+        .id = "exit-door",
+        .kind = safecrowd::domain::ConnectionKind::Exit,
+        .fromZoneId = "passage",
+        .toZoneId = "exit",
+        .effectiveWidth = 2.0,
+        .centerSpan = {{7.0, 1.0}, {7.0, 3.0}},
+    });
+    layout.barriers.push_back({
+        .id = "lower-door-jamb",
+        .geometry = {.vertices = {{4.0, 0.0}, {4.0, 1.55}}},
+        .blocksMovement = true,
+    });
+    layout.barriers.push_back({
+        .id = "upper-door-jamb",
+        .geometry = {.vertices = {{4.0, 2.45}, {4.0, 4.0}}},
+        .blocksMovement = true,
     });
     return layout;
 }
@@ -259,6 +392,183 @@ safecrowd::domain::FacilityLayout2D directedStairExitLayout(
         .effectiveWidth = 1.2,
         .centerSpan = {{4.0, 0.4}, {4.0, 1.6}},
     });
+    return layout;
+}
+
+safecrowd::domain::FacilityLayout2D blockedUShapedStairTransitionLayout() {
+    safecrowd::domain::FacilityLayout2D layout;
+    layout.id = "blocked-u-stair";
+    layout.levelId = "L1";
+    layout.floors.push_back({.id = "L1", .label = "Floor 1"});
+    layout.floors.push_back({.id = "L2", .label = "Floor 2", .elevationMeters = 3.5});
+    layout.zones.push_back({
+        .id = "stair-l1",
+        .floorId = "L1",
+        .kind = safecrowd::domain::ZoneKind::Stair,
+        .label = "U Stair L1",
+        .area = {.outline = {{2.0, 0.0}, {4.0, 0.0}, {4.0, 4.0}, {2.0, 4.0}}},
+        .isStair = true,
+    });
+    layout.zones.push_back({
+        .id = "stair-l2",
+        .floorId = "L2",
+        .kind = safecrowd::domain::ZoneKind::Stair,
+        .label = "U Stair L2",
+        .area = {.outline = {{0.0, 0.0}, {2.0, 0.0}, {2.0, 4.0}, {0.0, 4.0}}},
+        .isStair = true,
+    });
+    layout.zones.push_back({
+        .id = "exit-l2",
+        .floorId = "L2",
+        .kind = safecrowd::domain::ZoneKind::Exit,
+        .label = "Exit L2",
+        .area = {.outline = {{-2.0, 1.0}, {0.0, 1.0}, {0.0, 3.0}, {-2.0, 3.0}}},
+    });
+    layout.connections.push_back({
+        .id = "u-stair-l1-l2",
+        .floorId = "L1",
+        .kind = safecrowd::domain::ConnectionKind::Stair,
+        .fromZoneId = "stair-l1",
+        .toZoneId = "stair-l2",
+        .effectiveWidth = 1.2,
+        .isStair = true,
+        .lowerEntryDirection = safecrowd::domain::StairEntryDirection::West,
+        .upperEntryDirection = safecrowd::domain::StairEntryDirection::West,
+        .centerSpan = {{2.0, 2.8}, {2.0, 4.0}},
+    });
+    layout.connections.push_back({
+        .id = "stair-to-exit",
+        .floorId = "L2",
+        .kind = safecrowd::domain::ConnectionKind::Exit,
+        .fromZoneId = "stair-l2",
+        .toZoneId = "exit-l2",
+        .effectiveWidth = 1.2,
+        .centerSpan = {{0.0, 1.2}, {0.0, 2.8}},
+    });
+    layout.barriers.push_back({
+        .id = "blocked-platform-turn",
+        .floorId = "L1",
+        .geometry = {.vertices = {{2.0, 0.0}, {2.0, 4.0}}},
+        .blocksMovement = true,
+    });
+    return layout;
+}
+
+safecrowd::domain::FacilityLayout2D uShapedStairTransitionLayout() {
+    auto layout = blockedUShapedStairTransitionLayout();
+    layout.id = "u-stair";
+    layout.barriers.clear();
+    return layout;
+}
+
+safecrowd::domain::FacilityLayout2D westEntryUShapedStairTransitionLayout() {
+    safecrowd::domain::FacilityLayout2D layout;
+    layout.id = "west-entry-u-stair";
+    layout.levelId = "L1";
+    layout.floors.push_back({.id = "L1", .label = "Floor 1"});
+    layout.floors.push_back({.id = "L2", .label = "Floor 2", .elevationMeters = 3.5});
+    layout.zones.push_back({
+        .id = "stair-l1",
+        .floorId = "L1",
+        .kind = safecrowd::domain::ZoneKind::Stair,
+        .label = "U Stair L1",
+        .area = {.outline = {{0.0, 2.0}, {0.0, 0.0}, {4.0, 0.0}, {4.0, 2.0}}},
+        .isStair = true,
+    });
+    layout.zones.push_back({
+        .id = "stair-l2",
+        .floorId = "L2",
+        .kind = safecrowd::domain::ZoneKind::Stair,
+        .label = "U Stair L2",
+        .area = {.outline = {{0.0, 4.0}, {0.0, 2.0}, {4.0, 2.0}, {4.0, 4.0}}},
+        .isStair = true,
+    });
+    layout.zones.push_back({
+        .id = "exit-l2",
+        .floorId = "L2",
+        .kind = safecrowd::domain::ZoneKind::Exit,
+        .label = "Exit L2",
+        .area = {.outline = {{-2.0, 2.0}, {0.0, 2.0}, {0.0, 4.0}, {-2.0, 4.0}}},
+    });
+    layout.connections.push_back({
+        .id = "u-stair-l1-l2",
+        .floorId = "L1",
+        .kind = safecrowd::domain::ConnectionKind::Stair,
+        .fromZoneId = "stair-l1",
+        .toZoneId = "stair-l2",
+        .effectiveWidth = 1.2,
+        .isStair = true,
+        .lowerEntryDirection = safecrowd::domain::StairEntryDirection::West,
+        .upperEntryDirection = safecrowd::domain::StairEntryDirection::West,
+        .centerSpan = {{2.8, 2.0}, {4.0, 2.0}},
+    });
+    layout.connections.push_back({
+        .id = "stair-to-exit",
+        .floorId = "L2",
+        .kind = safecrowd::domain::ConnectionKind::Exit,
+        .fromZoneId = "stair-l2",
+        .toZoneId = "exit-l2",
+        .effectiveWidth = 1.2,
+        .centerSpan = {{0.0, 2.4}, {0.0, 3.6}},
+    });
+    layout.barriers.push_back({
+        .id = "source-south-wall",
+        .floorId = "L1",
+        .geometry = {.vertices = {{0.0, 0.0}, {4.0, 0.0}}},
+        .blocksMovement = true,
+    });
+    layout.barriers.push_back({
+        .id = "source-east-wall",
+        .floorId = "L1",
+        .geometry = {.vertices = {{4.0, 0.0}, {4.0, 2.0}}},
+        .blocksMovement = true,
+    });
+    layout.barriers.push_back({
+        .id = "source-north-wall-before-turn",
+        .floorId = "L1",
+        .geometry = {.vertices = {{0.0, 2.0}, {2.8, 2.0}}},
+        .blocksMovement = true,
+    });
+    layout.barriers.push_back({
+        .id = "target-south-wall-before-turn",
+        .floorId = "L2",
+        .geometry = {.vertices = {{0.0, 2.0}, {2.8, 2.0}}},
+        .blocksMovement = true,
+    });
+    layout.barriers.push_back({
+        .id = "target-east-wall",
+        .floorId = "L2",
+        .geometry = {.vertices = {{4.0, 2.0}, {4.0, 4.0}}},
+        .blocksMovement = true,
+    });
+    layout.barriers.push_back({
+        .id = "target-north-wall",
+        .floorId = "L2",
+        .geometry = {.vertices = {{4.0, 4.0}, {0.0, 4.0}}},
+        .blocksMovement = true,
+    });
+    return layout;
+}
+
+safecrowd::domain::FacilityLayout2D descendingWestEntryUShapedStairTransitionLayout() {
+    auto layout = westEntryUShapedStairTransitionLayout();
+    layout.id = "descending-west-entry-u-stair";
+    layout.zones[2] = {
+        .id = "exit-l1",
+        .floorId = "L1",
+        .kind = safecrowd::domain::ZoneKind::Exit,
+        .label = "Exit L1",
+        .area = {.outline = {{-2.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {-2.0, 2.0}}},
+    };
+    layout.connections[1] = {
+        .id = "stair-to-exit",
+        .floorId = "L1",
+        .kind = safecrowd::domain::ConnectionKind::Exit,
+        .fromZoneId = "stair-l1",
+        .toZoneId = "exit-l1",
+        .effectiveWidth = 1.2,
+        .centerSpan = {{0.0, 0.4}, {0.0, 1.6}},
+    };
     return layout;
 }
 
@@ -469,6 +779,45 @@ SC_TEST(ScenarioSimulationRunnerSkipsPassedDoorwaysWhenAgentIsAlreadyInLaterZone
     SC_EXPECT_TRUE(runner.frame().agents.front().velocity.x > 0.0);
 }
 
+SC_TEST(ScenarioSimulationRunnerKeepsCrowdedNarrowDoorAgentsOutOfWalls) {
+    safecrowd::domain::InitialPlacement2D placement;
+    placement.id = "crowded-door";
+    placement.zoneId = "room";
+    placement.initialVelocity = {.x = 1.4, .y = 0.0};
+    placement.explicitPositions = {
+        {.x = 3.35, .y = 1.35},
+        {.x = 3.35, .y = 1.75},
+        {.x = 3.35, .y = 2.15},
+        {.x = 3.35, .y = 2.55},
+        {.x = 2.85, .y = 1.25},
+        {.x = 2.85, .y = 1.65},
+        {.x = 2.85, .y = 2.05},
+        {.x = 2.85, .y = 2.45},
+        {.x = 2.35, .y = 1.45},
+        {.x = 2.35, .y = 1.85},
+        {.x = 2.35, .y = 2.25},
+        {.x = 2.35, .y = 2.65},
+    };
+
+    safecrowd::domain::ScenarioDraft scenario;
+    scenario.execution.timeLimitSeconds = 10.0;
+    scenario.population.initialPlacements.push_back(placement);
+
+    const auto layout = narrowDoorCrowdLayout();
+    safecrowd::domain::ScenarioSimulationRunner runner(layout, scenario);
+    bool anyAgentEnteredPassage = false;
+    for (int i = 0; i < 70 && !runner.complete(); ++i) {
+        runner.step(0.1);
+        for (const auto& agent : runner.frame().agents) {
+            anyAgentEnteredPassage = anyAgentEnteredPassage || agent.position.x > 4.0;
+            SC_EXPECT_TRUE(agentInsideAnyZoneOnFrameFloor(layout, agent));
+            SC_EXPECT_TRUE(agentKeepsBarrierClearance(layout, agent, agent.radius * 0.95));
+        }
+    }
+
+    SC_EXPECT_TRUE(anyAgentEnteredPassage);
+}
+
 SC_TEST(ScenarioSimulationRunnerTraversesStairConnectionBetweenFloors) {
     safecrowd::domain::InitialPlacement2D placement;
     placement.id = "agent-1";
@@ -617,6 +966,126 @@ SC_TEST(ScenarioSimulationRunnerDisplaysNextFloorAfterCrossingStairMidpoint) {
 
     SC_EXPECT_EQ(runner.frame().agents.size(), std::size_t{1});
     SC_EXPECT_EQ(runner.frame().agents.front().floorId, std::string{"L2"});
+}
+
+SC_TEST(ScenarioSimulationRunnerDoesNotAdvanceBlockedUShapedStairBeforeConnection) {
+    safecrowd::domain::InitialPlacement2D placement;
+    placement.id = "agent-1";
+    placement.floorId = "L1";
+    placement.zoneId = "stair-l1";
+    placement.targetAgentCount = 1;
+    placement.initialVelocity = {.x = -0.8, .y = 1.2};
+    placement.area.outline = {{.x = 3.4, .y = 0.6}};
+
+    safecrowd::domain::ScenarioDraft scenario;
+    scenario.population.initialPlacements.push_back(placement);
+    scenario.execution.timeLimitSeconds = 6.0;
+
+    safecrowd::domain::ScenarioSimulationRunner runner(blockedUShapedStairTransitionLayout(), scenario);
+    for (int i = 0; i < 40 && !runner.complete(); ++i) {
+        runner.step(0.1);
+    }
+
+    SC_EXPECT_EQ(runner.frame().agents.size(), std::size_t{1});
+    SC_EXPECT_EQ(runner.frame().agents.front().floorId, std::string{"L1"});
+    SC_EXPECT_TRUE(runner.frame().agents.front().position.x > 2.0);
+}
+
+SC_TEST(ScenarioSimulationRunnerLandsOnOppositeUShapedStairLaneAfterFloorTransition) {
+    safecrowd::domain::InitialPlacement2D placement;
+    placement.id = "agent-1";
+    placement.floorId = "L1";
+    placement.zoneId = "stair-l1";
+    placement.targetAgentCount = 1;
+    placement.initialVelocity = {.x = -0.8, .y = 1.2};
+    placement.area.outline = {{.x = 3.4, .y = 0.6}};
+
+    safecrowd::domain::ScenarioDraft scenario;
+    scenario.population.initialPlacements.push_back(placement);
+    scenario.execution.timeLimitSeconds = 10.0;
+
+    safecrowd::domain::ScenarioSimulationRunner runner(uShapedStairTransitionLayout(), scenario);
+    for (int i = 0; i < 80 && !runner.complete(); ++i) {
+        runner.step(0.1);
+        if (!runner.frame().agents.empty() && runner.frame().agents.front().floorId == "L2") {
+            break;
+        }
+    }
+
+    SC_EXPECT_EQ(runner.frame().agents.size(), std::size_t{1});
+    SC_EXPECT_EQ(runner.frame().agents.front().floorId, std::string{"L2"});
+    SC_EXPECT_TRUE(runner.frame().agents.front().position.x < 2.0);
+}
+
+SC_TEST(ScenarioSimulationRunnerKeepsUShapedStairVerticalOpeningClearOfEntryWalls) {
+    safecrowd::domain::InitialPlacement2D placement;
+    placement.id = "agent-1";
+    placement.floorId = "L1";
+    placement.zoneId = "stair-l1";
+    placement.targetAgentCount = 1;
+    placement.initialVelocity = {.x = 1.0, .y = 1.0};
+    placement.area.outline = {{.x = 1.0, .y = 1.0}};
+
+    safecrowd::domain::ScenarioDraft scenario;
+    scenario.population.initialPlacements.push_back(placement);
+    scenario.execution.timeLimitSeconds = 10.0;
+
+    safecrowd::domain::ScenarioSimulationRunner runner(westEntryUShapedStairTransitionLayout(), scenario);
+    for (int i = 0; i < 80 && !runner.complete(); ++i) {
+        runner.step(0.1);
+        if (!runner.frame().agents.empty() && runner.frame().agents.front().floorId == "L2") {
+            break;
+        }
+    }
+
+    SC_EXPECT_EQ(runner.frame().agents.size(), std::size_t{1});
+    SC_EXPECT_EQ(runner.frame().agents.front().floorId, std::string{"L2"});
+    SC_EXPECT_TRUE(runner.frame().agents.front().position.y > 2.0);
+}
+
+SC_TEST(ScenarioSimulationRunnerMovesFollowingAgentsThroughDescendingUShapedStair) {
+    safecrowd::domain::InitialPlacement2D placement;
+    placement.id = "descending-group";
+    placement.floorId = "L2";
+    placement.zoneId = "stair-l2";
+    placement.initialVelocity = {.x = 1.0, .y = -1.0};
+    placement.explicitPositions = {
+        {.x = 0.8, .y = 3.5},
+        {.x = 1.4, .y = 3.5},
+        {.x = 2.0, .y = 3.5},
+        {.x = 2.6, .y = 3.5},
+        {.x = 0.8, .y = 3.0},
+        {.x = 1.4, .y = 3.0},
+        {.x = 2.0, .y = 3.0},
+        {.x = 2.6, .y = 3.0},
+        {.x = 0.8, .y = 2.5},
+        {.x = 1.4, .y = 2.5},
+    };
+
+    safecrowd::domain::ScenarioDraft scenario;
+    scenario.population.initialPlacements.push_back(placement);
+    scenario.execution.timeLimitSeconds = 16.0;
+
+    const auto layout = descendingWestEntryUShapedStairTransitionLayout();
+    safecrowd::domain::ScenarioSimulationRunner runner(layout, scenario);
+    for (int i = 0; i < 120 && !runner.complete(); ++i) {
+        runner.step(0.1);
+    }
+
+    std::size_t agentsStillOnUpperFloor = 0;
+    std::size_t stalledAgents = 0;
+    for (const auto& agent : runner.frame().agents) {
+        if (agent.floorId == "L2") {
+            ++agentsStillOnUpperFloor;
+        }
+        if (agent.stalled) {
+            ++stalledAgents;
+        }
+        SC_EXPECT_TRUE(agentInsideAnyZoneOnFrameFloor(layout, agent));
+    }
+
+    SC_EXPECT_EQ(agentsStillOnUpperFloor, std::size_t{0});
+    SC_EXPECT_EQ(stalledAgents, std::size_t{0});
 }
 
 SC_TEST(ScenarioSimulationRunnerBlocksMovementAcrossBarrierSegments) {


### PR DESCRIPTION
## Summary

- Enforce agent-radius wall clearance for constrained movement and overlap relaxation in ordinary door/corridor movement.
- Keep vertical stair transition movement on crossing-based constraints so U-shaped stair floor changes do not stall.
- Add regression coverage for crowded narrow doors and descending U-shaped stair followers.

## Related Issue

- Closes #174

## Area

- [ ] Engine
- [x] Domain
- [x] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [ ] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug`
- [x] `ctest --preset test-debug`
- [x] `cmake --build --preset build-no-app-debug`
- [x] `ctest --preset test-no-app-debug --output-on-failure`

## Risks / Follow-up

- Local verification passed after rebasing on current `origin/main`.