### PR TITLE
[Domain] Replace heuristic crowd avoidance with Social Force model

### DIFF
--- a/src/domain/AgentComponents.h
+++ b/src/domain/AgentComponents.h
@@ -24,11 +24,6 @@ struct Velocity {
     Point2D value;
 };
 
-struct AvoidanceState {
-    int preferredSide{0};
-    double sideLockSeconds{0.0};
-};
-
 struct EvacuationRoute {
     std::vector<Point2D> waypoints{};
     std::vector<LineSegment2D> waypointPassages{};

--- a/src/domain/ScenarioSimulationInternal.cpp
+++ b/src/domain/ScenarioSimulationInternal.cpp
@@ -723,7 +723,7 @@ double speedOf(const Point2D& velocity) {
 }
 
 std::vector<engine::Entity> simulationEntities(engine::WorldQuery& query) {
-    return query.view<Position, Agent, Velocity, AvoidanceState, EvacuationRoute, EvacuationStatus>();
+    return query.view<Position, Agent, Velocity, EvacuationRoute, EvacuationStatus>();
 }
 
 AgentSpatialIndex buildAgentSpatialIndex(
@@ -793,42 +793,39 @@ Point2D deterministicFallbackDirection(engine::Entity entity) {
     return normalizedOr({.x = std::cos(seed * 1.37), .y = std::sin(seed * 1.37)}, {.x = 1.0, .y = 0.0});
 }
 
-int deterministicPairSide(engine::Entity first, engine::Entity second) {
-    const auto minIndex = std::min(first.index, second.index);
-    const auto maxIndex = std::max(first.index, second.index);
-    return ((minIndex + maxIndex) % 2U) == 0U ? -1 : 1;
+// Helbing & Molnár (1995) Eq. (3): driving force pushes the agent toward its
+// desired velocity over the relaxation time tau.
+Point2D socialForceDriving(const Point2D& desiredVelocity, const Point2D& currentVelocity) {
+    const auto delta = desiredVelocity - currentVelocity;
+    return delta * (1.0 / kSocialForceRelaxationTime);
 }
 
-Point2D forwardPreservingAgentAvoidanceVelocity(
+// Anisotropic agent-agent repulsion. Helbing & Molnár (1995) Eq. (4) gives the
+// isotropic exponential form; the angular weight w(phi) follows Helbing, Farkas
+// & Vicsek (2000) Eq. (3) so that obstacles in front are felt more strongly than
+// those behind.
+Point2D socialForceAgentRepulsion(
     engine::WorldQuery& query,
     engine::Entity entity,
     const std::vector<engine::Entity>& candidates,
-    const Point2D& desiredVelocity,
-    double deltaSeconds,
-    double& speedScale) {
+    const Point2D& currentVelocity) {
     const auto& position = query.get<Position>(entity);
     const auto& agent = query.get<Agent>(entity);
     const auto& route = query.get<EvacuationRoute>(entity);
-    auto& avoidance = query.get<AvoidanceState>(entity);
-    const auto desiredSpeed = lengthOf(desiredVelocity);
-    if (desiredSpeed <= 1e-9) {
-        speedScale = 1.0;
-        return {};
-    }
 
-    if (avoidance.sideLockSeconds > 0.0) {
-        avoidance.sideLockSeconds = std::max(0.0, avoidance.sideLockSeconds - std::max(0.0, deltaSeconds));
-        if (avoidance.sideLockSeconds <= 0.0) {
-            avoidance.preferredSide = 0;
+    Point2D heading{};
+    const auto currentSpeed = lengthOf(currentVelocity);
+    if (currentSpeed > 1e-6) {
+        heading = currentVelocity * (1.0 / currentSpeed);
+    } else if (route.nextWaypointIndex < route.waypoints.size()) {
+        const auto target = routeWaypointTarget(route, position.value);
+        const auto distance = distanceBetween(position.value, target);
+        if (distance > 1e-6) {
+            heading = (target - position.value) * (1.0 / distance);
         }
     }
 
-    const auto forward = desiredVelocity * (1.0 / desiredSpeed);
-    const auto lateral = perpendicularLeft(forward);
-    Point2D lateralCorrection{};
-    speedScale = 1.0;
-    bool lockedSideThisFrame = false;
-
+    Point2D acceleration{};
     for (const auto other : candidates) {
         if (other == entity) {
             continue;
@@ -837,117 +834,96 @@ Point2D forwardPreservingAgentAvoidanceVelocity(
         if (otherStatus.evacuated) {
             continue;
         }
-        const auto& otherPosition = query.get<Position>(other);
-        const auto& otherAgent = query.get<Agent>(other);
         const auto& otherRoute = query.get<EvacuationRoute>(other);
         if (agentCollisionFloorId(otherRoute) != agentCollisionFloorId(route)) {
             continue;
         }
-        const auto offsetToOther = otherPosition.value - position.value;
-        const auto distance = lengthOf(offsetToOther);
-        const auto desiredDistance = static_cast<double>(agent.radius + otherAgent.radius) + kPersonalSpaceBuffer;
-        const auto forwardDistance = dot(offsetToOther, forward);
-        const auto lateralDistance = dot(offsetToOther, lateral);
 
-        bool headOn = false;
-        if (route.nextWaypointIndex < route.waypoints.size() && distance <= kHeadOnLookAheadDistance) {
-            if (otherRoute.currentFloorId == route.currentFloorId
-                && otherRoute.nextWaypointIndex < otherRoute.waypoints.size()) {
-                const auto otherTarget = routeWaypointTarget(otherRoute, otherPosition.value);
-                const auto otherTargetDistance = distanceBetween(otherPosition.value, otherTarget);
-                if (otherTargetDistance > kArrivalEpsilon) {
-                    const auto otherForward = (otherTarget - otherPosition.value) * (1.0 / otherTargetDistance);
-                    const auto otherForwardDistance = dot(position.value - otherPosition.value, otherForward);
-                    headOn = dot(forward, otherForward) <= kHeadOnDirectionDotThreshold
-                        && forwardDistance > 0.0
-                        && otherForwardDistance > 0.0;
-                }
+        const auto& otherPosition = query.get<Position>(other);
+        const auto& otherAgent = query.get<Agent>(other);
+        const auto offsetFromOther = position.value - otherPosition.value;
+        const auto distance = lengthOf(offsetFromOther);
+        if (distance > kSocialForceAgentInteractionRadius) {
+            continue;
+        }
+        const auto contactDistance = static_cast<double>(agent.radius + otherAgent.radius);
+        const auto normal = distance > 1e-6
+            ? offsetFromOther * (1.0 / distance)
+            : deterministicFallbackDirection(entity);
+        const auto magnitude = kSocialForceAgentStrength
+            * std::exp((contactDistance - distance) / kSocialForceAgentRange);
+
+        // Anisotropy: agents perceive what is in front more strongly than what is behind.
+        // phi is the angle between the agent's heading and the direction toward the other.
+        double anisotropy = 1.0;
+        if (lengthOf(heading) > 1e-6) {
+            const auto towardOther = normal * -1.0;
+            const auto cosPhi = dot(heading, towardOther);
+            anisotropy = kSocialForceAgentAnisotropy
+                + (1.0 - kSocialForceAgentAnisotropy) * 0.5 * (1.0 + cosPhi);
+        }
+
+        auto contribution = normal * (magnitude * anisotropy);
+
+        // Symmetry breaker for nearly perfect head-on alignment. Two agents on
+        // a shared axis would otherwise receive purely longitudinal repulsion
+        // and stall against each other. Each agent biases to its own left, so a
+        // mirror-image pair ends up sliding past on opposite world sides — the
+        // convention is global and stays deterministic across replays.
+        if (lengthOf(heading) > 1e-6 && distance < contactDistance + kSocialForceAgentRange) {
+            const auto towardOther = normal * -1.0;
+            const auto alignment = dot(heading, towardOther);
+            if (alignment >= kSocialForceHeadOnAlignmentThreshold) {
+                const auto tangent = perpendicularLeft(heading);
+                contribution = contribution + (tangent * (magnitude * kSocialForceHeadOnTangentBias));
             }
         }
 
-        if (distance >= desiredDistance && !headOn) {
-            continue;
-        }
-
-        const auto pressure = headOn
-            ? std::clamp((kHeadOnLookAheadDistance - distance) / kHeadOnLookAheadDistance, 0.15, 1.0)
-            : (desiredDistance - distance) / desiredDistance;
-
-        if (forwardDistance > -desiredDistance && forwardDistance < kHeadOnLookAheadDistance) {
-            speedScale = std::min(speedScale, std::max(0.2, 1.0 - (pressure * kAvoidanceSlowdownStrength)));
-        }
-
-        double side = 0.0;
-        if (avoidance.preferredSide != 0 && avoidance.sideLockSeconds > 0.0) {
-            side = static_cast<double>(avoidance.preferredSide);
-        } else if (headOn) {
-            side = static_cast<double>(deterministicPairSide(entity, other));
-        } else if (std::fabs(lateralDistance) > 1e-6) {
-            side = lateralDistance < 0.0 ? 1.0 : -1.0;
-        } else {
-            side = entity.index < other.index ? -1.0 : 1.0;
-        }
-
-        if (headOn) {
-            avoidance.preferredSide = side < 0.0 ? -1 : 1;
-            avoidance.sideLockSeconds = kAvoidanceSideLockSeconds;
-            lockedSideThisFrame = true;
-            const bool shouldYield = entity.index > other.index;
-            speedScale = std::min(
-                speedScale,
-                shouldYield
-                    ? std::max(0.18, 1.0 - (pressure * 1.05))
-                    : std::max(0.55, 1.0 - (pressure * 0.35)));
-            const auto sideStepMultiplier = shouldYield ? 1.35 : 0.85;
-            lateralCorrection = lateralCorrection + (lateral * (
-                side * pressure * sideStepMultiplier * kAvoidanceLateralStrength * static_cast<double>(agent.maxSpeed)));
-        } else {
-            lateralCorrection = lateralCorrection + (lateral * (
-                side * pressure * kAvoidanceLateralStrength * static_cast<double>(agent.maxSpeed)));
-        }
+        acceleration = acceleration + contribution;
     }
 
-    if (!lockedSideThisFrame && avoidance.sideLockSeconds <= 0.0) {
-        avoidance.preferredSide = 0;
-    }
-
-    return clampedToLength(lateralCorrection, static_cast<double>(agent.maxSpeed) * 0.45);
+    return acceleration;
 }
 
-Point2D barrierSeparationVelocity(const FacilityLayout2D& layout, const Position& position, const Agent& agent) {
-    Point2D correction{};
-    const auto keepoutDistance = static_cast<double>(agent.radius) + kBarrierAvoidanceBuffer;
+// Wall repulsion follows the same exponential form as the agent-agent term.
+// Helbing & Molnár (1995) Eq. (5).
+Point2D socialForceWallRepulsion(
+    const FacilityLayout2D& layout,
+    const Position& position,
+    const Agent& agent) {
+    Point2D acceleration{};
+    const auto agentRadius = static_cast<double>(agent.radius);
+
+    auto accumulate = [&](const Point2D& closest, bool insideClosedRegion) {
+        const auto delta = position.value - closest;
+        const auto distance = lengthOf(delta);
+        if (!insideClosedRegion && distance > kSocialForceWallInteractionRadius) {
+            return;
+        }
+        const auto normal = distance > 1e-6
+            ? delta * (1.0 / distance)
+            : Point2D{.x = 0.0, .y = 1.0};
+        const auto effectiveDistance = insideClosedRegion ? -distance : distance;
+        const auto magnitude = kSocialForceWallStrength
+            * std::exp((agentRadius - effectiveDistance) / kSocialForceWallRange);
+        acceleration = acceleration + (normal * magnitude);
+    };
 
     for (const auto& barrier : layout.barriers) {
         if (!barrier.blocksMovement || barrier.geometry.vertices.size() < 2) {
             continue;
         }
-
         const auto& vertices = barrier.geometry.vertices;
         for (std::size_t index = 0; index + 1 < vertices.size(); ++index) {
-            const auto closest = closestPointOnSegment(position.value, vertices[index], vertices[index + 1]);
-            const auto delta = position.value - closest;
-            const auto distance = lengthOf(delta);
-            if (distance < keepoutDistance) {
-                const auto direction = normalizedOr(delta, deterministicFallbackDirection({static_cast<engine::EntityIndex>(index + 1), 0}));
-                const auto pressure = (keepoutDistance - distance) / keepoutDistance;
-                correction = correction + (direction * (pressure * kBarrierAvoidanceStrength * static_cast<double>(agent.maxSpeed)));
-            }
+            accumulate(closestPointOnSegment(position.value, vertices[index], vertices[index + 1]), false);
         }
-
         if (barrier.geometry.closed) {
             const auto closest = closestPointOnSegment(position.value, vertices.back(), vertices.front());
-            const auto delta = position.value - closest;
-            const auto distance = lengthOf(delta);
-            if (distance < keepoutDistance || pointInRing(vertices, position.value)) {
-                const auto direction = normalizedOr(delta, {.x = 0.0, .y = 1.0});
-                const auto pressure = distance < keepoutDistance ? (keepoutDistance - distance) / keepoutDistance : 1.0;
-                correction = correction + (direction * (pressure * kBarrierAvoidanceStrength * static_cast<double>(agent.maxSpeed)));
-            }
+            accumulate(closest, pointInRing(vertices, position.value));
         }
     }
 
-    return correction;
+    return acceleration;
 }
 
 bool movementCrossesBarrier(const FacilityLayout2D& layout, const Point2D& from, const Point2D& to) {

--- a/src/domain/ScenarioSimulationInternal.h
+++ b/src/domain/ScenarioSimulationInternal.h
@@ -24,18 +24,37 @@ inline constexpr double kDefaultAgentRadius = 0.25;
 inline constexpr double kDefaultAgentSpeed = 1.5;
 inline constexpr double kStairSpeedMultiplier = 0.55;
 inline constexpr double kArrivalEpsilon = 0.05;
-inline constexpr double kPersonalSpaceBuffer = 0.08;
-inline constexpr double kAvoidanceLateralStrength = 0.65;
-inline constexpr double kAvoidanceSlowdownStrength = 0.7;
-inline constexpr double kAvoidanceSideLockSeconds = 0.55;
-inline constexpr double kHeadOnLookAheadDistance = 1.2;
-inline constexpr double kHeadOnDirectionDotThreshold = -0.6;
-inline constexpr double kBarrierAvoidanceBuffer = 0.18;
-inline constexpr double kBarrierAvoidanceStrength = 1.1;
-inline constexpr int kOverlapRelaxationIterations = 4;
 inline constexpr double kGeometryEpsilon = 1e-9;
 inline constexpr double kPathClearance = 0.08;
-inline constexpr double kCandidateClearance = kDefaultAgentRadius + kBarrierAvoidanceBuffer;
+inline constexpr double kPathPlanningWallBuffer = 0.18;
+inline constexpr double kCandidateClearance = kDefaultAgentRadius + kPathPlanningWallBuffer;
+
+// Social Force model parameters.
+// Reference: Helbing & Molnár, "Social force model for pedestrian dynamics",
+//            Physical Review E 51 (1995); anisotropy from Helbing, Farkas & Vicsek,
+//            "Simulating dynamical features of escape panic", Nature 407 (2000).
+//
+// Driving term: a_drv = (v_desired - v_current) / tau
+inline constexpr double kSocialForceRelaxationTime = 0.5;            // tau, s
+// Agent-agent repulsion: f_ij = A * exp((r_ij - d_ij) / B) * n_ij * w(phi)
+inline constexpr double kSocialForceAgentStrength = 2.1;             // A_i / m_i, m/s^2
+inline constexpr double kSocialForceAgentRange = 0.30;               // B_i, m
+inline constexpr double kSocialForceAgentAnisotropy = 0.5;           // lambda; w(phi) = lambda + (1-lambda)*(1+cos(phi))/2
+inline constexpr double kSocialForceAgentInteractionRadius = 2.0;    // m, neighbor cutoff
+// Wall repulsion: f_iW = A_W * exp((r_i - d_iW) / B_W) * n_iW
+inline constexpr double kSocialForceWallStrength = 5.0;              // A_W / m_i, m/s^2
+inline constexpr double kSocialForceWallRange = 0.20;                // B_W, m
+inline constexpr double kSocialForceWallInteractionRadius = 1.0;     // m, wall cutoff
+// Body acceleration limit (typical comfortable human: 3-5 m/s^2)
+inline constexpr double kSocialForceMaxAcceleration = 5.0;           // m/s^2
+// Tangential nudge that breaks symmetry on a perfectly head-on encounter.
+// Without it two mirror-image agents along a shared axis would receive a purely
+// longitudinal repulsion and stall against each other. Each agent steps to its
+// own left so that a mirror-image pair separates onto opposite world sides.
+// The threshold keeps the bias narrowly scoped to nearly co-linear pairs so it
+// does not perturb generic oblique encounters handled by the base repulsion.
+inline constexpr double kSocialForceHeadOnTangentBias = 0.4;
+inline constexpr double kSocialForceHeadOnAlignmentThreshold = 0.985;
 inline constexpr double kWaypointCrossingEpsilon = 0.08;
 inline constexpr double kWaypointProgressEpsilon = 0.02;
 inline constexpr double kWaypointBypassLongitudinalTolerance = 0.5;
@@ -150,14 +169,16 @@ std::vector<engine::Entity> nearbyAgents(
     const std::string& floorId,
     double radius);
 Point2D deterministicFallbackDirection(engine::Entity entity);
-Point2D forwardPreservingAgentAvoidanceVelocity(
+Point2D socialForceDriving(const Point2D& desiredVelocity, const Point2D& currentVelocity);
+Point2D socialForceAgentRepulsion(
     engine::WorldQuery& query,
     engine::Entity entity,
     const std::vector<engine::Entity>& candidates,
-    const Point2D& desiredVelocity,
-    double deltaSeconds,
-    double& speedScale);
-Point2D barrierSeparationVelocity(const FacilityLayout2D& layout, const Position& position, const Agent& agent);
+    const Point2D& currentVelocity);
+Point2D socialForceWallRepulsion(
+    const FacilityLayout2D& layout,
+    const Position& position,
+    const Agent& agent);
 bool movementCrossesBarrier(const FacilityLayout2D& layout, const Point2D& from, const Point2D& to);
 bool lineOfSightClear(const FacilityLayout2D& layout, const Point2D& from, const Point2D& to, double clearance);
 std::vector<Point2D> buildPath(const FacilityLayout2D& layout, const Point2D& start, const Point2D& goal, double clearance);

--- a/src/domain/ScenarioSimulationMotionSystem.cpp
+++ b/src/domain/ScenarioSimulationMotionSystem.cpp
@@ -103,10 +103,6 @@ public:
             const auto routeDirection = (target - position.value) * (1.0 / distance);
             const auto maxSpeed = effectiveMaxSpeed(layoutCache, agent, route, position.value);
             const auto desiredVelocity = routeDirection * maxSpeed;
-            double speedScale = 1.0;
-            const auto neighborRadius = std::max(
-                static_cast<double>(agent.radius) + kDefaultAgentRadius + kPersonalSpaceBuffer,
-                kHeadOnLookAheadDistance);
             const auto collisionFloorId = agentCollisionFloorId(route);
             const auto neighborCandidates = resources.contains<ScenarioAgentSpatialIndexResource>()
                 ? scenarioNearbyAgents(
@@ -114,33 +110,28 @@ public:
                     resources.get<ScenarioAgentSpatialIndexResource>(),
                     position.value,
                     collisionFloorId,
-                    neighborRadius)
-                : nearbyAgents(query, localNeighborIndex, position.value, collisionFloorId, neighborRadius);
-            const auto avoidanceVelocity =
-                forwardPreservingAgentAvoidanceVelocity(
+                    kSocialForceAgentInteractionRadius)
+                : nearbyAgents(
                     query,
-                    entity,
-                    neighborCandidates,
-                    desiredVelocity,
-                    clampedDelta,
-                    speedScale);
-            const auto barrierVelocity = barrierSeparationVelocity(floorLayout, position, agent);
-            auto finalVelocity = (desiredVelocity * speedScale) + avoidanceVelocity + barrierVelocity;
-            const auto lateral = perpendicularLeft(routeDirection);
-            if (dot(finalVelocity, routeDirection) < 0.0) {
-                finalVelocity = (routeDirection * (static_cast<double>(agent.maxSpeed) * 0.15))
-                    + (lateral * dot(finalVelocity, lateral));
-            }
-            const auto forwardComponent = dot(finalVelocity, routeDirection);
-            const auto lateralComponent = dot(finalVelocity, lateral);
-            const auto maxLateralComponent = maxSpeed * 0.55;
-            if (std::fabs(lateralComponent) > maxLateralComponent) {
-                finalVelocity = (routeDirection * std::max(0.0, forwardComponent))
-                    + (lateral * std::clamp(lateralComponent, -maxLateralComponent, maxLateralComponent));
-            }
+                    localNeighborIndex,
+                    position.value,
+                    collisionFloorId,
+                    kSocialForceAgentInteractionRadius);
+
+            // Helbing-Molnár social force model: integrate driving + repulsion
+            // accelerations with semi-implicit Euler. Velocity carried over from
+            // the previous frame supplies the v_current term.
+            const auto driving = socialForceDriving(desiredVelocity, velocity.value);
+            const auto agentRepulsion =
+                socialForceAgentRepulsion(query, entity, neighborCandidates, velocity.value);
+            const auto wallRepulsion = socialForceWallRepulsion(floorLayout, position, agent);
+            auto acceleration = driving + agentRepulsion + wallRepulsion;
+            acceleration = clampedToLength(acceleration, kSocialForceMaxAcceleration);
+            const auto integratedVelocity =
+                clampedToLength(velocity.value + (acceleration * clampedDelta), maxSpeed);
             plans.push_back({
                 .entity = entity,
-                .velocity = clampedToLength(finalVelocity, maxSpeed),
+                .velocity = integratedVelocity,
             });
         }
 
@@ -168,7 +159,6 @@ public:
             updateDisplayFloor(route, nextPosition);
         }
 
-        resolveAgentOverlaps(query, entities, layoutCache);
         advanceRoutesForCurrentZones(query, entities, layoutCache);
         advanceRoutesForWaypointProgress(query, clampedDelta, entities, layoutCache);
         advanceClock(query, clock, entities, clampedDelta);
@@ -690,75 +680,6 @@ private:
         }
     }
 
-    void resolveAgentOverlaps(
-        engine::WorldQuery& query,
-        const std::vector<engine::Entity>& entities,
-        const ScenarioLayoutCacheResource& layoutCache) const {
-        for (int iteration = 0; iteration < kOverlapRelaxationIterations; ++iteration) {
-            const auto spatialIndex = buildAgentSpatialIndex(query, entities, 1.0);
-            std::unordered_set<unsigned long long> checkedPairs;
-            checkedPairs.reserve(entities.size() * 4);
-            for (const auto first : entities) {
-                auto& firstStatus = query.get<EvacuationStatus>(first);
-                if (firstStatus.evacuated) {
-                    continue;
-                }
-
-                auto& firstPosition = query.get<Position>(first);
-                const auto& firstAgent = query.get<Agent>(first);
-                const auto& firstRoute = query.get<EvacuationRoute>(first);
-                const auto firstCollisionFloorId = agentCollisionFloorId(firstRoute);
-                const auto candidates = nearbyAgents(
-                    query,
-                    spatialIndex,
-                    firstPosition.value,
-                    firstCollisionFloorId,
-                    static_cast<double>(firstAgent.radius) + kDefaultAgentRadius);
-                for (const auto second : candidates) {
-                    if (first == second) {
-                        continue;
-                    }
-                    const auto minIndex = std::min(first.index, second.index);
-                    const auto maxIndex = std::max(first.index, second.index);
-                    const auto pairKey = (static_cast<unsigned long long>(minIndex) << 32)
-                        ^ static_cast<unsigned int>(maxIndex);
-                    if (!checkedPairs.insert(pairKey).second) {
-                        continue;
-                    }
-
-                    auto& secondStatus = query.get<EvacuationStatus>(second);
-                    if (firstStatus.evacuated || secondStatus.evacuated) {
-                        continue;
-                    }
-
-                    auto& secondPosition = query.get<Position>(second);
-                    const auto& secondAgent = query.get<Agent>(second);
-                    const auto delta = firstPosition.value - secondPosition.value;
-                    const auto distance = lengthOf(delta);
-                    const auto minimumDistance = static_cast<double>(firstAgent.radius + secondAgent.radius);
-                    if (distance >= minimumDistance) {
-                        continue;
-                    }
-
-                    const auto direction = normalizedOr(delta, deterministicFallbackDirection(first));
-                    const auto push = std::min(0.08, (minimumDistance - distance) * 0.35);
-                    const auto& secondRoute = query.get<EvacuationRoute>(second);
-                    if (agentCollisionFloorId(secondRoute) != firstCollisionFloorId) {
-                        continue;
-                    }
-                    firstPosition.value = constrainedMove(
-                        cachedLayoutForFloor(layoutCache, firstRoute.currentFloorId),
-                        firstPosition.value,
-                        firstPosition.value + (direction * push));
-                    secondPosition.value = constrainedMove(
-                        cachedLayoutForFloor(layoutCache, secondRoute.currentFloorId),
-                        secondPosition.value,
-                        secondPosition.value - (direction * push));
-                }
-            }
-        }
-    }
-
     void advanceClock(
         engine::WorldQuery& query,
         ScenarioSimulationClockResource& clock,
@@ -807,7 +728,7 @@ private:
 
     std::optional<ScenarioLayoutCacheResource> layoutCache_{};
 };
-
+
 
 
 }  // namespace

--- a/src/domain/ScenarioSimulationSystems.cpp
+++ b/src/domain/ScenarioSimulationSystems.cpp
@@ -276,7 +276,6 @@ void ScenarioAgentSpawnSystem::configure(engine::EngineWorld& world) {
             seed.position,
             seed.agent,
             seed.velocity,
-            seed.avoidance,
             seed.route,
             seed.status);
     }

--- a/src/domain/ScenarioSimulationSystems.h
+++ b/src/domain/ScenarioSimulationSystems.h
@@ -74,7 +74,6 @@ struct ScenarioAgentSeed {
     Position position{};
     Agent agent{};
     Velocity velocity{};
-    AvoidanceState avoidance{};
     EvacuationRoute route{};
     EvacuationStatus status{};
 };

--- a/tests/ScenarioSimulationRunnerTests.cpp
+++ b/tests/ScenarioSimulationRunnerTests.cpp
@@ -348,7 +348,10 @@ SC_TEST(ScenarioSimulationRunnerSeparatesOverlappingAgents) {
     scenario.population.initialPlacements.push_back(second);
 
     safecrowd::domain::ScenarioSimulationRunner runner(safecrowd::domain::DemoLayouts::demoFacility(), scenario);
-    runner.step(0.1);
+    // Social-force repulsion separates coincident agents over physical time
+    // rather than instantly via a relaxation pass; step long enough for the
+    // contact-range exponential force to push them apart by a body diameter.
+    runner.step(0.6);
 
     SC_EXPECT_EQ(runner.frame().agents.size(), static_cast<std::size_t>(2));
     const auto dx = runner.frame().agents[0].position.x - runner.frame().agents[1].position.x;
@@ -535,7 +538,10 @@ SC_TEST(ScenarioSimulationRunnerDoesNotSlowAgentsOnDifferentFloorsAtSameCoordina
     scenario.execution.timeLimitSeconds = 5.0;
 
     safecrowd::domain::ScenarioSimulationRunner runner(overlappingTwoFloorExitLayout(), scenario);
-    runner.step(0.1);
+    // Social-force driving accelerates over the relaxation time tau (~0.5 s).
+    // Step long enough for both agents to settle above 1 m/s, but short enough
+    // that neither reaches its exit zone (which would zero the velocity).
+    runner.step(0.8);
 
     const auto& agents = runner.frame().agents;
     SC_EXPECT_EQ(agents.size(), std::size_t{2});

--- a/tests/ScenarioSimulationSystemsTests.cpp
+++ b/tests/ScenarioSimulationSystemsTests.cpp
@@ -1,5 +1,6 @@
 #include "TestSupport.h"
 
+#include <cmath>
 #include <memory>
 #include <string>
 
@@ -384,7 +385,6 @@ SC_TEST(ScenarioSimulationMotionSystem_SkipsIntermediateWaypointWhenCrowdPushesA
     const auto entities = runtime.world().query().view<
         safecrowd::domain::Position,
         safecrowd::domain::Velocity,
-        safecrowd::domain::AvoidanceState,
         safecrowd::domain::EvacuationRoute>();
     SC_EXPECT_EQ(entities.size(), std::size_t{1});
     const auto entity = entities.front();
@@ -395,7 +395,7 @@ SC_TEST(ScenarioSimulationMotionSystem_SkipsIntermediateWaypointWhenCrowdPushesA
     SC_EXPECT_TRUE(velocity.value.x > 0.0);
 }
 
-SC_TEST(ScenarioSimulationMotionSystem_UsesStableHeadOnAvoidance) {
+SC_TEST(ScenarioSimulationMotionSystem_HeadOnAgentsSeparateLaterally) {
     std::vector<safecrowd::domain::ScenarioAgentSeed> seeds;
     seeds.push_back({
         .position = {.value = {.x = -0.4, .y = 0.0}},
@@ -449,10 +449,16 @@ SC_TEST(ScenarioSimulationMotionSystem_UsesStableHeadOnAvoidance) {
     runtime.world().resources().set(safecrowd::domain::ScenarioSimulationStepResource{.deltaSeconds = 0.2});
     runtime.stepFrame(0.0);
 
+    // Step the simulation a few times so the social-force tangent bias has
+    // room to translate into measurable lateral velocity.
+    for (int frame = 0; frame < 10; ++frame) {
+        runtime.world().resources().set(safecrowd::domain::ScenarioSimulationStepResource{.deltaSeconds = 0.2});
+        runtime.stepFrame(0.0);
+    }
+
     const auto entities = runtime.world().query().view<
         safecrowd::domain::Position,
         safecrowd::domain::Velocity,
-        safecrowd::domain::AvoidanceState,
         safecrowd::domain::EvacuationRoute>();
     SC_EXPECT_EQ(entities.size(), std::size_t{2});
 
@@ -460,14 +466,18 @@ SC_TEST(ScenarioSimulationMotionSystem_UsesStableHeadOnAvoidance) {
     const auto second = entities[1];
     const auto& firstVelocity = runtime.world().query().get<safecrowd::domain::Velocity>(first);
     const auto& secondVelocity = runtime.world().query().get<safecrowd::domain::Velocity>(second);
-    const auto& firstAvoidance = runtime.world().query().get<safecrowd::domain::AvoidanceState>(first);
-    const auto& secondAvoidance = runtime.world().query().get<safecrowd::domain::AvoidanceState>(second);
+    const auto& firstPosition = runtime.world().query().get<safecrowd::domain::Position>(first);
+    const auto& secondPosition = runtime.world().query().get<safecrowd::domain::Position>(second);
 
+    // Both agents must keep heading toward their goals (positive/negative x).
     SC_EXPECT_TRUE(firstVelocity.value.x > 0.0);
     SC_EXPECT_TRUE(secondVelocity.value.x < 0.0);
+    // Symmetry-breaker should drive them onto opposite sides of the original axis.
     SC_EXPECT_TRUE(firstVelocity.value.y * secondVelocity.value.y < 0.0);
-    SC_EXPECT_TRUE(firstAvoidance.preferredSide != 0);
-    SC_EXPECT_EQ(firstAvoidance.preferredSide, secondAvoidance.preferredSide);
+    // No body overlap: distance must stay above the sum of radii.
+    const auto dx = firstPosition.value.x - secondPosition.value.x;
+    const auto dy = firstPosition.value.y - secondPosition.value.y;
+    SC_EXPECT_TRUE(std::sqrt(dx * dx + dy * dy) >= 0.5);
 }
 
 SC_TEST(ScenarioControlSystem_BlocksConnectionsUsingScenarioClock) {


### PR DESCRIPTION
## Summary

- 자작 휴리스틱 회피(`forwardPreservingAgentAvoidanceVelocity` / `barrierSeparationVelocity` / `resolveAgentOverlaps`)를 Helbing & Molnár (1995) "Social force model for pedestrian dynamics"의 표준 모델로 교체
- 출처 주석을 단 파라미터(`τ`, `A_i`, `B_i`, `λ` anisotropy, `A_W`, `B_W`, `a_max`)와 가속도 기반 semi-implicit Euler 적분으로 재구성
- 휴리스틱 전용 상태였던 `AvoidanceState` 컴포넌트와 사후 overlap relaxation 패스 완전 제거 — 회피가 사전적으로 동작하므로 사후 보정 불필요

## Related Issue

- Closes #176

## Area

- [ ] Engine
- [x] Domain
- [ ] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [x] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug`
- [x] `ctest --preset test-debug`
- [x] `cmake --preset windows-debug-no-app` / `cmake --build --preset build-no-app-debug` / `ctest --preset test-no-app-debug` (CI 경로)

## Risks / Follow-up

- 두 head-on 에이전트가 완벽히 대칭이면 순수 SF에서 멈춰버리므로 결정론적 좌측 편향(각자 자신의 left tangent)을 추가했다. `kSocialForceHeadOnAlignmentThreshold = 0.985`로 정렬도가 매우 높을 때만 적용되어 일반적인 사선 회피에는 영향이 없다.
- 이전 회귀 테스트 일부는 "한 프레임에 즉시 maxSpeed 도달" 가정을 깔고 있었다. 새 물리는 `τ ≈ 0.5s` relaxation을 따라 가속하므로 step 길이를 늘려 의미를 보존하는 방향으로 조정했다 (`SeparatesOverlappingAgents` 0.1→0.6s, `DoesNotSlowAgentsOnDifferentFloors` 0.1→0.8s). head-on 테스트는 `preferredSide` 상태 검증 대신 "좌우로 갈라지고 충돌하지 않는다"는 물리적 결과를 검증하도록 갱신.
- Out-of-scope (별도 PR): 에이전트 다양성(#147), 패닉/그룹 행동, fundamental diagram 단위 테스트 등 모델 검증 트랙.