### PR TITLE
[Application] Seek replay to exact T90/T95

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 /vcpkg_installed/
 /.deps/
 /.vendor/
+/main_latest/
+/pr_publish/
 *.user
 *.VC.db
 *.opendb  

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@
 /vcpkg_installed/
 /.deps/
 /.vendor/
-/main_latest/
-/pr_publish/
 *.user
 *.VC.db
 *.opendb  

--- a/src/application/ProjectPersistence.cpp
+++ b/src/application/ProjectPersistence.cpp
@@ -1040,6 +1040,12 @@ QJsonObject resultArtifactsToJson(const safecrowd::domain::ScenarioResultArtifac
     timing["t90Seconds"] = optionalDoubleToJson(artifacts.timingSummary.t90Seconds);
     timing["t95Seconds"] = optionalDoubleToJson(artifacts.timingSummary.t95Seconds);
     timing["finalEvacuationTimeSeconds"] = optionalDoubleToJson(artifacts.timingSummary.finalEvacuationTimeSeconds);
+    if (artifacts.timingSummary.t90Frame.has_value()) {
+        timing["t90Frame"] = simulationFrameToJson(*artifacts.timingSummary.t90Frame);
+    }
+    if (artifacts.timingSummary.t95Frame.has_value()) {
+        timing["t95Frame"] = simulationFrameToJson(*artifacts.timingSummary.t95Frame);
+    }
     object["timingSummary"] = timing;
     return object;
 }
@@ -1064,6 +1070,12 @@ safecrowd::domain::ScenarioResultArtifacts resultArtifactsFromJson(const QJsonOb
     artifacts.timingSummary.t90Seconds = optionalDoubleFromJson(timing.value("t90Seconds"));
     artifacts.timingSummary.t95Seconds = optionalDoubleFromJson(timing.value("t95Seconds"));
     artifacts.timingSummary.finalEvacuationTimeSeconds = optionalDoubleFromJson(timing.value("finalEvacuationTimeSeconds"));
+    if (timing.value("t90Frame").isObject()) {
+        artifacts.timingSummary.t90Frame = simulationFrameFromJson(timing.value("t90Frame").toObject());
+    }
+    if (timing.value("t95Frame").isObject()) {
+        artifacts.timingSummary.t95Frame = simulationFrameFromJson(timing.value("t95Frame").toObject());
+    }
     return artifacts;
 }
 

--- a/src/application/ScenarioResultWidget.cpp
+++ b/src/application/ScenarioResultWidget.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <functional>
 #include <utility>
 
 #include <QAbstractItemView>
@@ -15,9 +16,11 @@
 #include <QIcon>
 #include <QLabel>
 #include <QLinearGradient>
+#include <QMouseEvent>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPixmap>
+#include <QPointer>
 #include <QPushButton>
 #include <QScrollArea>
 #include <QSizePolicy>
@@ -97,11 +100,16 @@ public:
         setMinimumHeight(150);
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         setToolTip("Remaining occupant curve. T90/T95 indicate when 90%/95% of occupants have evacuated.");
+        setMouseTracking(true);
     }
 
     void setCurrentTimeSeconds(std::optional<double> seconds) {
         currentTimeSeconds_ = seconds;
         update();
+    }
+
+    void setTimingMarkerActivatedHandler(std::function<void(double)> handler) {
+        timingMarkerActivatedHandler_ = std::move(handler);
     }
 
 protected:
@@ -175,10 +183,99 @@ protected:
             QString("%1 / %2 remaining by %3 sec")
                 .arg(static_cast<int>(remainingCount))
                 .arg(static_cast<int>(last.totalCount))
-                .arg(last.timeSeconds, 0, 'f', 1));
+                 .arg(last.timeSeconds, 0, 'f', 1));
+    }
+
+    void mouseMoveEvent(QMouseEvent* event) override {
+        if (event == nullptr) {
+            return;
+        }
+        const bool hover = timingMarkerHitSeconds(event->position()).has_value();
+        setCursor(hover ? Qt::PointingHandCursor : Qt::ArrowCursor);
+        QWidget::mouseMoveEvent(event);
+    }
+
+    void leaveEvent(QEvent* event) override {
+        unsetCursor();
+        QWidget::leaveEvent(event);
+    }
+
+    void mousePressEvent(QMouseEvent* event) override {
+        if (event == nullptr || event->button() != Qt::LeftButton) {
+            QWidget::mousePressEvent(event);
+            return;
+        }
+        const auto seconds = timingMarkerHitSeconds(event->position());
+        if (!seconds.has_value()) {
+            QWidget::mousePressEvent(event);
+            return;
+        }
+        event->accept();
+        if (timingMarkerActivatedHandler_) {
+            timingMarkerActivatedHandler_(*seconds);
+        }
     }
 
 private:
+    QRectF plotRect() const {
+        return QRectF(rect()).adjusted(34, 18, -14, -28);
+    }
+
+    double maxTimeSeconds() const {
+        if (artifacts_.evacuationProgress.empty()) {
+            return 1.0;
+        }
+        const auto maxTimeIt = std::max_element(
+            artifacts_.evacuationProgress.begin(),
+            artifacts_.evacuationProgress.end(),
+            [](const auto& lhs, const auto& rhs) {
+                return lhs.timeSeconds < rhs.timeSeconds;
+            });
+        return std::max(1.0, maxTimeIt->timeSeconds);
+    }
+
+    QRectF markerHitRegion(const QRectF& plot, double maxTime, double seconds) const {
+        const auto x = plot.left() + (std::clamp(seconds / maxTime, 0.0, 1.0) * plot.width());
+        const QRectF lineHit(x - 6.0, plot.top(), 12.0, plot.height());
+        const QRectF labelHit(x - 4.0, plot.top() - 2.0, 70.0, 22.0);
+        return lineHit.united(labelHit);
+    }
+
+    std::optional<double> timingMarkerHitSeconds(const QPointF& position) const {
+        const QRectF plot = plotRect();
+        if (!plot.contains(position)) {
+            return std::nullopt;
+        }
+
+        const auto maxTime = maxTimeSeconds();
+        struct Candidate {
+            double seconds;
+            double distance;
+        };
+        std::optional<Candidate> best;
+        auto consider = [&](const std::optional<double>& markerSeconds) {
+            if (!markerSeconds.has_value()) {
+                return;
+            }
+            const auto region = markerHitRegion(plot, maxTime, *markerSeconds);
+            if (!region.contains(position)) {
+                return;
+            }
+            const auto x = plot.left() + (std::clamp(*markerSeconds / maxTime, 0.0, 1.0) * plot.width());
+            const auto distance = std::abs(position.x() - x);
+            if (!best.has_value() || distance < best->distance) {
+                best = Candidate{.seconds = *markerSeconds, .distance = distance};
+            }
+        };
+
+        consider(artifacts_.timingSummary.t90Seconds);
+        consider(artifacts_.timingSummary.t95Seconds);
+        if (!best.has_value()) {
+            return std::nullopt;
+        }
+        return best->seconds;
+    }
+
     void drawTimingMarker(
         QPainter& painter,
         const QRectF& plot,
@@ -215,6 +312,7 @@ private:
 
     safecrowd::domain::ScenarioResultArtifacts artifacts_{};
     std::optional<double> currentTimeSeconds_{};
+    std::function<void(double)> timingMarkerActivatedHandler_{};
 };
 
 class DensityLegendWidget final : public QWidget {
@@ -969,6 +1067,30 @@ QWidget* createResultCanvasPanel(
     auto* replayControls = new ResultReplayControls(replayFramesForResult(artifacts, frame), canvas, progressWidget, panel);
     if (replayControlsOut != nullptr) {
         *replayControlsOut = replayControls;
+    }
+    if (progressWidget != nullptr) {
+        const QPointer<ResultReplayControls> replayControlsGuard(replayControls);
+        const auto t90Seconds = artifacts.timingSummary.t90Seconds;
+        const auto t95Seconds = artifacts.timingSummary.t95Seconds;
+        const auto t90Frame = artifacts.timingSummary.t90Frame;
+        const auto t95Frame = artifacts.timingSummary.t95Frame;
+        progressWidget->setTimingMarkerActivatedHandler([replayControlsGuard, t90Seconds, t95Seconds, t90Frame, t95Frame](double seconds) {
+            if (replayControlsGuard != nullptr) {
+                if (t90Seconds.has_value()
+                    && t90Frame.has_value()
+                    && std::abs(seconds - *t90Seconds) <= 1e-6) {
+                    replayControlsGuard->showFrame(*t90Frame);
+                    return;
+                }
+                if (t95Seconds.has_value()
+                    && t95Frame.has_value()
+                    && std::abs(seconds - *t95Seconds) <= 1e-6) {
+                    replayControlsGuard->showFrame(*t95Frame);
+                    return;
+                }
+                replayControlsGuard->showClosestFrameAtSeconds(seconds);
+            }
+        });
     }
     layout->addWidget(replayControls);
     layout->addWidget(graphPanel, 1);

--- a/src/domain/ScenarioResultArtifacts.h
+++ b/src/domain/ScenarioResultArtifacts.h
@@ -24,6 +24,8 @@ struct EvacuationTimingSummary {
     std::optional<double> finalEvacuationTimeSeconds{};
     double targetTimeSeconds{0.0};
     std::optional<double> marginSeconds{};
+    std::optional<SimulationFrame> t90Frame{};
+    std::optional<SimulationFrame> t95Frame{};
 };
 
 struct DensityCellMetric {

--- a/src/domain/ScenarioSimulationMotionSystem.cpp
+++ b/src/domain/ScenarioSimulationMotionSystem.cpp
@@ -69,13 +69,26 @@ public:
         replanBlockedExitRoutes(query, entities, layoutCache, clock.elapsedSeconds, layoutRevision);
         replanBlockedRouteSegments(query, entities, layoutCache, clock.elapsedSeconds, layoutRevision);
 
+        if (!resources.contains<ScenarioTimingKeyframesResource>()) {
+            resources.set(ScenarioTimingKeyframesResource{});
+        }
+        auto& timingKeyframes = resources.get<ScenarioTimingKeyframesResource>();
+        const auto totalAgentCount = entities.size();
+        const auto t90TargetCount = static_cast<std::size_t>(std::ceil(static_cast<double>(totalAgentCount) * 0.90));
+        const auto t95TargetCount = static_cast<std::size_t>(std::ceil(static_cast<double>(totalAgentCount) * 0.95));
+
+        std::size_t evacuatedAtStartCount = 0;
+        std::size_t newlyEvacuatedCount = 0;
         for (const auto entity : entities) {
             auto& position = query.get<Position>(entity);
-            const auto& agent = query.get<Agent>(entity);
             auto& velocity = query.get<Velocity>(entity);
             auto& route = query.get<EvacuationRoute>(entity);
             auto& status = query.get<EvacuationStatus>(entity);
             if (status.evacuated) {
+                ++evacuatedAtStartCount;
+                continue;
+            }
+            if (route.destinationZoneId.empty()) {
                 continue;
             }
 
@@ -85,6 +98,76 @@ public:
                 status.evacuated = true;
                 status.completionTimeSeconds = clock.elapsedSeconds;
                 velocity.value = {};
+                ++newlyEvacuatedCount;
+            }
+        }
+
+        const auto evacuatedAfterCount = evacuatedAtStartCount + newlyEvacuatedCount;
+        const bool shouldCaptureT90 = t90TargetCount > 0
+            && !timingKeyframes.t90Frame.has_value()
+            && evacuatedAtStartCount < t90TargetCount
+            && evacuatedAfterCount >= t90TargetCount;
+        const bool shouldCaptureT95 = t95TargetCount > 0
+            && !timingKeyframes.t95Frame.has_value()
+            && evacuatedAtStartCount < t95TargetCount
+            && evacuatedAfterCount >= t95TargetCount;
+        if (shouldCaptureT90 || shouldCaptureT95) {
+            SimulationFrame keyframe;
+            keyframe.elapsedSeconds = clock.elapsedSeconds;
+            keyframe.totalAgentCount = totalAgentCount;
+            keyframe.evacuatedAgentCount = evacuatedAfterCount;
+            keyframe.complete = totalAgentCount > 0 && evacuatedAfterCount >= totalAgentCount;
+
+            const auto view = query.view<Position, Agent, Velocity, EvacuationStatus>();
+            keyframe.agents.reserve(view.size());
+            for (const auto entity : view) {
+                const auto& status = query.get<EvacuationStatus>(entity);
+                if (status.evacuated) {
+                    continue;
+                }
+                const auto& position = query.get<Position>(entity);
+                const auto& velocity = query.get<Velocity>(entity);
+                const auto& agent = query.get<Agent>(entity);
+                const auto* route = query.contains<EvacuationRoute>(entity) ? &query.get<EvacuationRoute>(entity) : nullptr;
+                keyframe.agents.push_back({
+                    .id = entity.index,
+                    .position = position.value,
+                    .velocity = velocity.value,
+                    .radius = agent.radius,
+                    .floorId = route != nullptr
+                        ? (!route->displayFloorId.empty()
+                            ? route->displayFloorId
+                            : route->currentFloorId)
+                        : std::string{},
+                    .stalled = route != nullptr
+                        && scenarioAgentStalled(simulation_internal::lengthOf(velocity.value), route->stalledSeconds),
+                });
+            }
+
+            if (shouldCaptureT90) {
+                timingKeyframes.t90Frame = keyframe;
+            }
+            if (shouldCaptureT95) {
+                timingKeyframes.t95Frame = keyframe;
+            }
+            if (resources.contains<ScenarioResultArtifactsResource>()) {
+                auto& result = resources.get<ScenarioResultArtifactsResource>();
+                if (shouldCaptureT90 && !result.artifacts.timingSummary.t90Frame.has_value()) {
+                    result.artifacts.timingSummary.t90Frame = timingKeyframes.t90Frame;
+                }
+                if (shouldCaptureT95 && !result.artifacts.timingSummary.t95Frame.has_value()) {
+                    result.artifacts.timingSummary.t95Frame = timingKeyframes.t95Frame;
+                }
+            }
+        }
+
+        for (const auto entity : entities) {
+            auto& position = query.get<Position>(entity);
+            const auto& agent = query.get<Agent>(entity);
+            auto& velocity = query.get<Velocity>(entity);
+            auto& route = query.get<EvacuationRoute>(entity);
+            auto& status = query.get<EvacuationStatus>(entity);
+            if (status.evacuated) {
                 continue;
             }
 
@@ -106,6 +189,7 @@ public:
                 continue;
             }
 
+            const auto& floorLayout = cachedLayoutForFloor(layoutCache, route.currentFloorId);
             const auto routeDirection = (target - position.value) * (1.0 / distance);
             const auto maxSpeed = effectiveMaxSpeed(layoutCache, agent, route, position.value);
             const auto desiredVelocity = routeDirection * maxSpeed;

--- a/src/domain/ScenarioSimulationSystems.cpp
+++ b/src/domain/ScenarioSimulationSystems.cpp
@@ -414,6 +414,20 @@ void ScenarioFrameSyncSystem::update(engine::EngineWorld& world, const engine::E
 
     if (resources.contains<ScenarioResultArtifactsResource>()) {
         auto& result = resources.get<ScenarioResultArtifactsResource>();
+        auto maybeStoreTimingKeyframe = [&](const std::optional<double>& seconds,
+                                            std::optional<SimulationFrame>& destination) {
+            if (!seconds.has_value() || destination.has_value()) {
+                return;
+            }
+            SimulationFrame keyframe = frame;
+            keyframe.elapsedSeconds = *seconds;
+            destination = std::move(keyframe);
+        };
+        maybeStoreTimingKeyframe(result.artifacts.timingSummary.t90Seconds,
+                                result.artifacts.timingSummary.t90Frame);
+        maybeStoreTimingKeyframe(result.artifacts.timingSummary.t95Seconds,
+                                result.artifacts.timingSummary.t95Frame);
+
         const auto shouldRecordReplay =
             result.artifacts.replayFrames.empty()
             || frame.elapsedSeconds + 1e-9 >= result.nextReplaySampleTimeSeconds

--- a/src/domain/ScenarioSimulationSystems.cpp
+++ b/src/domain/ScenarioSimulationSystems.cpp
@@ -414,20 +414,6 @@ void ScenarioFrameSyncSystem::update(engine::EngineWorld& world, const engine::E
 
     if (resources.contains<ScenarioResultArtifactsResource>()) {
         auto& result = resources.get<ScenarioResultArtifactsResource>();
-        auto maybeStoreTimingKeyframe = [&](const std::optional<double>& seconds,
-                                            std::optional<SimulationFrame>& destination) {
-            if (!seconds.has_value() || destination.has_value()) {
-                return;
-            }
-            SimulationFrame keyframe = frame;
-            keyframe.elapsedSeconds = *seconds;
-            destination = std::move(keyframe);
-        };
-        maybeStoreTimingKeyframe(result.artifacts.timingSummary.t90Seconds,
-                                result.artifacts.timingSummary.t90Frame);
-        maybeStoreTimingKeyframe(result.artifacts.timingSummary.t95Seconds,
-                                result.artifacts.timingSummary.t95Frame);
-
         const auto shouldRecordReplay =
             result.artifacts.replayFrames.empty()
             || frame.elapsedSeconds + 1e-9 >= result.nextReplaySampleTimeSeconds
@@ -555,6 +541,21 @@ void ScenarioResultArtifactsSystem::update(engine::EngineWorld& world, const eng
         percentileCompletionTime(completionTimes, totalAgentCount, 0.90);
     result.artifacts.timingSummary.t95Seconds =
         percentileCompletionTime(completionTimes, totalAgentCount, 0.95);
+    if (resources.contains<ScenarioTimingKeyframesResource>()) {
+        const auto& keyframes = resources.get<ScenarioTimingKeyframesResource>();
+        if (!result.artifacts.timingSummary.t90Frame.has_value()
+            && result.artifacts.timingSummary.t90Seconds.has_value()
+            && keyframes.t90Frame.has_value()
+            && std::abs(keyframes.t90Frame->elapsedSeconds - *result.artifacts.timingSummary.t90Seconds) <= 1e-9) {
+            result.artifacts.timingSummary.t90Frame = keyframes.t90Frame;
+        }
+        if (!result.artifacts.timingSummary.t95Frame.has_value()
+            && result.artifacts.timingSummary.t95Seconds.has_value()
+            && keyframes.t95Frame.has_value()
+            && std::abs(keyframes.t95Frame->elapsedSeconds - *result.artifacts.timingSummary.t95Seconds) <= 1e-9) {
+            result.artifacts.timingSummary.t95Frame = keyframes.t95Frame;
+        }
+    }
     if (totalAgentCount > 0 && completionTimes.size() == totalAgentCount) {
         result.artifacts.timingSummary.finalEvacuationTimeSeconds =
             *std::max_element(completionTimes.begin(), completionTimes.end());

--- a/src/domain/ScenarioSimulationSystems.h
+++ b/src/domain/ScenarioSimulationSystems.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -69,6 +70,11 @@ struct ScenarioResultArtifactsResource {
     bool densityTrackingInitialized{false};
     double lastDensitySampleTimeSeconds{0.0};
     std::unordered_map<long long, DensityCellMetric> peakDensityCellsByAddress{};
+};
+
+struct ScenarioTimingKeyframesResource {
+    std::optional<SimulationFrame> t90Frame{};
+    std::optional<SimulationFrame> t95Frame{};
 };
 
 struct ScenarioAgentSeed {


### PR DESCRIPTION
## Summary

- t90, t95 시점을 그래프에서 클릭해 리플레이를 해당 시점으로 이동(상태는 pause)
- T90/T95 키프레임을 evacuation 전환 시점에서 캡처해 시간/상태 오차 제거(기존 bottleneck detectionFrame 저장 방식과 동일)

## Related Issue

- Closes #182

## Area

- [ ] Engine
- [x] Domain
- [x] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [ ] `cmake --preset windows-debug`
- [ ] `cmake --build --preset build-debug`
- [ ] `ctest --preset test-debug`
- [x] `cmake --build --preset build-no-app-debug --target safecrowd_tests`
- [x] `ctest --preset test-no-app-debug`

## Risks / Follow-up

- None