### PR TITLE
[Application] Improve door color visibility

### DIFF
--- a/src/application/LayoutCanvasRendering.cpp
+++ b/src/application/LayoutCanvasRendering.cpp
@@ -16,6 +16,9 @@
 namespace safecrowd::application {
 namespace {
 
+const QColor kDoorStrokeColor("#ff8c00");
+const QColor kOpeningStrokeColor("#2f6fb2");
+
 bool matchesFloor(const std::string& elementFloorId, const std::string& floorId) {
     return floorId.empty() || elementFloorId.empty() || elementFloorId == floorId;
 }
@@ -25,6 +28,13 @@ bool isVerticalConnection(const safecrowd::domain::Connection2D& connection) {
         || connection.kind == safecrowd::domain::ConnectionKind::Ramp
         || connection.isStair
         || connection.isRamp;
+}
+
+QColor connectionStrokeColor(const safecrowd::domain::Connection2D& connection) {
+    if (connection.kind == safecrowd::domain::ConnectionKind::Doorway) {
+        return kDoorStrokeColor;
+    }
+    return kOpeningStrokeColor;
 }
 
 const safecrowd::domain::Zone2D* findZone(
@@ -763,11 +773,11 @@ void drawFacilityLayoutCanvas(QPainter& painter, const safecrowd::domain::Facili
         painter.drawPath(layoutCanvasPolygonPath(zone.area, transform));
     }
 
-    painter.setPen(QPen(QColor(56, 122, 186), 2.5));
     for (const auto& connection : layout.connections) {
         if (isVerticalConnection(connection) || isStairAdjacentOpening(layout, connection)) {
             continue;
         }
+        painter.setPen(QPen(connectionStrokeColor(connection), 3.0));
         drawLayoutCanvasLine(painter, connection.centerSpan, transform);
     }
 
@@ -806,11 +816,11 @@ void drawFacilityLayoutCanvas(
         }
     }
 
-    painter.setPen(QPen(QColor(56, 122, 186), 2.5));
     for (const auto& connection : layout.connections) {
         if (!isVerticalConnection(connection)
             && !isStairAdjacentOpening(layout, connection)
             && matchesFloor(connection.floorId, floorId)) {
+            painter.setPen(QPen(connectionStrokeColor(connection), 3.0));
             drawLayoutCanvasLine(painter, connection.centerSpan, transform);
         }
     }

--- a/src/application/LayoutNavigationPanelWidget.cpp
+++ b/src/application/LayoutNavigationPanelWidget.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include <QColor>
 #include <QVBoxLayout>
 
 #include "application/NavigationTreeWidget.h"
@@ -15,6 +16,8 @@ namespace safecrowd::application {
 namespace {
 
 constexpr double kGeometryEpsilon = 1e-4;
+const QColor kExitAccentColor("#2d8f5b");
+const QColor kDoorAccentColor("#ff8c00");
 
 QString floorActionId(const std::string& floorId) {
     return QString("floor:%1").arg(QString::fromStdString(floorId));
@@ -34,7 +37,7 @@ QIcon floorIcon() {
 
 QIcon zoneIcon(const safecrowd::domain::Zone2D& zone) {
     if (zone.kind == safecrowd::domain::ZoneKind::Exit) {
-        return treeIcon(QStringLiteral(":/tool-icons/layout-authoring/draw-exit.svg"), QColor("#2d8f5b"));
+        return treeIcon(QStringLiteral(":/tool-icons/layout-authoring/draw-exit.svg"), kExitAccentColor);
     }
     if (zone.kind == safecrowd::domain::ZoneKind::Stair || zone.isStair || zone.isRamp) {
         return treeIcon(QStringLiteral(":/tool-icons/layout-authoring/draw-stair-ramp.svg"), QColor("#6a5d9f"));
@@ -56,9 +59,9 @@ QIcon connectionIcon(const safecrowd::domain::Connection2D& connection) {
         return treeIcon(QStringLiteral(":/tool-icons/layout-authoring/draw-stair-ramp.svg"), QColor("#6a5d9f"));
     }
     if (connection.kind == safecrowd::domain::ConnectionKind::Exit) {
-        return treeIcon(QStringLiteral(":/tool-icons/layout-authoring/draw-exit.svg"), QColor("#2d8f5b"));
+        return treeIcon(QStringLiteral(":/tool-icons/layout-authoring/draw-exit.svg"), kExitAccentColor);
     }
-    return treeIcon(QStringLiteral(":/tool-icons/layout-authoring/draw-door.svg"), QColor("#8e6b23"));
+    return treeIcon(QStringLiteral(":/tool-icons/layout-authoring/draw-door.svg"), kDoorAccentColor);
 }
 
 QString zoneLabel(const safecrowd::domain::Zone2D& zone) {

--- a/src/application/LayoutPreviewWidget.cpp
+++ b/src/application/LayoutPreviewWidget.cpp
@@ -49,6 +49,8 @@ constexpr int kPropertyPanelHeight = 42;
 constexpr int kSideToolbarWidth = 44;
 constexpr int kToolbarButtonSize = 44;
 const QColor kSelectionHighlightColor("#0b3d78");
+const QColor kExitAccentColor("#2d8f5b");
+const QColor kDoorAccentColor("#ff8c00");
 
 QRectF previewViewport(const QRect& widgetRect) {
     return layoutCanvasViewport(widgetRect, kSideToolbarWidth + 16, kTopToolbarHeight + kPropertyPanelHeight + 16, 16, 16);
@@ -2922,8 +2924,11 @@ void LayoutPreviewWidget::paintEvent(QPaintEvent* event) {
             drawLine(painter, wall.segment, transform);
         }
 
-        painter.setPen(QPen(QColor(66, 156, 96), 2.5, Qt::DashLine));
         for (const auto& opening : importResult_.canonicalGeometry->openings) {
+            const auto openingColor = opening.kind == safecrowd::domain::OpeningKind::Doorway
+                ? kDoorAccentColor
+                : QColor(66, 156, 96);
+            painter.setPen(QPen(openingColor, 3.0, Qt::DashLine));
             drawLine(painter, opening.span, transform);
         }
     }
@@ -5042,10 +5047,10 @@ void LayoutPreviewWidget::setupToolbars() {
     topLayout->addStretch(1);
 
     roomToolButton_ = makeButton(sideToolbar_, sideLayout, makeToolIcon("room", QColor("#2f5d8a")), "Draw Room");
-    exitToolButton_ = makeButton(sideToolbar_, sideLayout, makeToolIcon("exit", QColor("#2d8f5b")), "Draw Exit");
+    exitToolButton_ = makeButton(sideToolbar_, sideLayout, makeToolIcon("exit", kExitAccentColor), "Draw Exit");
     wallToolButton_ = makeButton(sideToolbar_, sideLayout, makeToolIcon("wall", QColor("#4f5d6b")), "Draw Wall");
     obstructionToolButton_ = makeButton(sideToolbar_, sideLayout, makeToolIcon("obstruction", QColor("#6c4f38")), "Draw Obstruction");
-    doorToolButton_ = makeButton(sideToolbar_, sideLayout, makeToolIcon("door", QColor("#8e6b23")), "Draw Door");
+    doorToolButton_ = makeButton(sideToolbar_, sideLayout, makeToolIcon("door", kDoorAccentColor), "Draw Door");
     stairToolButton_ = makeButton(sideToolbar_, sideLayout, makeToolIcon("stair", QColor("#6a5d9f")), "Draw Stair/Ramp");
     uStairToolButton_ = makeButton(sideToolbar_, sideLayout, makeToolIcon("u-stair", QColor("#4f46a5")), "Draw U-shaped Stair");
     sideLayout->addStretch(1);


### PR DESCRIPTION
## Summary

- 문(Doorway) 연결선이 기존 파란색 계열에서는 배경 및 다른 연결 요소와 구분이 약해, 파란색의 보색인 주황색으로 변경해 대비와 가시성을 높인다.
- 문 도구 버튼과 좌측 레이아웃 트리의 문 아이콘 색상도 같은 주황색으로 맞춘다.
- 출구 색상은 기존 녹색 계열을 유지한다.

## Related Issue

- None (application-only PR)

## Area

- [ ] Engine
- [ ] Domain
- [x] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [ ] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug --target safecrowd_app`
- [ ] `ctest --preset test-debug`
- [ ] Not run (reason below)

## Risks / Follow-up

- application-only 시각 표시 변경이라 전체 CTest는 실행하지 않았다.
- 가운데 Demo 문이 실제 Doorway로 분류되는 수정은 별도 Domain PR에서 처리한다.