### PR TITLE
[Application] Enable drag panning on result canvas

### DIFF
--- a/src/application/LayoutCanvasRendering.cpp
+++ b/src/application/LayoutCanvasRendering.cpp
@@ -440,7 +440,8 @@ bool LayoutCanvasCamera::handleKeyRelease(QKeyEvent* event) {
 }
 
 bool LayoutCanvasCamera::beginPan(QMouseEvent* event) {
-    if (event->button() != Qt::MiddleButton && !(event->button() == Qt::LeftButton && spacePressed_)) {
+    if (event->button() != Qt::MiddleButton
+        && !(event->button() == Qt::LeftButton && (spacePressed_ || allowLeftDragPan_))) {
         return false;
     }
 
@@ -495,6 +496,9 @@ bool LayoutCanvasCamera::zoomAt(QWheelEvent* event, const LayoutCanvasBounds& bo
 void LayoutCanvasCamera::reset() {
     zoom_ = 1.0;
     panOffset_ = {};
+    panning_ = false;
+    panButton_ = Qt::NoButton;
+    lastMousePosition_ = {};
 }
 
 void includeLayoutCanvasPoint(LayoutCanvasBounds& bounds, const safecrowd::domain::Point2D& point) {

--- a/src/application/LayoutCanvasRendering.h
+++ b/src/application/LayoutCanvasRendering.h
@@ -61,6 +61,10 @@ public:
     bool zoomAt(QWheelEvent* event, const LayoutCanvasBounds& bounds, const QRectF& viewport);
     void reset();
 
+    void setAllowLeftDragPan(bool allow) noexcept {
+        allowLeftDragPan_ = allow;
+    }
+
     double zoom() const noexcept {
         return zoom_;
     }
@@ -88,6 +92,7 @@ private:
     Qt::MouseButton panButton_{Qt::NoButton};
     bool panning_{false};
     bool spacePressed_{false};
+    bool allowLeftDragPan_{false};
 };
 
 void includeLayoutCanvasPoint(LayoutCanvasBounds& bounds, const safecrowd::domain::Point2D& point);

--- a/src/application/SimulationCanvasWidget.cpp
+++ b/src/application/SimulationCanvasWidget.cpp
@@ -102,6 +102,7 @@ SimulationCanvasWidget::SimulationCanvasWidget(safecrowd::domain::FacilityLayout
     setFocusPolicy(Qt::StrongFocus);
     setMinimumSize(520, 360);
     setStyleSheet("QWidget { background: #f4f7fb; }");
+    camera_.setAllowLeftDragPan(true);
     currentFloorId_ = defaultFloorId(layout_);
     layoutBounds_ = collectLayoutCanvasBounds(layout_, currentFloorId_);
     QCoreApplication::instance()->installEventFilter(this);
@@ -214,6 +215,7 @@ void SimulationCanvasWidget::keyReleaseEvent(QKeyEvent* event) {
 void SimulationCanvasWidget::mouseDoubleClickEvent(QMouseEvent* event) {
     if (event->button() == Qt::LeftButton) {
         camera_.reset();
+        unsetCursor();
         layoutCacheValid_ = false;
         update();
         event->accept();
@@ -234,6 +236,7 @@ void SimulationCanvasWidget::mouseMoveEvent(QMouseEvent* event) {
 void SimulationCanvasWidget::mousePressEvent(QMouseEvent* event) {
     setFocus(Qt::MouseFocusReason);
     if (camera_.beginPan(event)) {
+        setCursor(Qt::SizeAllCursor);
         return;
     }
     QWidget::mousePressEvent(event);
@@ -241,6 +244,7 @@ void SimulationCanvasWidget::mousePressEvent(QMouseEvent* event) {
 
 void SimulationCanvasWidget::mouseReleaseEvent(QMouseEvent* event) {
     if (camera_.finishPan(event)) {
+        unsetCursor();
         return;
     }
     QWidget::mouseReleaseEvent(event);


### PR DESCRIPTION
## Summary

- Add drag-to-pan (left mouse drag) in Result canvas; keep wheel zoom.
- Use a stable system cursor during panning to avoid Qt debug assert on Windows.

## Related Issue

- None (application-only PR)

## Area

- [ ] Engine
- [ ] Domain
- [x] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [x] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug`
- [x] `ctest --preset test-debug`
- [ ] Not run (reason below)

## Risks / Follow-up

- If needed, consider exposing a dedicated “Hand tool” toggle in the Result view instead of always-on left-drag pan.
