### PR TITLE
[Domain] Demo 맵 가운데 연결을 문으로 분류

### DIFF
--- a/src/domain/DemoLayouts.cpp
+++ b/src/domain/DemoLayouts.cpp
@@ -96,7 +96,7 @@ FacilityLayout2D demoFacility() {
     Connection2D roomConnection;
     roomConnection.id = Sprint1FacilityIds::OpeningConnectionId;
     roomConnection.floorId = Sprint1FacilityIds::FloorId;
-    roomConnection.kind = ConnectionKind::Opening;
+    roomConnection.kind = ConnectionKind::Doorway;
     roomConnection.fromZoneId = mainRoom.id;
     roomConnection.toZoneId = sideRoom.id;
     roomConnection.effectiveWidth = 3.0;

--- a/tests/DemoFixtureServiceTests.cpp
+++ b/tests/DemoFixtureServiceTests.cpp
@@ -19,6 +19,14 @@ bool containsConnectionKind(
     });
 }
 
+std::size_t countConnectionKind(
+    const std::vector<safecrowd::domain::Connection2D>& connections,
+    safecrowd::domain::ConnectionKind kind) {
+    return static_cast<std::size_t>(std::count_if(connections.begin(), connections.end(), [&](const auto& connection) {
+        return connection.kind == kind;
+    }));
+}
+
 bool containsZoneId(
     const std::vector<safecrowd::domain::Zone2D>& zones,
     const std::string& id) {
@@ -72,7 +80,7 @@ SC_TEST(DemoFixtureServiceBuildsSprint1Fixture) {
     }));
 
     SC_EXPECT_EQ(layout.connections.size(), std::size_t{3});
-    SC_EXPECT_TRUE(containsConnectionKind(layout.connections, safecrowd::domain::ConnectionKind::Opening));
+    SC_EXPECT_EQ(countConnectionKind(layout.connections, safecrowd::domain::ConnectionKind::Doorway), std::size_t{2});
     SC_EXPECT_TRUE(containsConnectionKind(layout.connections, safecrowd::domain::ConnectionKind::Doorway));
     SC_EXPECT_TRUE(containsConnectionKind(layout.connections, safecrowd::domain::ConnectionKind::Exit));
     SC_EXPECT_EQ(layout.barriers.size(), std::size_t{14});


### PR DESCRIPTION
## Summary

- Demo layout의 가운데 room-to-room 연결을 `Opening`에서 `Doorway`로 수정했습니다.
- Demo fixture 테스트가 문 2개와 출구 1개 구성을 검증하도록 업데이트했습니다.

## Related Issue

- Closes #184 
 
## Area

- [ ] Engine
- [x] Domain
- [ ] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [x] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug`
- [x] `ctest --preset test-debug`
- [ ] Not run (reason below)

## Risks / Follow-up

- Door color rendering changes are intentionally left for a separate PR.
