### PR TITLE
[Application] Route guidance periods + compliance model

### DIFF
--- a/src/application/ProjectPersistence.cpp
+++ b/src/application/ProjectPersistence.cpp
@@ -752,6 +752,54 @@ safecrowd::domain::OperationalEventDraft eventFromJson(const QJsonObject& object
     };
 }
 
+QJsonObject routeGuidanceToJson(const safecrowd::domain::RouteGuidanceDraft& guidance) {
+    QJsonObject object;
+    object["id"] = QString::fromStdString(guidance.id);
+    object["startSeconds"] = guidance.startSeconds;
+    object["endSeconds"] = guidance.endSeconds;
+    QJsonArray periods;
+    for (const auto& period : guidance.periods) {
+        QJsonObject periodObject;
+        periodObject["startSeconds"] = period.startSeconds;
+        periodObject["endSeconds"] = period.endSeconds;
+        periods.append(periodObject);
+    }
+    object["periods"] = periods;
+    object["guidedExitZoneId"] = QString::fromStdString(guidance.guidedExitZoneId);
+    object["installConnectionId"] = QString::fromStdString(guidance.installConnectionId);
+    object["baseComplianceRate"] = guidance.baseComplianceRate;
+    object["guidanceStrength"] = guidance.guidanceStrength;
+    object["maxDetourMeters"] = guidance.maxDetourMeters;
+    return object;
+}
+
+safecrowd::domain::RouteGuidanceDraft routeGuidanceFromJson(const QJsonObject& object) {
+    safecrowd::domain::RouteGuidanceDraft guidance;
+    guidance.id = object.value("id").toString().toStdString();
+    guidance.startSeconds = object.value("startSeconds").toDouble(0.0);
+    guidance.endSeconds = object.value("endSeconds").toDouble(10.0);
+    for (const auto& value : object.value("periods").toArray()) {
+        const auto periodObject = value.toObject();
+        guidance.periods.push_back({
+            .startSeconds = periodObject.value("startSeconds").toDouble(0.0),
+            .endSeconds = periodObject.value("endSeconds").toDouble(0.0),
+        });
+    }
+    if (guidance.periods.empty() && (object.contains("startSeconds") || object.contains("endSeconds"))) {
+        // Backward compatibility: older projects stored a single scalar period.
+        guidance.periods.push_back({
+            .startSeconds = guidance.startSeconds,
+            .endSeconds = guidance.endSeconds,
+        });
+    }
+    guidance.guidedExitZoneId = object.value("guidedExitZoneId").toString().toStdString();
+    guidance.installConnectionId = object.value("installConnectionId").toString().toStdString();
+    guidance.baseComplianceRate = object.value("baseComplianceRate").toDouble(0.5);
+    guidance.guidanceStrength = object.value("guidanceStrength").toDouble(0.55);
+    guidance.maxDetourMeters = object.value("maxDetourMeters").toDouble(20.0);
+    return guidance;
+}
+
 QJsonObject connectionBlockIntervalToJson(const safecrowd::domain::ConnectionBlockIntervalDraft& interval) {
     QJsonObject object;
     object["startSeconds"] = interval.startSeconds;
@@ -796,6 +844,12 @@ QJsonObject controlPlanToJson(const safecrowd::domain::ControlPlan& control) {
     }
     object["events"] = events;
 
+    QJsonArray routeGuidances;
+    for (const auto& guidance : control.routeGuidances) {
+        routeGuidances.append(routeGuidanceToJson(guidance));
+    }
+    object["routeGuidances"] = routeGuidances;
+
     QJsonArray connectionBlocks;
     for (const auto& block : control.connectionBlocks) {
         connectionBlocks.append(connectionBlockToJson(block));
@@ -808,6 +862,9 @@ safecrowd::domain::ControlPlan controlPlanFromJson(const QJsonObject& object) {
     safecrowd::domain::ControlPlan control;
     for (const auto& value : object.value("events").toArray()) {
         control.events.push_back(eventFromJson(value.toObject()));
+    }
+    for (const auto& value : object.value("routeGuidances").toArray()) {
+        control.routeGuidances.push_back(routeGuidanceFromJson(value.toObject()));
     }
     for (const auto& value : object.value("connectionBlocks").toArray()) {
         control.connectionBlocks.push_back(connectionBlockFromJson(value.toObject()));

--- a/src/application/ScenarioAuthoringWidget.cpp
+++ b/src/application/ScenarioAuthoringWidget.cpp
@@ -283,6 +283,69 @@ std::vector<NavigationTreeNode> buildEventsTree(
         });
     }
 
+    const auto& routeGuidances = scenario->draft.control.routeGuidances;
+    if (!routeGuidances.empty()) {
+        std::vector<NavigationTreeNode> nodes;
+        nodes.reserve(routeGuidances.size());
+        for (const auto& guidance : routeGuidances) {
+            const auto guidanceId = QString::fromStdString(guidance.id);
+            const auto doorLabel = guidance.installConnectionId.empty()
+                ? QString{}
+                : connectionLabelForId(layout, guidance.installConnectionId);
+            const auto exitLabel = guidance.guidedExitZoneId.empty()
+                ? QStringLiteral("Nearest exit")
+                : zoneName(layout, guidance.guidedExitZoneId);
+            QString periodSummary = QStringLiteral("Always");
+            if (!guidance.periods.empty()) {
+                periodSummary = blockScheduleSummary(safecrowd::domain::ConnectionBlockDraft{
+                    .intervals = [&]() {
+                        std::vector<safecrowd::domain::ConnectionBlockIntervalDraft> intervals;
+                        intervals.reserve(guidance.periods.size());
+                        for (const auto& period : guidance.periods) {
+                            intervals.push_back({
+                                .startSeconds = std::max(0.0, period.startSeconds),
+                                .endSeconds = std::max(0.0, period.endSeconds),
+                            });
+                        }
+                        return intervals;
+                    }(),
+                });
+            }
+
+            std::vector<NavigationTreeNode> children;
+            children.reserve(doorLabel.isEmpty() ? 2u : 3u);
+            children.push_back({
+                .label = QString("Exit  -  %1").arg(exitLabel),
+                .id = QString("%1/exit").arg(guidanceId),
+            });
+            if (!doorLabel.isEmpty()) {
+                children.push_back({
+                    .label = QString("Door  -  %1").arg(doorLabel),
+                    .id = QString("%1/door").arg(guidanceId),
+                });
+            }
+            children.push_back({
+                .label = QString("Period  -  %1").arg(periodSummary),
+                .id = QString("%1/period").arg(guidanceId),
+            });
+
+            nodes.push_back({
+                .label = QString("Guidance  -  %1").arg(doorLabel.isEmpty() ? exitLabel : doorLabel),
+                .id = guidanceId,
+                .detail = QString("Period: %1").arg(periodSummary),
+                .children = std::move(children),
+                .expanded = true,
+            });
+        }
+
+        sections.push_back({
+            .label = QString("Route Guidance (%1)").arg(static_cast<int>(routeGuidances.size())),
+            .children = std::move(nodes),
+            .expanded = true,
+            .selectable = false,
+        });
+    }
+
     const auto& connectionBlocks = scenario->draft.control.connectionBlocks;
     if (!connectionBlocks.empty()) {
         std::vector<NavigationTreeNode> blocks;
@@ -558,6 +621,16 @@ void ScenarioAuthoringWidget::refreshCanvas() {
         refreshNavigationPanel();
         refreshInspector();
     });
+    canvas_->setRouteGuidances(scenario->draft.control.routeGuidances);
+    canvas_->setRouteGuidancesChangedHandler([this](const std::vector<safecrowd::domain::RouteGuidanceDraft>& guidances) {
+        auto* current = currentScenario();
+        if (current == nullptr) {
+            return;
+        }
+        current->draft.control.routeGuidances = guidances;
+        refreshNavigationPanel();
+        refreshInspector();
+    });
     if (!selectedLayoutElementId_.isEmpty()) {
         canvas_->focusLayoutElement(selectedLayoutElementId_);
     } else if (!selectedCrowdElementId_.isEmpty()) {
@@ -576,13 +649,15 @@ void ScenarioAuthoringWidget::refreshInspector() {
         } else {
             const int people = totalOccupantCount(*scenario);
             const auto blockCount = static_cast<int>(scenario->draft.control.connectionBlocks.size());
-            scenarioSummaryLabel_->setText(QString("Name: %1\nRole: %2\nPopulation: %3\nStart: %4\nDestination: %5\nEvents: %6\nBlocked exits: %7")
+            const auto guidanceCount = static_cast<int>(scenario->draft.control.routeGuidances.size());
+            scenarioSummaryLabel_->setText(QString("Name: %1\nRole: %2\nPopulation: %3\nStart: %4\nDestination: %5\nEvents: %6\nRoute guidance: %7\nBlocked exits: %8")
                 .arg(
                     QString::fromStdString(scenario->draft.name),
                     scenario->draft.role == safecrowd::domain::ScenarioRole::Baseline ? "Baseline" : "Alternative")
                 .arg(people)
                 .arg(scenario->startText, scenario->destinationText)
                 .arg(static_cast<int>(scenario->events.size()))
+                .arg(guidanceCount)
                 .arg(blockCount));
         }
     }
@@ -598,6 +673,10 @@ void ScenarioAuthoringWidget::refreshInspector() {
             if (!scenario->draft.control.connectionBlocks.empty()) {
                 changes << QString("Blocked exits: %1 configured")
                     .arg(static_cast<int>(scenario->draft.control.connectionBlocks.size()));
+            }
+            if (!scenario->draft.control.routeGuidances.empty()) {
+                changes << QString("Route guidance: %1 configured")
+                    .arg(static_cast<int>(scenario->draft.control.routeGuidances.size()));
             }
             if (changes.isEmpty()) {
                 changes << "No changed fields yet";

--- a/src/application/ScenarioCanvasWidget.cpp
+++ b/src/application/ScenarioCanvasWidget.cpp
@@ -26,6 +26,7 @@
 #include <QPushButton>
 #include <QSpinBox>
 #include <QToolButton>
+#include <QToolTip>
 #include <QVBoxLayout>
 #include <QWheelEvent>
 
@@ -53,6 +54,66 @@ struct PointBounds {
 
 bool matchesFloor(const std::string& elementFloorId, const QString& floorId) {
     return floorId.isEmpty() || elementFloorId.empty() || QString::fromStdString(elementFloorId) == floorId;
+}
+
+QString formatConnectionBlockTooltip(const safecrowd::domain::ConnectionBlockDraft& block) {
+    if (block.connectionId.empty()) {
+        return {};
+    }
+
+    QString text = QStringLiteral("차단 스케줄");
+    if (block.intervals.empty()) {
+        text.append("\n- 항상 차단");
+        return text;
+    }
+
+    for (const auto& interval : block.intervals) {
+        const auto start = std::max(0.0, interval.startSeconds);
+        const auto end = std::max(start, interval.endSeconds);
+        text.append(QString("\n- %1s ~ %2s").arg(start, 0, 'f', 1).arg(end, 0, 'f', 1));
+    }
+    return text;
+}
+
+std::optional<std::size_t> hoveredConnectionBlockIndex(
+    const safecrowd::domain::FacilityLayout2D& layout,
+    const std::vector<safecrowd::domain::ConnectionBlockDraft>& blocks,
+    const LayoutCanvasTransform& transform,
+    const QString& currentFloorId,
+    const QPointF& screenPosition) {
+    constexpr double kHoverRadiusPixels = 14.0;
+
+    std::optional<std::size_t> closestIndex;
+    double closestDistanceSq = kHoverRadiusPixels * kHoverRadiusPixels;
+
+    for (std::size_t index = 0; index < blocks.size(); ++index) {
+        const auto& block = blocks[index];
+        if (block.connectionId.empty()) {
+            continue;
+        }
+
+        const auto it = std::find_if(layout.connections.begin(), layout.connections.end(), [&](const auto& connection) {
+            return connection.id == block.connectionId;
+        });
+        if (it == layout.connections.end()) {
+            continue;
+        }
+        if (!matchesFloor(it->floorId, currentFloorId)) {
+            continue;
+        }
+
+        const auto center = transform.map({.x = (it->centerSpan.start.x + it->centerSpan.end.x) * 0.5,
+                                          .y = (it->centerSpan.start.y + it->centerSpan.end.y) * 0.5});
+        const auto dx = center.x() - screenPosition.x();
+        const auto dy = center.y() - screenPosition.y();
+        const auto distanceSq = (dx * dx) + (dy * dy);
+        if (distanceSq <= closestDistanceSq) {
+            closestDistanceSq = distanceSq;
+            closestIndex = index;
+        }
+    }
+
+    return closestIndex;
 }
 
 QString defaultFloorId(const safecrowd::domain::FacilityLayout2D& layout) {
@@ -699,6 +760,12 @@ void ScenarioCanvasWidget::keyReleaseEvent(QKeyEvent* event) {
     QWidget::keyReleaseEvent(event);
 }
 
+void ScenarioCanvasWidget::leaveEvent(QEvent* event) {
+    hoveredConnectionBlockId_.clear();
+    QToolTip::hideText();
+    QWidget::leaveEvent(event);
+}
+
 void ScenarioCanvasWidget::mouseDoubleClickEvent(QMouseEvent* event) {
     if (event->button() == Qt::LeftButton) {
         camera_.reset();
@@ -716,16 +783,45 @@ void ScenarioCanvasWidget::mouseMoveEvent(QMouseEvent* event) {
     }
 
     if (dragging_) {
+        if (!hoveredConnectionBlockId_.isEmpty()) {
+            hoveredConnectionBlockId_.clear();
+            QToolTip::hideText();
+        }
         dragCurrent_ = event->position();
         update();
         event->accept();
         return;
     }
     if (selectionDragging_) {
+        if (!hoveredConnectionBlockId_.isEmpty()) {
+            hoveredConnectionBlockId_.clear();
+            QToolTip::hideText();
+        }
         selectionDragCurrent_ = event->position();
         update();
         event->accept();
         return;
+    }
+
+    if (const auto bounds = collectBounds(); bounds.has_value()) {
+        const auto transform = currentTransform(*bounds);
+        const auto hoveredIndex = hoveredConnectionBlockIndex(layout_, connectionBlocks_, transform, currentFloorId_, event->position());
+        if (!hoveredIndex.has_value()) {
+            if (!hoveredConnectionBlockId_.isEmpty()) {
+                hoveredConnectionBlockId_.clear();
+                QToolTip::hideText();
+            }
+        } else {
+            const auto& block = connectionBlocks_[*hoveredIndex];
+            const auto tooltip = formatConnectionBlockTooltip(block);
+            if (!tooltip.isEmpty()) {
+                const auto hoveredId = QString::fromStdString(block.id.empty() ? block.connectionId : block.id);
+                if (hoveredId != hoveredConnectionBlockId_) {
+                    hoveredConnectionBlockId_ = hoveredId;
+                    QToolTip::showText(event->globalPosition().toPoint(), tooltip, this);
+                }
+            }
+        }
     }
     QWidget::mouseMoveEvent(event);
 }

--- a/src/application/ScenarioCanvasWidget.cpp
+++ b/src/application/ScenarioCanvasWidget.cpp
@@ -188,10 +188,11 @@ QString formatRouteGuidanceTooltip(
     if (guidance.periods.empty()) {
         text.append(QStringLiteral("\n Always"));
     } else {
-        const auto& period = guidance.periods.front();
-        const auto start = std::max(0.0, period.startSeconds);
-        const auto end = std::max(start, std::max(0.0, period.endSeconds));
-        text.append(QString("\n %1s~%2s").arg(start, 0, 'f', 1).arg(end, 0, 'f', 1));
+        for (const auto& period : guidance.periods) {
+            const auto start = std::max(0.0, period.startSeconds);
+            const auto end = std::max(start, std::max(0.0, period.endSeconds));
+            text.append(QString("\n %1s~%2s").arg(start, 0, 'f', 1).arg(end, 0, 'f', 1));
+        }
     }
     text.append(QString("\n Base compliance: %1").arg(std::clamp(guidance.baseComplianceRate, 0.0, 1.0), 0, 'f', 2));
     text.append(QString("\n Strength: %1").arg(std::clamp(guidance.guidanceStrength, 0.0, 1.0), 0, 'f', 2));

--- a/src/application/ScenarioCanvasWidget.cpp
+++ b/src/application/ScenarioCanvasWidget.cpp
@@ -1,11 +1,14 @@
 #include "application/ScenarioCanvasWidget.h"
 
 #include "application/ToolIconResources.h"
+#include "application/UiStyle.h"
 
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <functional>
+#include <limits>
+#include <memory>
 #include <optional>
 #include <random>
 
@@ -13,11 +16,14 @@
 #include <QComboBox>
 #include <QDialog>
 #include <QDialogButtonBox>
+#include <QDoubleSpinBox>
 #include <QEvent>
 #include <QFrame>
+#include <QGridLayout>
 #include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QLabel>
+#include <QLineEdit>
 #include <QMouseEvent>
 #include <QMenu>
 #include <QMessageBox>
@@ -45,6 +51,8 @@ constexpr double kGeometryEpsilon = 1e-9;
 constexpr double kSelectionDragThresholdPixels = 4.0;
 const QColor kSelectionHighlightColor("#0b3d78");
 
+[[nodiscard]] safecrowd::domain::Point2D polygonCenter(const safecrowd::domain::Polygon2D& polygon);
+
 struct PointBounds {
     double minX{0.0};
     double minY{0.0};
@@ -56,14 +64,72 @@ bool matchesFloor(const std::string& elementFloorId, const QString& floorId) {
     return floorId.isEmpty() || elementFloorId.empty() || QString::fromStdString(elementFloorId) == floorId;
 }
 
+safecrowd::domain::Point2D connectionMarkerCenter(const safecrowd::domain::Connection2D& connection) {
+    return {
+        .x = (connection.centerSpan.start.x + connection.centerSpan.end.x) * 0.5,
+        .y = (connection.centerSpan.start.y + connection.centerSpan.end.y) * 0.5,
+    };
+}
+
+std::string pickNearestExitZoneIdForConnection(
+    const safecrowd::domain::FacilityLayout2D& layout,
+    const safecrowd::domain::Connection2D& connection) {
+    const auto pickAdjacentExit = [&]() -> std::string {
+        if (connection.fromZoneId.empty() && connection.toZoneId.empty()) {
+            return {};
+        }
+        const auto exitIt = std::find_if(layout.zones.begin(), layout.zones.end(), [&](const auto& zone) {
+            if (zone.kind != safecrowd::domain::ZoneKind::Exit) {
+                return false;
+            }
+            return zone.id == connection.fromZoneId || zone.id == connection.toZoneId;
+        });
+        return exitIt == layout.zones.end() ? std::string{} : exitIt->id;
+    };
+
+    if (auto adjacent = pickAdjacentExit(); !adjacent.empty()) {
+        return adjacent;
+    }
+
+    const auto doorCenter = connectionMarkerCenter(connection);
+
+    const auto pickNearest = [&](bool sameFloorOnly) -> std::string {
+        double bestDistanceSq = std::numeric_limits<double>::infinity();
+        const safecrowd::domain::Zone2D* bestZone = nullptr;
+        for (const auto& zone : layout.zones) {
+            if (zone.kind != safecrowd::domain::ZoneKind::Exit) {
+                continue;
+            }
+            if (sameFloorOnly && !connection.floorId.empty() && !zone.floorId.empty() && zone.floorId != connection.floorId) {
+                continue;
+            }
+
+            const auto exitCenter = polygonCenter(zone.area);
+            const auto dx = exitCenter.x - doorCenter.x;
+            const auto dy = exitCenter.y - doorCenter.y;
+            const auto d2 = (dx * dx) + (dy * dy);
+            if (d2 < bestDistanceSq) {
+                bestDistanceSq = d2;
+                bestZone = &zone;
+            }
+        }
+        return bestZone == nullptr ? std::string{} : bestZone->id;
+    };
+
+    if (auto sameFloor = pickNearest(true); !sameFloor.empty()) {
+        return sameFloor;
+    }
+    return pickNearest(false);
+}
+
 QString formatConnectionBlockTooltip(const safecrowd::domain::ConnectionBlockDraft& block) {
     if (block.connectionId.empty()) {
         return {};
     }
 
-    QString text = QStringLiteral("차단 스케줄");
+    QString text = QStringLiteral("Block schedule");
     if (block.intervals.empty()) {
-        text.append("\n- 항상 차단");
+        text.append("\n- Block always");
         return text;
     }
 
@@ -106,6 +172,135 @@ std::optional<std::size_t> hoveredConnectionBlockIndex(
                                           .y = (it->centerSpan.start.y + it->centerSpan.end.y) * 0.5});
         const auto dx = center.x() - screenPosition.x();
         const auto dy = center.y() - screenPosition.y();
+        const auto distanceSq = (dx * dx) + (dy * dy);
+        if (distanceSq <= closestDistanceSq) {
+            closestDistanceSq = distanceSq;
+            closestIndex = index;
+        }
+    }
+
+    return closestIndex;
+}
+
+QString formatRouteGuidanceTooltip(
+    const safecrowd::domain::RouteGuidanceDraft& guidance) {
+    QString text = QStringLiteral("Route guidance");
+    if (guidance.periods.empty()) {
+        text.append(QStringLiteral("\n Always"));
+    } else {
+        const auto& period = guidance.periods.front();
+        const auto start = std::max(0.0, period.startSeconds);
+        const auto end = std::max(start, std::max(0.0, period.endSeconds));
+        text.append(QString("\n %1s~%2s").arg(start, 0, 'f', 1).arg(end, 0, 'f', 1));
+    }
+    text.append(QString("\n Base compliance: %1").arg(std::clamp(guidance.baseComplianceRate, 0.0, 1.0), 0, 'f', 2));
+    text.append(QString("\n Strength: %1").arg(std::clamp(guidance.guidanceStrength, 0.0, 1.0), 0, 'f', 2));
+    text.append(QString("\n Max detour:%1m").arg(std::max(0.0, guidance.maxDetourMeters), 0, 'f', 1));
+    return text;
+}
+
+std::optional<QPointF> routeGuidanceMarkerCenter(
+    const safecrowd::domain::FacilityLayout2D& layout,
+    const safecrowd::domain::RouteGuidanceDraft& guidance,
+    const std::vector<safecrowd::domain::ConnectionBlockDraft>& blocks,
+    const LayoutCanvasTransform& transform,
+    const QString& currentFloorId) {
+    std::optional<QPointF> center;
+    if (!guidance.installConnectionId.empty()) {
+        const auto it = std::find_if(layout.connections.begin(), layout.connections.end(), [&](const auto& connection) {
+            return connection.id == guidance.installConnectionId;
+        });
+        if (it == layout.connections.end()) {
+            return std::nullopt;
+        }
+        if (!matchesFloor(it->floorId, currentFloorId)) {
+            return std::nullopt;
+        }
+        center = transform.map(connectionMarkerCenter(*it));
+    } else if (!guidance.guidedExitZoneId.empty()) {
+        const auto it = std::find_if(layout.zones.begin(), layout.zones.end(), [&](const auto& zone) {
+            return zone.id == guidance.guidedExitZoneId;
+        });
+        if (it == layout.zones.end() || it->kind != safecrowd::domain::ZoneKind::Exit) {
+            return std::nullopt;
+        }
+        if (!matchesFloor(it->floorId, currentFloorId)) {
+            return std::nullopt;
+        }
+        center = transform.map(polygonCenter(it->area));
+    } else {
+        return std::nullopt;
+    }
+
+    if (!center.has_value() || blocks.empty()) {
+        return center;
+    }
+
+    constexpr double kMinSeparationPixels = 28.0;
+    constexpr double kStackOffsetPixels = 34.0;
+
+    std::vector<QPointF> blockedCenters;
+    blockedCenters.reserve(blocks.size());
+    for (const auto& block : blocks) {
+        if (block.connectionId.empty()) {
+            continue;
+        }
+        const auto it = std::find_if(layout.connections.begin(), layout.connections.end(), [&](const auto& connection) {
+            return connection.id == block.connectionId;
+        });
+        if (it == layout.connections.end()) {
+            continue;
+        }
+        if (!matchesFloor(it->floorId, currentFloorId)) {
+            continue;
+        }
+        blockedCenters.push_back(transform.map(connectionMarkerCenter(*it)));
+    }
+    if (blockedCenters.empty()) {
+        return center;
+    }
+
+    const auto minDistanceToBlocks = [&](const QPointF& candidate) {
+        double minDistance = std::numeric_limits<double>::infinity();
+        for (const auto& blocked : blockedCenters) {
+            minDistance = std::min(minDistance, QLineF(candidate, blocked).length());
+        }
+        return minDistance;
+    };
+
+    const auto baseMinDistance = minDistanceToBlocks(*center);
+    if (baseMinDistance >= kMinSeparationPixels) {
+        return center;
+    }
+
+    const QPointF up = *center + QPointF(0.0, -kStackOffsetPixels);
+    const QPointF down = *center + QPointF(0.0, kStackOffsetPixels);
+    const auto upDistance = minDistanceToBlocks(up);
+    const auto downDistance = minDistanceToBlocks(down);
+    return upDistance >= downDistance ? up : down;
+}
+
+std::optional<std::size_t> hoveredRouteGuidanceIndex(
+    const safecrowd::domain::FacilityLayout2D& layout,
+    const std::vector<safecrowd::domain::RouteGuidanceDraft>& guidances,
+    const std::vector<safecrowd::domain::ConnectionBlockDraft>& blocks,
+    const LayoutCanvasTransform& transform,
+    const QString& currentFloorId,
+    const QPointF& screenPosition) {
+    constexpr double kHoverRadiusPixels = 14.0;
+
+    std::optional<std::size_t> closestIndex;
+    double closestDistanceSq = kHoverRadiusPixels * kHoverRadiusPixels;
+
+    for (std::size_t index = 0; index < guidances.size(); ++index) {
+        const auto& guidance = guidances[index];
+        const auto center = routeGuidanceMarkerCenter(layout, guidance, blocks, transform, currentFloorId);
+        if (!center.has_value()) {
+            continue;
+        }
+
+        const auto dx = center->x() - screenPosition.x();
+        const auto dy = center->y() - screenPosition.y();
         const auto distanceSq = (dx * dx) + (dy * dy);
         if (distanceSq <= closestDistanceSq) {
             closestDistanceSq = distanceSq;
@@ -449,6 +644,24 @@ QIcon makeToolIcon(const QString& type, const QColor& color) {
         return QIcon(pixmap);
     }
 
+    if (type == "guidance") {
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(color);
+        painter.save();
+        painter.translate(QPointF(22, 22));
+        painter.rotate(-25.0);
+        painter.translate(QPointF(-22, -22));
+        painter.drawRoundedRect(QRectF(18, 8, 10, 20), 3.0, 3.0);
+        painter.drawRoundedRect(QRectF(19, 28, 8, 9), 2.5, 2.5);
+        painter.restore();
+
+        painter.setPen(QPen(color, 2.8, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+        painter.drawLine(QPointF(32, 10), QPointF(36, 6));
+        painter.drawLine(QPointF(34, 15), QPointF(39, 13));
+        painter.drawLine(QPointF(29, 7), QPointF(31, 2));
+        return QIcon(pixmap);
+    }
+
     if (type != "group") {
         return QIcon(pixmap);
     }
@@ -633,6 +846,358 @@ private:
     std::vector<safecrowd::domain::ConnectionBlockIntervalDraft> intervals_{};
 };
 
+class RouteGuidanceSettingsDialog final : public QDialog {
+public:
+    explicit RouteGuidanceSettingsDialog(
+        safecrowd::domain::RouteGuidanceDraft guidance,
+        QWidget* parent = nullptr)
+        : QDialog(parent),
+          guidance_(std::move(guidance)) {
+        setWindowTitle("Route guidance settings");
+        setModal(true);
+
+        auto* root = new QVBoxLayout(this);
+        root->setContentsMargins(12, 12, 12, 12);
+        root->setSpacing(10);
+
+        auto* caption = new QLabel(
+            "Route guidance settings.\n"
+            "Period defines when the event is active.\n"
+            "Parameters control how strongly agents follow the guidance.\n"
+            "Target exit is selected by clicking an exit or a door on the canvas.",
+            this);
+        caption->setWordWrap(true);
+        root->addWidget(caption);
+
+        auto* form = new QWidget(this);
+        auto* formLayout = new QGridLayout(form);
+        formLayout->setContentsMargins(0, 0, 0, 0);
+        formLayout->setHorizontalSpacing(10);
+        formLayout->setVerticalSpacing(8);
+        root->addWidget(form);
+
+        int row = 0;
+        periodRowsContainer_ = nullptr;
+        alwaysPeriodLabel_ = nullptr;
+
+        {
+            auto* title = new QLabel("Period", this);
+            title->setStyleSheet("QLabel { font-weight: 600; color: #16202b; }");
+            formLayout->addWidget(title, row * 2, 0, Qt::AlignLeft);
+
+            periodRowsContainer_ = new QWidget(this);
+            periodRowsLayout_ = new QVBoxLayout(periodRowsContainer_);
+            periodRowsLayout_->setContentsMargins(0, 0, 0, 0);
+            periodRowsLayout_->setSpacing(6);
+            formLayout->addWidget(periodRowsContainer_, row * 2, 1, Qt::AlignLeft);
+
+            alwaysPeriodLabel_ = new QLabel("Always (no periods configured).", this);
+            alwaysPeriodLabel_->setStyleSheet("QLabel { color: #4f5d6b; }");
+            periodRowsLayout_->addWidget(alwaysPeriodLabel_);
+
+            auto* helpRow = new QWidget(this);
+            auto* helpLayout = new QHBoxLayout(helpRow);
+            helpLayout->setContentsMargins(0, 0, 0, 0);
+            helpLayout->setSpacing(8);
+
+            auto* helpLabel = new QLabel("Active time range for this guidance event.", this);
+            helpLabel->setWordWrap(true);
+            helpLabel->setStyleSheet("QLabel { color: #4f5d6b; font-size: 12px; }");
+            helpLayout->addWidget(helpLabel, 1);
+
+            addPeriodButton_ = new QPushButton("+", this);
+            addPeriodButton_->setToolTip("Add a period interval.");
+            addPeriodButton_->setStyleSheet(ui::secondaryButtonStyleSheet());
+            {
+                auto font = addPeriodButton_->font();
+                font.setPointSize(std::max(9, font.pointSize() - 1));
+                addPeriodButton_->setFont(font);
+            }
+            helpLayout->addWidget(addPeriodButton_, 0);
+
+            removePeriodButton_ = new QPushButton("-", this);
+            removePeriodButton_->setToolTip("Remove the last period interval.");
+            removePeriodButton_->setStyleSheet(ui::secondaryButtonStyleSheet());
+            {
+                auto font = removePeriodButton_->font();
+                font.setPointSize(std::max(9, font.pointSize() - 1));
+                removePeriodButton_->setFont(font);
+            }
+            helpLayout->addWidget(removePeriodButton_, 0);
+
+            formLayout->addWidget(helpRow, (row * 2) + 1, 0, 1, 2);
+
+            connect(addPeriodButton_, &QPushButton::clicked, this, [this]() {
+                addPeriodRow(std::nullopt);
+            });
+            connect(removePeriodButton_, &QPushButton::clicked, this, [this]() {
+                removeLastPeriodRow();
+            });
+
+            // Seed UI rows from existing guidance data.
+            if (!guidance_.periods.empty()) {
+                for (const auto& period : guidance_.periods) {
+                    addPeriodRow(period);
+                }
+            } else if (guidance_.endSeconds > 0.0 || guidance_.startSeconds > 0.0) {
+                addPeriodRow(safecrowd::domain::RouteGuidancePeriodDraft{
+                    .startSeconds = guidance_.startSeconds,
+                    .endSeconds = guidance_.endSeconds,
+                });
+            }
+
+            refreshPeriodUiState();
+            row++;
+        }
+
+        auto* paramsHeader = new QLabel("Parameters", this);
+        paramsHeader->setStyleSheet("QLabel { font-weight: 600; color: #16202b; }");
+        formLayout->addWidget(paramsHeader, row * 2, 0, 1, 2, Qt::AlignLeft);
+        row++;
+
+        baseComplianceRate_ = addField(
+            formLayout,
+            row++,
+            "Base compliance",
+            "Baseline compliance (0~1). Target group-average probability of following the guidance.",
+            0.0,
+            1.0,
+            0.01,
+            2,
+            std::clamp(guidance_.baseComplianceRate, 0.0, 1.0));
+
+        guidanceStrength_ = addField(
+            formLayout,
+            row++,
+            "Guidance strength",
+            "Guidance strength (0~1). Examples: signage 0.25 / broadcast 0.55 / staff control 0.85.",
+            0.0,
+            1.0,
+            0.01,
+            2,
+            std::clamp(guidance_.guidanceStrength, 0.0, 1.0));
+
+        maxDetourMeters_ = addField(
+            formLayout,
+            row++,
+            "Max detour (m)",
+            "Max detour tolerance in meters. Larger detours reduce compliance.",
+            0.0,
+            10'000.0,
+            1.0,
+            1,
+            std::max(0.0, guidance_.maxDetourMeters));
+
+        auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+        root->addWidget(buttons);
+        connect(buttons, &QDialogButtonBox::accepted, this, [this]() {
+            if (!applyFromUi()) {
+                return;
+            }
+            accept();
+        });
+        connect(buttons, &QDialogButtonBox::rejected, this, [this]() {
+            reject();
+        });
+    }
+
+    safecrowd::domain::RouteGuidanceDraft guidance() const {
+        return guidance_;
+    }
+
+private:
+    struct PeriodRowWidgets {
+        QWidget* root{nullptr};
+        QDoubleSpinBox* start{nullptr};
+        QDoubleSpinBox* end{nullptr};
+        QString startRaw{};
+        QString endRaw{};
+    };
+
+    void refreshPeriodUiState() {
+        const bool hasPeriods = !periodRows_.empty();
+        if (alwaysPeriodLabel_ != nullptr) {
+            alwaysPeriodLabel_->setVisible(!hasPeriods);
+        }
+        if (removePeriodButton_ != nullptr) {
+            removePeriodButton_->setEnabled(hasPeriods);
+        }
+    }
+
+    void addPeriodRow(std::optional<safecrowd::domain::RouteGuidancePeriodDraft> period) {
+        if (periodRowsContainer_ == nullptr || periodRowsLayout_ == nullptr) {
+            return;
+        }
+
+        auto row = std::make_unique<PeriodRowWidgets>();
+        row->root = new QWidget(this);
+        auto* layout = new QHBoxLayout(row->root);
+        layout->setContentsMargins(0, 0, 0, 0);
+        layout->setSpacing(8);
+
+        auto* startLabel = new QLabel("Start", this);
+        startLabel->setStyleSheet("QLabel { color: #4f5d6b; }");
+        layout->addWidget(startLabel);
+
+        row->start = new QDoubleSpinBox(this);
+        row->start->setRange(0.0, 1'000'000.0);
+        row->start->setDecimals(1);
+        row->start->setSingleStep(0.5);
+        row->start->setMinimumWidth(120);
+        row->start->setValue(period.has_value() ? std::max(0.0, period->startSeconds) : 0.0);
+        layout->addWidget(row->start);
+
+        auto* startUnit = new QLabel("sec", this);
+        startUnit->setStyleSheet("QLabel { color: #4f5d6b; }");
+        layout->addWidget(startUnit);
+
+        auto* endLabel = new QLabel("End", this);
+        endLabel->setStyleSheet("QLabel { color: #4f5d6b; }");
+        layout->addWidget(endLabel);
+
+        row->end = new QDoubleSpinBox(this);
+        row->end->setRange(0.0, 1'000'000.0);
+        row->end->setDecimals(1);
+        row->end->setSingleStep(0.5);
+        row->end->setMinimumWidth(120);
+        const auto seedEnd = period.has_value()
+            ? std::max(std::max(0.0, period->startSeconds), std::max(0.0, period->endSeconds))
+            : 10.0;
+        row->end->setValue(seedEnd);
+        layout->addWidget(row->end);
+
+        auto* endUnit = new QLabel("sec", this);
+        endUnit->setStyleSheet("QLabel { color: #4f5d6b; }");
+        layout->addWidget(endUnit);
+
+        layout->addStretch(1);
+
+        periodRowsLayout_->addWidget(row->root);
+        row->startRaw = row->start->text();
+        if (auto* edit = row->start->findChild<QLineEdit*>(); edit != nullptr) {
+            connect(edit, &QLineEdit::textEdited, this, [rowPtr = row.get()](const QString& text) {
+                if (rowPtr != nullptr) {
+                    rowPtr->startRaw = text;
+                }
+            });
+        }
+        row->endRaw = row->end->text();
+        if (auto* edit = row->end->findChild<QLineEdit*>(); edit != nullptr) {
+            connect(edit, &QLineEdit::textEdited, this, [rowPtr = row.get()](const QString& text) {
+                if (rowPtr != nullptr) {
+                    rowPtr->endRaw = text;
+                }
+            });
+        }
+
+        periodRows_.push_back(std::move(row));
+
+        refreshPeriodUiState();
+    }
+
+    void removeLastPeriodRow() {
+        if (periodRows_.empty()) {
+            return;
+        }
+        auto row = std::move(periodRows_.back());
+        periodRows_.pop_back();
+        if (row != nullptr && row->root != nullptr) {
+            row->root->deleteLater();
+        }
+        refreshPeriodUiState();
+    }
+
+    QDoubleSpinBox* addField(
+        QGridLayout* layout,
+        int row,
+        const QString& label,
+        const QString& help,
+        double min,
+        double max,
+        double step,
+        int decimals,
+        double value) {
+        auto* title = new QLabel(label, this);
+        title->setStyleSheet("QLabel { color: #16202b; }");
+        layout->addWidget(title, row * 2, 0, Qt::AlignLeft);
+
+        auto* spin = new QDoubleSpinBox(this);
+        spin->setRange(min, max);
+        spin->setDecimals(decimals);
+        spin->setSingleStep(step);
+        spin->setValue(value);
+        spin->setMinimumWidth(140);
+        spin->setToolTip(help);
+        layout->addWidget(spin, row * 2, 1, Qt::AlignLeft);
+
+        auto* helpLabel = new QLabel(help, this);
+        helpLabel->setWordWrap(true);
+        helpLabel->setStyleSheet("QLabel { color: #4f5d6b; font-size: 12px; }");
+        layout->addWidget(helpLabel, (row * 2) + 1, 0, 1, 2);
+        return spin;
+    }
+
+    bool applyFromUi() {
+        auto validateNonNegative = [&](const QString& rawText, QDoubleSpinBox* spin, QString* rawOut) -> bool {
+            if (rawText.isEmpty()) {
+                return true;
+            }
+            bool ok = false;
+            const auto typedValue = rawText.toDouble(&ok);
+            if (ok && typedValue < 0.0) {
+                QMessageBox::information(this, "Invalid value", "Only numbers greater than or equal to 0 can be entered.");
+                spin->setValue(0.0);
+                if (rawOut != nullptr) {
+                    *rawOut = spin->text();
+                }
+                return false;
+            }
+            return true;
+        };
+
+        guidance_.periods.clear();
+        for (const auto& rowPtr : periodRows_) {
+            if (rowPtr == nullptr || rowPtr->start == nullptr || rowPtr->end == nullptr) {
+                continue;
+            }
+            if (!validateNonNegative(rowPtr->startRaw, rowPtr->start, &rowPtr->startRaw)) {
+                return false;
+            }
+            if (!validateNonNegative(rowPtr->endRaw, rowPtr->end, &rowPtr->endRaw)) {
+                return false;
+            }
+            const auto start = std::max(0.0, rowPtr->start->value());
+            const auto end = std::max(start, std::max(0.0, rowPtr->end->value()));
+            guidance_.periods.push_back({.startSeconds = start, .endSeconds = end});
+        }
+
+        // Keep legacy scalar fields in sync for older views.
+        if (!guidance_.periods.empty()) {
+            guidance_.startSeconds = guidance_.periods.front().startSeconds;
+            guidance_.endSeconds = guidance_.periods.front().endSeconds;
+        } else {
+            guidance_.startSeconds = 0.0;
+            guidance_.endSeconds = 0.0;
+        }
+
+        guidance_.baseComplianceRate = std::clamp(baseComplianceRate_->value(), 0.0, 1.0);
+        guidance_.guidanceStrength = std::clamp(guidanceStrength_->value(), 0.0, 1.0);
+        guidance_.maxDetourMeters = std::max(0.0, maxDetourMeters_->value());
+        return true;
+    }
+
+    safecrowd::domain::RouteGuidanceDraft guidance_{};
+    QWidget* periodRowsContainer_{nullptr};
+    QVBoxLayout* periodRowsLayout_{nullptr};
+    QLabel* alwaysPeriodLabel_{nullptr};
+    QPushButton* addPeriodButton_{nullptr};
+    QPushButton* removePeriodButton_{nullptr};
+    std::vector<std::unique_ptr<PeriodRowWidgets>> periodRows_{};
+    QDoubleSpinBox* baseComplianceRate_{nullptr};
+    QDoubleSpinBox* guidanceStrength_{nullptr};
+    QDoubleSpinBox* maxDetourMeters_{nullptr};
+};
+
 }  // namespace
 
 ScenarioCanvasWidget::ScenarioCanvasWidget(
@@ -679,6 +1244,16 @@ void ScenarioCanvasWidget::setConnectionBlocksChangedHandler(std::function<void(
     connectionBlocksChangedHandler_ = std::move(handler);
 }
 
+void ScenarioCanvasWidget::setRouteGuidances(std::vector<safecrowd::domain::RouteGuidanceDraft> guidances) {
+    routeGuidances_ = std::move(guidances);
+    update();
+}
+
+void ScenarioCanvasWidget::setRouteGuidancesChangedHandler(
+    std::function<void(const std::vector<safecrowd::domain::RouteGuidanceDraft>&)> handler) {
+    routeGuidancesChangedHandler_ = std::move(handler);
+}
+
 void ScenarioCanvasWidget::setLayoutElementActivatedHandler(std::function<void(const QString&)> handler) {
     layoutElementActivatedHandler_ = std::move(handler);
 }
@@ -710,19 +1285,36 @@ void ScenarioCanvasWidget::focusLayoutElement(const QString& elementId) {
 void ScenarioCanvasWidget::activateLayoutElement(const QString& elementId) {
     focusLayoutElement(elementId);
 
-    if (toolMode_ != ToolMode::BlockDoor) {
+    if (toolMode_ == ToolMode::BlockDoor) {
+        const auto targetId = elementId.toStdString();
+        const auto it = std::find_if(layout_.connections.begin(), layout_.connections.end(), [&](const auto& connection) {
+            return connection.id == targetId;
+        });
+        if (it == layout_.connections.end()) {
+            return;
+        }
+        addConnectionBlockForConnection(*it);
         return;
     }
 
-    const auto targetId = elementId.toStdString();
-    const auto it = std::find_if(layout_.connections.begin(), layout_.connections.end(), [&](const auto& connection) {
-        return connection.id == targetId;
-    });
-    if (it == layout_.connections.end()) {
-        return;
-    }
+    if (toolMode_ == ToolMode::RouteGuidance) {
+        const auto targetId = elementId.toStdString();
+        const auto it = std::find_if(layout_.zones.begin(), layout_.zones.end(), [&](const auto& zone) {
+            return zone.id == targetId;
+        });
+        if (it != layout_.zones.end() && it->kind == safecrowd::domain::ZoneKind::Exit) {
+            addRouteGuidanceForExitZone(*it);
+            return;
+        }
 
-    addConnectionBlockForConnection(*it);
+        const auto connectionIt = std::find_if(layout_.connections.begin(), layout_.connections.end(), [&](const auto& connection) {
+            return connection.id == targetId;
+        });
+        if (connectionIt == layout_.connections.end()) {
+            return;
+        }
+        addRouteGuidanceForConnection(*connectionIt);
+    }
 }
 
 void ScenarioCanvasWidget::focusPlacement(const QString& placementId) {
@@ -762,6 +1354,7 @@ void ScenarioCanvasWidget::keyReleaseEvent(QKeyEvent* event) {
 
 void ScenarioCanvasWidget::leaveEvent(QEvent* event) {
     hoveredConnectionBlockId_.clear();
+    hoveredRouteGuidanceId_.clear();
     QToolTip::hideText();
     QWidget::leaveEvent(event);
 }
@@ -783,8 +1376,9 @@ void ScenarioCanvasWidget::mouseMoveEvent(QMouseEvent* event) {
     }
 
     if (dragging_) {
-        if (!hoveredConnectionBlockId_.isEmpty()) {
+        if (!hoveredConnectionBlockId_.isEmpty() || !hoveredRouteGuidanceId_.isEmpty()) {
             hoveredConnectionBlockId_.clear();
+            hoveredRouteGuidanceId_.clear();
             QToolTip::hideText();
         }
         dragCurrent_ = event->position();
@@ -793,8 +1387,9 @@ void ScenarioCanvasWidget::mouseMoveEvent(QMouseEvent* event) {
         return;
     }
     if (selectionDragging_) {
-        if (!hoveredConnectionBlockId_.isEmpty()) {
+        if (!hoveredConnectionBlockId_.isEmpty() || !hoveredRouteGuidanceId_.isEmpty()) {
             hoveredConnectionBlockId_.clear();
+            hoveredRouteGuidanceId_.clear();
             QToolTip::hideText();
         }
         selectionDragCurrent_ = event->position();
@@ -805,21 +1400,42 @@ void ScenarioCanvasWidget::mouseMoveEvent(QMouseEvent* event) {
 
     if (const auto bounds = collectBounds(); bounds.has_value()) {
         const auto transform = currentTransform(*bounds);
-        const auto hoveredIndex = hoveredConnectionBlockIndex(layout_, connectionBlocks_, transform, currentFloorId_, event->position());
-        if (!hoveredIndex.has_value()) {
-            if (!hoveredConnectionBlockId_.isEmpty()) {
+        const auto hoveredGuidance = hoveredRouteGuidanceIndex(
+            layout_,
+            routeGuidances_,
+            connectionBlocks_,
+            transform,
+            currentFloorId_,
+            event->position());
+        const auto hoveredBlock = hoveredConnectionBlockIndex(layout_, connectionBlocks_, transform, currentFloorId_, event->position());
+
+        if (hoveredGuidance.has_value()) {
+            const auto& guidance = routeGuidances_[*hoveredGuidance];
+            const auto tooltip = formatRouteGuidanceTooltip(guidance);
+            const auto hoveredId = QString::fromStdString(guidance.id.empty()
+                ? (!guidance.installConnectionId.empty() ? guidance.installConnectionId : guidance.guidedExitZoneId)
+                : guidance.id);
+            if (hoveredId != hoveredRouteGuidanceId_) {
+                hoveredRouteGuidanceId_ = hoveredId;
                 hoveredConnectionBlockId_.clear();
-                QToolTip::hideText();
+                QToolTip::showText(event->globalPosition().toPoint(), tooltip, this);
             }
-        } else {
-            const auto& block = connectionBlocks_[*hoveredIndex];
+        } else if (hoveredBlock.has_value()) {
+            const auto& block = connectionBlocks_[*hoveredBlock];
             const auto tooltip = formatConnectionBlockTooltip(block);
             if (!tooltip.isEmpty()) {
                 const auto hoveredId = QString::fromStdString(block.id.empty() ? block.connectionId : block.id);
                 if (hoveredId != hoveredConnectionBlockId_) {
                     hoveredConnectionBlockId_ = hoveredId;
+                    hoveredRouteGuidanceId_.clear();
                     QToolTip::showText(event->globalPosition().toPoint(), tooltip, this);
                 }
+            }
+        } else {
+            if (!hoveredConnectionBlockId_.isEmpty() || !hoveredRouteGuidanceId_.isEmpty()) {
+                hoveredConnectionBlockId_.clear();
+                hoveredRouteGuidanceId_.clear();
+                QToolTip::hideText();
             }
         }
     }
@@ -854,6 +1470,28 @@ void ScenarioCanvasWidget::mousePressEvent(QMouseEvent* event) {
         const auto dx = offsetPoint.x - point.x;
         const auto dy = offsetPoint.y - point.y;
         const auto hitTolerance = std::max(1.2, std::hypot(dx, dy));
+
+        if (const auto bounds = collectBounds(); bounds.has_value()) {
+            const auto transform = currentTransform(*bounds);
+            constexpr double kHitTolerancePixels = 18.0;
+            for (const auto& guidance : routeGuidances_) {
+                const auto center = routeGuidanceMarkerCenter(
+                    layout_,
+                    guidance,
+                    connectionBlocks_,
+                    transform,
+                    currentFloorId_);
+                if (!center.has_value()) {
+                    continue;
+                }
+                if (QLineF(event->position(), *center).length() <= kHitTolerancePixels) {
+                    openRouteGuidanceEditor(QString::fromStdString(guidance.id), event->globalPosition().toPoint());
+                    event->accept();
+                    return;
+                }
+            }
+        }
+
         for (const auto& block : connectionBlocks_) {
             if (block.connectionId.empty()) {
                 continue;
@@ -904,6 +1542,12 @@ void ScenarioCanvasWidget::mousePressEvent(QMouseEvent* event) {
 
     if (toolMode_ == ToolMode::BlockDoor) {
         addConnectionBlock(event->position());
+        event->accept();
+        return;
+    }
+
+    if (toolMode_ == ToolMode::RouteGuidance) {
+        addRouteGuidance(event->position());
         event->accept();
         return;
     }
@@ -1018,6 +1662,7 @@ void ScenarioCanvasWidget::paintEvent(QPaintEvent* event) {
     }
     drawFocusedPlacement(painter, transform);
     drawConnectionBlocks(painter, transform);
+    drawRouteGuidances(painter, transform);
 
     if (dragging_ || selectionDragging_) {
         const auto start = dragging_ ? dragStart_ : selectionDragStart_;
@@ -1186,6 +1831,44 @@ void ScenarioCanvasWidget::drawConnectionBlocks(QPainter& painter, const LayoutC
         const double r = 10.0;
         painter.drawEllipse(center, r, r);
         painter.drawLine(QPointF(center.x() - 6.5, center.y() + 6.5), QPointF(center.x() + 6.5, center.y() - 6.5));
+    }
+}
+
+void ScenarioCanvasWidget::drawRouteGuidances(QPainter& painter, const LayoutCanvasTransform& transform) const {
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(QColor("#1f5fae"));
+
+    for (const auto& guidance : routeGuidances_) {
+        const auto center = routeGuidanceMarkerCenter(
+            layout_,
+            guidance,
+            connectionBlocks_,
+            transform,
+            currentFloorId_);
+        if (!center.has_value()) {
+            continue;
+        }
+
+        const QPointF markerCenter = *center;
+
+        const double r = 10.0;
+        painter.setBrush(QColor("#1f5fae"));
+        painter.drawEllipse(markerCenter, r, r);
+
+        painter.save();
+        painter.translate(markerCenter);
+        painter.rotate(-25.0);
+        painter.translate(-markerCenter);
+        painter.setBrush(Qt::white);
+        painter.drawRoundedRect(QRectF(markerCenter.x() - 1.8, markerCenter.y() - 7.0, 3.6, 10.5), 1.4, 1.4);
+        painter.drawRoundedRect(QRectF(markerCenter.x() - 1.5, markerCenter.y() + 2.2, 3.0, 5.2), 1.2, 1.2);
+        painter.restore();
+
+        painter.setPen(QPen(Qt::white, 1.7, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+        painter.drawLine(QPointF(markerCenter.x() + 5.3, markerCenter.y() - 5.0), QPointF(markerCenter.x() + 8.2, markerCenter.y() - 7.7));
+        painter.drawLine(QPointF(markerCenter.x() + 6.3, markerCenter.y() - 2.0), QPointF(markerCenter.x() + 9.2, markerCenter.y() - 2.8));
+        painter.drawLine(QPointF(markerCenter.x() + 3.7, markerCenter.y() - 7.2), QPointF(markerCenter.x() + 4.8, markerCenter.y() - 9.8));
+        painter.setPen(Qt::NoPen);
     }
 }
 
@@ -1530,6 +2213,10 @@ QString ScenarioCanvasWidget::nextConnectionBlockId() const {
     return QString("block-%1").arg(static_cast<int>(connectionBlocks_.size()) + 1);
 }
 
+QString ScenarioCanvasWidget::nextRouteGuidanceId() const {
+    return QString("guidance-%1").arg(static_cast<int>(routeGuidances_.size()) + 1);
+}
+
 void ScenarioCanvasWidget::addGroupPlacement(const QPointF& start, const QPointF& end) {
     if ((QLineF(start, end).length()) < 8.0) {
         return;
@@ -1691,6 +2378,114 @@ void ScenarioCanvasWidget::addConnectionBlockForConnection(const safecrowd::doma
     update();
 }
 
+void ScenarioCanvasWidget::addRouteGuidance(const QPointF& position) {
+    const auto point = unmapPoint(position);
+    const auto zoneId = zoneAt(point);
+    if (!zoneId.isEmpty()) {
+        const auto zoneIdStd = zoneId.toStdString();
+        const auto it = std::find_if(layout_.zones.begin(), layout_.zones.end(), [&](const auto& zone) {
+            return zone.id == zoneIdStd;
+        });
+        if (it != layout_.zones.end() && it->kind == safecrowd::domain::ZoneKind::Exit) {
+            addRouteGuidanceForExitZone(*it);
+            return;
+        }
+        // If the user clicked inside a non-exit zone, still allow installing guidance by selecting a nearby door.
+    }
+
+    constexpr double kPickRadiusPixels = 18.0;
+    const auto offsetPoint = unmapPoint(position + QPointF(kPickRadiusPixels, 0.0));
+    const auto dx = offsetPoint.x - point.x;
+    const auto dy = offsetPoint.y - point.y;
+    const auto pixelToleranceWorldUnits = std::hypot(dx, dy);
+    const auto toleranceWorldUnits = std::max(1.2, pixelToleranceWorldUnits);
+
+    const safecrowd::domain::Connection2D* connection = nullptr;
+    double bestDistance = toleranceWorldUnits;
+    for (const auto& candidate : layout_.connections) {
+        if (!matchesFloor(candidate.floorId, currentFloorId_)) {
+            continue;
+        }
+        if (candidate.kind != safecrowd::domain::ConnectionKind::Doorway
+            && candidate.kind != safecrowd::domain::ConnectionKind::Exit) {
+            continue;
+        }
+        const auto halfWidth = std::max(0.0, candidate.effectiveWidth * 0.5);
+        const auto distance =
+            std::max(0.0, distancePointToSegment(point, candidate.centerSpan.start, candidate.centerSpan.end) - halfWidth);
+        if (distance <= bestDistance) {
+            bestDistance = distance;
+            connection = &candidate;
+        }
+    }
+
+    if (connection == nullptr) {
+        QMessageBox::information(this, "Route guidance", "Click an exit zone or a door to install guidance.");
+        return;
+    }
+
+    addRouteGuidanceForConnection(*connection);
+}
+
+void ScenarioCanvasWidget::addRouteGuidanceForExitZone(const safecrowd::domain::Zone2D& zone) {
+    if (zone.kind != safecrowd::domain::ZoneKind::Exit) {
+        QMessageBox::information(this, "Route guidance", "This tool can only be used on exit zones.");
+        return;
+    }
+
+    for (const auto& existing : routeGuidances_) {
+        if (existing.installConnectionId.empty() && existing.guidedExitZoneId == zone.id) {
+            QMessageBox::information(this, "Route guidance", "Guidance is already installed on this exit.");
+            return;
+        }
+    }
+
+    safecrowd::domain::RouteGuidanceDraft draft;
+    draft.id = nextRouteGuidanceId().toStdString();
+    draft.startSeconds = 0.0;
+    draft.endSeconds = 0.0;
+    draft.periods.clear();
+    draft.guidedExitZoneId = zone.id;
+    draft.installConnectionId.clear();
+    draft.baseComplianceRate = 0.5;
+    draft.guidanceStrength = 0.55;
+    draft.maxDetourMeters = 20.0;
+    routeGuidances_.push_back(std::move(draft));
+    emitRouteGuidancesChanged();
+    update();
+}
+
+void ScenarioCanvasWidget::addRouteGuidanceForConnection(const safecrowd::domain::Connection2D& connection) {
+    if (connection.kind != safecrowd::domain::ConnectionKind::Doorway
+        && connection.kind != safecrowd::domain::ConnectionKind::Exit) {
+        QMessageBox::information(this, "Route guidance", "This tool can only be used on exit zones or doors.");
+        return;
+    }
+
+    for (const auto& existing : routeGuidances_) {
+        if (!existing.installConnectionId.empty() && existing.installConnectionId == connection.id) {
+            QMessageBox::information(this, "Route guidance", "Guidance is already installed on this door.");
+            return;
+        }
+    }
+
+    const auto exitZoneId = pickNearestExitZoneIdForConnection(layout_, connection);
+
+    safecrowd::domain::RouteGuidanceDraft draft;
+    draft.id = nextRouteGuidanceId().toStdString();
+    draft.startSeconds = 0.0;
+    draft.endSeconds = 0.0;
+    draft.periods.clear();
+    draft.guidedExitZoneId = exitZoneId;
+    draft.installConnectionId = connection.id;
+    draft.baseComplianceRate = 0.5;
+    draft.guidanceStrength = 0.55;
+    draft.maxDetourMeters = 20.0;
+    routeGuidances_.push_back(std::move(draft));
+    emitRouteGuidancesChanged();
+    update();
+}
+
 void ScenarioCanvasWidget::selectSingleAt(const QPointF& position, const LayoutCanvasTransform& transform) {
     const auto crowdElementId = placementAt(position, transform);
     if (!crowdElementId.isEmpty()) {
@@ -1817,6 +2612,39 @@ void ScenarioCanvasWidget::openConnectionBlockScheduleEditor(const QString& bloc
     update();
 }
 
+void ScenarioCanvasWidget::openRouteGuidanceEditor(const QString& guidanceId, const QPoint& screenPosition) {
+    QMenu menu(this);
+    auto* settingsAction = menu.addAction("Settings...");
+    auto* deleteAction = menu.addAction("Delete");
+    const auto* selected = menu.exec(screenPosition);
+    if (selected != settingsAction && selected != deleteAction) {
+        return;
+    }
+
+    auto it = std::find_if(routeGuidances_.begin(), routeGuidances_.end(), [&](const auto& guidance) {
+        return QString::fromStdString(guidance.id) == guidanceId;
+    });
+    if (it == routeGuidances_.end()) {
+        return;
+    }
+
+    if (selected == deleteAction) {
+        routeGuidances_.erase(it);
+        emitRouteGuidancesChanged();
+        update();
+        return;
+    }
+
+    RouteGuidanceSettingsDialog dialog(*it, this);
+    dialog.move(screenPosition);
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+    *it = dialog.guidance();
+    emitRouteGuidancesChanged();
+    update();
+}
+
 void ScenarioCanvasWidget::openCrowdPlacementContextMenu(const QString& crowdElementId, const QPoint& screenPosition) {
     QMenu menu(this);
     auto* deleteAction = menu.addAction("Delete");
@@ -1910,6 +2738,12 @@ void ScenarioCanvasWidget::emitConnectionBlocksChanged() {
     }
 }
 
+void ScenarioCanvasWidget::emitRouteGuidancesChanged() {
+    if (routeGuidancesChangedHandler_) {
+        routeGuidancesChangedHandler_(routeGuidances_);
+    }
+}
+
 void ScenarioCanvasWidget::repositionToolbars() {
     if (topToolbar_ != nullptr) {
         topToolbar_->setGeometry(0, 0, width(), kTopToolbarHeight);
@@ -1934,6 +2768,9 @@ void ScenarioCanvasWidget::setToolMode(ToolMode mode) {
     }
     if (blockDoorToolButton_ != nullptr) {
         blockDoorToolButton_->setChecked(mode == ToolMode::BlockDoor);
+    }
+    if (routeGuidanceToolButton_ != nullptr) {
+        routeGuidanceToolButton_->setChecked(mode == ToolMode::RouteGuidance);
     }
     if (groupCountLabel_ != nullptr) {
         groupCountLabel_->setVisible(mode == ToolMode::GroupPlacement);
@@ -1986,6 +2823,7 @@ void ScenarioCanvasWidget::setupToolbars() {
     individualToolButton_ = makeButton(makeToolIcon("individual", QColor("#1f5fae")), "Add Individual Occupant");
     groupToolButton_ = makeButton(makeToolIcon("group", QColor("#1f5fae")), "Add Occupant Group");
     blockDoorToolButton_ = makeButton(makeToolIcon("block", QColor("#c0392b")), "block door");
+    routeGuidanceToolButton_ = makeButton(makeToolIcon("guidance", QColor("#1f5fae")), "Route guidance");
     topLayout->addStretch(1);
 
     groupCountLabel_ = new QLabel("Group count", propertyPanel_);
@@ -2009,6 +2847,7 @@ void ScenarioCanvasWidget::setupToolbars() {
     connect(individualToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::IndividualPlacement); });
     connect(groupToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::GroupPlacement); });
     connect(blockDoorToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::BlockDoor); });
+    connect(routeGuidanceToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::RouteGuidance); });
 
     setToolMode(ToolMode::Select);
     repositionToolbars();

--- a/src/application/ScenarioCanvasWidget.h
+++ b/src/application/ScenarioCanvasWidget.h
@@ -67,6 +67,7 @@ protected:
     bool eventFilter(QObject* watched, QEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void keyReleaseEvent(QKeyEvent* event) override;
+    void leaveEvent(QEvent* event) override;
     void mouseDoubleClickEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
@@ -145,6 +146,7 @@ private:
     QSpinBox* groupCountSpinBox_{nullptr};
     QLabel* groupDistributionLabel_{nullptr};
     QComboBox* groupDistributionComboBox_{nullptr};
+    QString hoveredConnectionBlockId_{};
     std::function<void(const QString&)> layoutElementActivatedHandler_{};
     std::function<void(const QString&)> crowdSelectionChangedHandler_{};
     std::function<void(const std::vector<ScenarioCrowdPlacement>&)> placementsChangedHandler_{};

--- a/src/application/ScenarioCanvasWidget.h
+++ b/src/application/ScenarioCanvasWidget.h
@@ -57,6 +57,8 @@ public:
     void setPlacementsChangedHandler(std::function<void(const std::vector<ScenarioCrowdPlacement>&)> handler);
     void setConnectionBlocks(std::vector<safecrowd::domain::ConnectionBlockDraft> blocks);
     void setConnectionBlocksChangedHandler(std::function<void(const std::vector<safecrowd::domain::ConnectionBlockDraft>&)> handler);
+    void setRouteGuidances(std::vector<safecrowd::domain::RouteGuidanceDraft> guidances);
+    void setRouteGuidancesChangedHandler(std::function<void(const std::vector<safecrowd::domain::RouteGuidanceDraft>&)> handler);
     void setLayoutElementActivatedHandler(std::function<void(const QString&)> handler);
     void setCrowdSelectionChangedHandler(std::function<void(const QString&)> handler);
     void focusLayoutElement(const QString& elementId);
@@ -82,6 +84,7 @@ private:
         IndividualPlacement,
         GroupPlacement,
         BlockDoor,
+        RouteGuidance,
     };
 
     std::optional<LayoutCanvasBounds> collectBounds() const;
@@ -101,10 +104,15 @@ private:
     safecrowd::domain::Point2D defaultVelocityFrom(const safecrowd::domain::Point2D& point) const;
     QString nextPlacementId(ScenarioCrowdPlacementKind kind) const;
     QString nextConnectionBlockId() const;
+    QString nextRouteGuidanceId() const;
     void addGroupPlacement(const QPointF& start, const QPointF& end);
     void addIndividualPlacement(const QPointF& position);
     void addConnectionBlock(const QPointF& position);
     void addConnectionBlockForConnection(const safecrowd::domain::Connection2D& connection);
+    void addRouteGuidance(const QPointF& position);
+    void addRouteGuidanceForExitZone(const safecrowd::domain::Zone2D& zone);
+    void addRouteGuidanceForConnection(const safecrowd::domain::Connection2D& connection);
+    void openRouteGuidanceEditor(const QString& guidanceId, const QPoint& screenPosition);
     void selectSingleAt(const QPointF& position, const LayoutCanvasTransform& transform);
     void selectPlacementsInRect(const QRectF& screenRect, const LayoutCanvasTransform& transform);
     void selectLayoutElementAt(const QPointF& position);
@@ -114,8 +122,10 @@ private:
     void drawFocusedLayoutElement(QPainter& painter, const LayoutCanvasTransform& transform) const;
     void drawFocusedPlacement(QPainter& painter, const LayoutCanvasTransform& transform) const;
     void drawConnectionBlocks(QPainter& painter, const LayoutCanvasTransform& transform) const;
+    void drawRouteGuidances(QPainter& painter, const LayoutCanvasTransform& transform) const;
     void emitPlacementsChanged();
     void emitConnectionBlocksChanged();
+    void emitRouteGuidancesChanged();
     void repositionToolbars();
     void setToolMode(ToolMode mode);
     void setupToolbars();
@@ -123,6 +133,7 @@ private:
     safecrowd::domain::FacilityLayout2D layout_{};
     std::vector<ScenarioCrowdPlacement> placements_{};
     std::vector<safecrowd::domain::ConnectionBlockDraft> connectionBlocks_{};
+    std::vector<safecrowd::domain::RouteGuidanceDraft> routeGuidances_{};
     QString currentFloorId_{};
     QString focusedLayoutElementId_{};
     QString focusedCrowdElementId_{};
@@ -142,15 +153,18 @@ private:
     QToolButton* individualToolButton_{nullptr};
     QToolButton* groupToolButton_{nullptr};
     QToolButton* blockDoorToolButton_{nullptr};
+    QToolButton* routeGuidanceToolButton_{nullptr};
     QLabel* groupCountLabel_{nullptr};
     QSpinBox* groupCountSpinBox_{nullptr};
     QLabel* groupDistributionLabel_{nullptr};
     QComboBox* groupDistributionComboBox_{nullptr};
     QString hoveredConnectionBlockId_{};
+    QString hoveredRouteGuidanceId_{};
     std::function<void(const QString&)> layoutElementActivatedHandler_{};
     std::function<void(const QString&)> crowdSelectionChangedHandler_{};
     std::function<void(const std::vector<ScenarioCrowdPlacement>&)> placementsChangedHandler_{};
     std::function<void(const std::vector<safecrowd::domain::ConnectionBlockDraft>&)> connectionBlocksChangedHandler_{};
+    std::function<void(const std::vector<safecrowd::domain::RouteGuidanceDraft>&)> routeGuidancesChangedHandler_{};
 };
 
 }  // namespace safecrowd::application

--- a/src/application/ScenarioRunWidget.cpp
+++ b/src/application/ScenarioRunWidget.cpp
@@ -199,6 +199,7 @@ ScenarioRunWidget::ScenarioRunWidget(
     });
     canvas_ = new SimulationCanvasWidget(layout_, shell_);
     canvas_->setConnectionBlocks(scenario_.control.connectionBlocks);
+    canvas_->setRouteGuidances(scenario_.control.routeGuidances);
     canvas_->setFrame(runner_.frame());
     shell_->setCanvas(canvas_);
     shell_->setReviewPanel(createRunPanel());

--- a/src/application/SimulationCanvasWidget.cpp
+++ b/src/application/SimulationCanvasWidget.cpp
@@ -16,6 +16,7 @@
 #include <QRadialGradient>
 #include <QResizeEvent>
 #include <QSignalBlocker>
+#include <QToolTip>
 #include <QWheelEvent>
 
 namespace safecrowd::application {
@@ -91,6 +92,65 @@ QColor densityHeatmapColor(double ratio, int alpha) {
         return QColor(249, 115, 22, alpha);
     }
     return QColor(220, 38, 38, alpha);
+}
+
+QString formatScheduleTooltip(const safecrowd::domain::ConnectionBlockDraft& block) {
+    if (block.connectionId.empty()) {
+        return {};
+    }
+
+    QString text = QStringLiteral("차단 스케줄");
+    if (block.intervals.empty()) {
+        text.append("\n- 항상 차단");
+        return text;
+    }
+
+    for (const auto& interval : block.intervals) {
+        const auto start = std::max(0.0, interval.startSeconds);
+        const auto end = std::max(start, interval.endSeconds);
+        text.append(QString("\n- %1s ~ %2s").arg(start, 0, 'f', 1).arg(end, 0, 'f', 1));
+    }
+    return text;
+}
+
+std::optional<std::size_t> hoveredBlockedConnectionIndex(
+    const safecrowd::domain::FacilityLayout2D& layout,
+    const std::vector<safecrowd::domain::ConnectionBlockDraft>& blocks,
+    const LayoutCanvasTransform& transform,
+    const std::string& currentFloorId,
+    double elapsedSeconds,
+    const QPointF& screenPosition) {
+    constexpr double kHoverRadiusPixels = 14.0;
+
+    std::optional<std::size_t> closestIndex;
+    double closestDistanceSq = kHoverRadiusPixels * kHoverRadiusPixels;
+
+    for (std::size_t index = 0; index < blocks.size(); ++index) {
+        const auto& block = blocks[index];
+        if (!connectionShouldBeBlocked(block, elapsedSeconds)) {
+            continue;
+        }
+        const auto it = std::find_if(layout.connections.begin(), layout.connections.end(), [&](const auto& connection) {
+            return connection.id == block.connectionId;
+        });
+        if (it == layout.connections.end()) {
+            continue;
+        }
+        if (!matchesFloor(it->floorId, currentFloorId)) {
+            continue;
+        }
+
+        const auto center = transform.map(connectionCenter(*it));
+        const auto dx = center.x() - screenPosition.x();
+        const auto dy = center.y() - screenPosition.y();
+        const auto distanceSq = (dx * dx) + (dy * dy);
+        if (distanceSq <= closestDistanceSq) {
+            closestDistanceSq = distanceSq;
+            closestIndex = index;
+        }
+    }
+
+    return closestIndex;
 }
 
 }  // namespace
@@ -211,6 +271,12 @@ void SimulationCanvasWidget::keyReleaseEvent(QKeyEvent* event) {
     QWidget::keyReleaseEvent(event);
 }
 
+void SimulationCanvasWidget::leaveEvent(QEvent* event) {
+    hoveredConnectionBlockId_.clear();
+    QToolTip::hideText();
+    QWidget::leaveEvent(event);
+}
+
 void SimulationCanvasWidget::mouseDoubleClickEvent(QMouseEvent* event) {
     if (event->button() == Qt::LeftButton) {
         camera_.reset();
@@ -227,6 +293,48 @@ void SimulationCanvasWidget::mouseMoveEvent(QMouseEvent* event) {
         layoutCacheValid_ = false;
         update();
         return;
+    }
+
+    const auto bounds = collectBounds();
+    if (!bounds.has_value()) {
+        if (!hoveredConnectionBlockId_.empty()) {
+            hoveredConnectionBlockId_.clear();
+            QToolTip::hideText();
+        }
+        QWidget::mouseMoveEvent(event);
+        return;
+    }
+
+    const auto transform = currentTransform(*bounds);
+    const auto elapsedSeconds = std::max(0.0, frame_.elapsedSeconds);
+    const auto hoveredIndex = hoveredBlockedConnectionIndex(
+        layout_,
+        connectionBlocks_,
+        transform,
+        currentFloorId_,
+        elapsedSeconds,
+        event->position());
+
+    if (!hoveredIndex.has_value()) {
+        if (!hoveredConnectionBlockId_.empty()) {
+            hoveredConnectionBlockId_.clear();
+            QToolTip::hideText();
+        }
+        QWidget::mouseMoveEvent(event);
+        return;
+    }
+
+    const auto& block = connectionBlocks_[*hoveredIndex];
+    const auto tooltip = formatScheduleTooltip(block);
+    if (tooltip.isEmpty()) {
+        QWidget::mouseMoveEvent(event);
+        return;
+    }
+
+    const auto hoveredId = block.id.empty() ? block.connectionId : block.id;
+    if (hoveredId != hoveredConnectionBlockId_) {
+        hoveredConnectionBlockId_ = hoveredId;
+        QToolTip::showText(event->globalPosition().toPoint(), tooltip, this);
     }
     QWidget::mouseMoveEvent(event);
 }

--- a/src/application/SimulationCanvasWidget.cpp
+++ b/src/application/SimulationCanvasWidget.cpp
@@ -133,10 +133,11 @@ QString formatRouteGuidanceTooltip(const safecrowd::domain::RouteGuidanceDraft& 
     if (guidance.periods.empty()) {
         text.append(QStringLiteral("\n Always"));
     } else {
-        const auto& period = guidance.periods.front();
-        const auto start = std::max(0.0, period.startSeconds);
-        const auto end = std::max(start, std::max(0.0, period.endSeconds));
-        text.append(QString("\n %1s~%2s").arg(start, 0, 'f', 1).arg(end, 0, 'f', 1));
+        for (const auto& period : guidance.periods) {
+            const auto start = std::max(0.0, period.startSeconds);
+            const auto end = std::max(start, std::max(0.0, period.endSeconds));
+            text.append(QString("\n %1s~%2s").arg(start, 0, 'f', 1).arg(end, 0, 'f', 1));
+        }
     }
     text.append(QString("\n Base compliance: %1").arg(std::clamp(guidance.baseComplianceRate, 0.0, 1.0), 0, 'f', 2));
     text.append(QString("\n Strength: %1").arg(std::clamp(guidance.guidanceStrength, 0.0, 1.0), 0, 'f', 2));

--- a/src/application/SimulationCanvasWidget.cpp
+++ b/src/application/SimulationCanvasWidget.cpp
@@ -74,6 +74,21 @@ safecrowd::domain::Point2D connectionCenter(const safecrowd::domain::Connection2
     };
 }
 
+safecrowd::domain::Point2D polygonCenter(const safecrowd::domain::Polygon2D& polygon) {
+    if (polygon.outline.empty()) {
+        return {};
+    }
+
+    double x = 0.0;
+    double y = 0.0;
+    for (const auto& point : polygon.outline) {
+        x += point.x;
+        y += point.y;
+    }
+    const auto count = static_cast<double>(polygon.outline.size());
+    return {.x = x / count, .y = y / count};
+}
+
 QColor densityHeatmapColor(double ratio, int alpha) {
     const auto t = std::clamp(ratio, 0.0, 1.0);
     if (t < 0.22) {
@@ -99,9 +114,9 @@ QString formatScheduleTooltip(const safecrowd::domain::ConnectionBlockDraft& blo
         return {};
     }
 
-    QString text = QStringLiteral("차단 스케줄");
+    QString text = QStringLiteral("Block schedule");
     if (block.intervals.empty()) {
-        text.append("\n- 항상 차단");
+        text.append("\n- Block always");
         return text;
     }
 
@@ -110,6 +125,22 @@ QString formatScheduleTooltip(const safecrowd::domain::ConnectionBlockDraft& blo
         const auto end = std::max(start, interval.endSeconds);
         text.append(QString("\n- %1s ~ %2s").arg(start, 0, 'f', 1).arg(end, 0, 'f', 1));
     }
+    return text;
+}
+
+QString formatRouteGuidanceTooltip(const safecrowd::domain::RouteGuidanceDraft& guidance) {
+    QString text = QStringLiteral("Route guidance");
+    if (guidance.periods.empty()) {
+        text.append(QStringLiteral("\n Always"));
+    } else {
+        const auto& period = guidance.periods.front();
+        const auto start = std::max(0.0, period.startSeconds);
+        const auto end = std::max(start, std::max(0.0, period.endSeconds));
+        text.append(QString("\n %1s~%2s").arg(start, 0, 'f', 1).arg(end, 0, 'f', 1));
+    }
+    text.append(QString("\n Base compliance: %1").arg(std::clamp(guidance.baseComplianceRate, 0.0, 1.0), 0, 'f', 2));
+    text.append(QString("\n Strength: %1").arg(std::clamp(guidance.guidanceStrength, 0.0, 1.0), 0, 'f', 2));
+    text.append(QString("\n Max detour:%1m").arg(std::max(0.0, guidance.maxDetourMeters), 0, 'f', 1));
     return text;
 }
 
@@ -153,6 +184,167 @@ std::optional<std::size_t> hoveredBlockedConnectionIndex(
     return closestIndex;
 }
 
+struct ActiveRouteGuidanceSelection {
+    std::size_t guidanceIndex{0};
+    std::size_t periodIndex{0};
+    double startSeconds{0.0};
+    double endSeconds{0.0};
+};
+
+std::optional<ActiveRouteGuidanceSelection> activeRouteGuidanceSelection(
+    const std::vector<safecrowd::domain::RouteGuidanceDraft>& guidances,
+    double elapsedSeconds) {
+    std::optional<ActiveRouteGuidanceSelection> best;
+    double bestStart = -1.0;
+
+    for (std::size_t guidanceIndex = 0; guidanceIndex < guidances.size(); ++guidanceIndex) {
+        const auto& guidance = guidances[guidanceIndex];
+        if (guidance.periods.empty()) {
+            const double start = 0.0;
+            const double end = 1e18;
+            if (elapsedSeconds + 1e-9 < start || elapsedSeconds > end + 1e-9) {
+                continue;
+            }
+            if (!best.has_value() || start >= bestStart) {
+                bestStart = start;
+                best = ActiveRouteGuidanceSelection{.guidanceIndex = guidanceIndex, .periodIndex = 0, .startSeconds = start, .endSeconds = end};
+            }
+            continue;
+        }
+
+        for (std::size_t periodIndex = 0; periodIndex < guidance.periods.size(); ++periodIndex) {
+            const auto& period = guidance.periods[periodIndex];
+            const auto start = std::max(0.0, period.startSeconds);
+            const auto end = std::max(start, std::max(0.0, period.endSeconds));
+            if (elapsedSeconds + 1e-9 < start) {
+                continue;
+            }
+            if (elapsedSeconds > end + 1e-9) {
+                continue;
+            }
+            if (!best.has_value() || start >= bestStart) {
+                bestStart = start;
+                best = ActiveRouteGuidanceSelection{.guidanceIndex = guidanceIndex, .periodIndex = periodIndex, .startSeconds = start, .endSeconds = end};
+            }
+        }
+    }
+
+    return best;
+}
+
+std::optional<QPointF> routeGuidanceMarkerCenter(
+    const safecrowd::domain::FacilityLayout2D& layout,
+    const safecrowd::domain::RouteGuidanceDraft& guidance,
+    const std::vector<safecrowd::domain::ConnectionBlockDraft>& blocks,
+    const LayoutCanvasTransform& transform,
+    const std::string& currentFloorId,
+    double elapsedSeconds) {
+    QPointF center;
+    if (!guidance.installConnectionId.empty()) {
+        const auto it = std::find_if(layout.connections.begin(), layout.connections.end(), [&](const auto& connection) {
+            return connection.id == guidance.installConnectionId;
+        });
+        if (it == layout.connections.end()) {
+            return std::nullopt;
+        }
+        if (!matchesFloor(it->floorId, currentFloorId)) {
+            return std::nullopt;
+        }
+        center = transform.map(connectionCenter(*it));
+    } else if (!guidance.guidedExitZoneId.empty()) {
+        const auto it = std::find_if(layout.zones.begin(), layout.zones.end(), [&](const auto& zone) {
+            return zone.id == guidance.guidedExitZoneId;
+        });
+        if (it == layout.zones.end() || it->kind != safecrowd::domain::ZoneKind::Exit) {
+            return std::nullopt;
+        }
+        if (!matchesFloor(it->floorId, currentFloorId)) {
+            return std::nullopt;
+        }
+        center = transform.map(polygonCenter(it->area));
+    } else {
+        return std::nullopt;
+    }
+
+    constexpr double kMinSeparationPixels = 28.0;
+    constexpr double kStackOffsetPixels = 34.0;
+
+    std::vector<QPointF> blockedCenters;
+    blockedCenters.reserve(blocks.size());
+    for (const auto& block : blocks) {
+        if (!connectionShouldBeBlocked(block, elapsedSeconds)) {
+            continue;
+        }
+        const auto connectionIt = std::find_if(layout.connections.begin(), layout.connections.end(), [&](const auto& connection) {
+            return connection.id == block.connectionId;
+        });
+        if (connectionIt == layout.connections.end()) {
+            continue;
+        }
+        if (!matchesFloor(connectionIt->floorId, currentFloorId)) {
+            continue;
+        }
+        blockedCenters.push_back(transform.map(connectionCenter(*connectionIt)));
+    }
+    if (blockedCenters.empty()) {
+        return center;
+    }
+
+    const auto minDistanceToBlocks = [&](const QPointF& candidate) {
+        double minDistance = 1e12;
+        for (const auto& blocked : blockedCenters) {
+            minDistance = std::min(minDistance, QLineF(candidate, blocked).length());
+        }
+        return minDistance;
+    };
+
+    const auto baseMinDistance = minDistanceToBlocks(center);
+    if (baseMinDistance >= kMinSeparationPixels) {
+        return center;
+    }
+
+    const QPointF up = center + QPointF(0.0, -kStackOffsetPixels);
+    const QPointF down = center + QPointF(0.0, kStackOffsetPixels);
+    const auto upDistance = minDistanceToBlocks(up);
+    const auto downDistance = minDistanceToBlocks(down);
+    return upDistance >= downDistance ? up : down;
+}
+
+std::optional<std::size_t> hoveredActiveRouteGuidanceIndex(
+    const safecrowd::domain::FacilityLayout2D& layout,
+    const std::vector<safecrowd::domain::RouteGuidanceDraft>& guidances,
+    const std::vector<safecrowd::domain::ConnectionBlockDraft>& blocks,
+    const LayoutCanvasTransform& transform,
+    const std::string& currentFloorId,
+    double elapsedSeconds,
+    const QPointF& screenPosition) {
+    constexpr double kHoverRadiusPixels = 14.0;
+
+    const auto active = activeRouteGuidanceSelection(guidances, elapsedSeconds);
+    if (!active.has_value()) {
+        return std::nullopt;
+    }
+    const auto& guidance = guidances[active->guidanceIndex];
+    const auto center = routeGuidanceMarkerCenter(
+        layout,
+        guidance,
+        blocks,
+        transform,
+        currentFloorId,
+        elapsedSeconds);
+    if (!center.has_value()) {
+        return std::nullopt;
+    }
+
+    const auto dx = center->x() - screenPosition.x();
+    const auto dy = center->y() - screenPosition.y();
+    const auto distanceSq = (dx * dx) + (dy * dy);
+    if (distanceSq <= kHoverRadiusPixels * kHoverRadiusPixels) {
+        return active->guidanceIndex;
+    }
+    return std::nullopt;
+}
+
 }  // namespace
 
 SimulationCanvasWidget::SimulationCanvasWidget(safecrowd::domain::FacilityLayout2D layout, QWidget* parent)
@@ -193,6 +385,11 @@ void SimulationCanvasWidget::setFrame(safecrowd::domain::SimulationFrame frame) 
 
 void SimulationCanvasWidget::setConnectionBlocks(std::vector<safecrowd::domain::ConnectionBlockDraft> blocks) {
     connectionBlocks_ = std::move(blocks);
+    update();
+}
+
+void SimulationCanvasWidget::setRouteGuidances(std::vector<safecrowd::domain::RouteGuidanceDraft> guidances) {
+    routeGuidances_ = std::move(guidances);
     update();
 }
 
@@ -273,6 +470,7 @@ void SimulationCanvasWidget::keyReleaseEvent(QKeyEvent* event) {
 
 void SimulationCanvasWidget::leaveEvent(QEvent* event) {
     hoveredConnectionBlockId_.clear();
+    hoveredRouteGuidanceId_.clear();
     QToolTip::hideText();
     QWidget::leaveEvent(event);
 }
@@ -290,6 +488,11 @@ void SimulationCanvasWidget::mouseDoubleClickEvent(QMouseEvent* event) {
 
 void SimulationCanvasWidget::mouseMoveEvent(QMouseEvent* event) {
     if (camera_.updatePan(event)) {
+        if (!hoveredConnectionBlockId_.empty() || !hoveredRouteGuidanceId_.empty()) {
+            hoveredConnectionBlockId_.clear();
+            hoveredRouteGuidanceId_.clear();
+            QToolTip::hideText();
+        }
         layoutCacheValid_ = false;
         update();
         return;
@@ -307,6 +510,14 @@ void SimulationCanvasWidget::mouseMoveEvent(QMouseEvent* event) {
 
     const auto transform = currentTransform(*bounds);
     const auto elapsedSeconds = std::max(0.0, frame_.elapsedSeconds);
+    const auto hoveredGuidance = hoveredActiveRouteGuidanceIndex(
+        layout_,
+        routeGuidances_,
+        connectionBlocks_,
+        transform,
+        currentFloorId_,
+        elapsedSeconds,
+        event->position());
     const auto hoveredIndex = hoveredBlockedConnectionIndex(
         layout_,
         connectionBlocks_,
@@ -315,8 +526,24 @@ void SimulationCanvasWidget::mouseMoveEvent(QMouseEvent* event) {
         elapsedSeconds,
         event->position());
 
+    if (hoveredGuidance.has_value()) {
+        const auto& guidance = routeGuidances_[*hoveredGuidance];
+        const auto tooltip = formatRouteGuidanceTooltip(guidance);
+        const auto hoveredId = guidance.id.empty()
+            ? (!guidance.installConnectionId.empty() ? guidance.installConnectionId : guidance.guidedExitZoneId)
+            : guidance.id;
+        if (hoveredId != hoveredRouteGuidanceId_) {
+            hoveredRouteGuidanceId_ = hoveredId;
+            hoveredConnectionBlockId_.clear();
+            QToolTip::showText(event->globalPosition().toPoint(), tooltip, this);
+        }
+        QWidget::mouseMoveEvent(event);
+        return;
+    }
+
     if (!hoveredIndex.has_value()) {
-        if (!hoveredConnectionBlockId_.empty()) {
+        if (!hoveredConnectionBlockId_.empty() || !hoveredRouteGuidanceId_.empty()) {
+            hoveredRouteGuidanceId_.clear();
             hoveredConnectionBlockId_.clear();
             QToolTip::hideText();
         }
@@ -334,6 +561,7 @@ void SimulationCanvasWidget::mouseMoveEvent(QMouseEvent* event) {
     const auto hoveredId = block.id.empty() ? block.connectionId : block.id;
     if (hoveredId != hoveredConnectionBlockId_) {
         hoveredConnectionBlockId_ = hoveredId;
+        hoveredRouteGuidanceId_.clear();
         QToolTip::showText(event->globalPosition().toPoint(), tooltip, this);
     }
     QWidget::mouseMoveEvent(event);
@@ -376,6 +604,7 @@ void SimulationCanvasWidget::paintEvent(QPaintEvent* event) {
 
     const auto transform = currentTransform(*bounds);
     drawConnectionBlockOverlay(painter, transform);
+    drawRouteGuidanceOverlay(painter, transform);
     if (overlayMode_ == ResultOverlayMode::Density) {
         drawDensityOverlay(painter, transform);
     } else if (overlayMode_ == ResultOverlayMode::Hotspots) {
@@ -520,6 +749,49 @@ void SimulationCanvasWidget::drawConnectionBlockOverlay(QPainter& painter, const
         painter.drawEllipse(center, r, r);
         painter.drawLine(QPointF(center.x() - 6.5, center.y() + 6.5), QPointF(center.x() + 6.5, center.y() - 6.5));
     }
+
+    painter.restore();
+}
+
+void SimulationCanvasWidget::drawRouteGuidanceOverlay(QPainter& painter, const LayoutCanvasTransform& transform) const {
+    const auto elapsedSeconds = std::max(0.0, frame_.elapsedSeconds);
+    const auto active = activeRouteGuidanceSelection(routeGuidances_, elapsedSeconds);
+    if (!active.has_value()) {
+        return;
+    }
+
+    const auto& guidance = routeGuidances_[active->guidanceIndex];
+    const auto center = routeGuidanceMarkerCenter(
+        layout_,
+        guidance,
+        connectionBlocks_,
+        transform,
+        currentFloorId_,
+        elapsedSeconds);
+    if (!center.has_value()) {
+        return;
+    }
+
+    painter.save();
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(QColor("#1f5fae"));
+
+    const double r = 10.0;
+    painter.drawEllipse(*center, r, r);
+
+    painter.save();
+    painter.translate(*center);
+    painter.rotate(-25.0);
+    painter.translate(-(*center));
+    painter.setBrush(Qt::white);
+    painter.drawRoundedRect(QRectF(center->x() - 1.8, center->y() - 7.0, 3.6, 10.5), 1.4, 1.4);
+    painter.drawRoundedRect(QRectF(center->x() - 1.5, center->y() + 2.2, 3.0, 5.2), 1.2, 1.2);
+    painter.restore();
+
+    painter.setPen(QPen(Qt::white, 1.7, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+    painter.drawLine(QPointF(center->x() + 5.3, center->y() - 5.0), QPointF(center->x() + 8.2, center->y() - 7.7));
+    painter.drawLine(QPointF(center->x() + 6.3, center->y() - 2.0), QPointF(center->x() + 9.2, center->y() - 2.8));
+    painter.drawLine(QPointF(center->x() + 3.7, center->y() - 7.2), QPointF(center->x() + 4.8, center->y() - 9.8));
 
     painter.restore();
 }

--- a/src/application/SimulationCanvasWidget.h
+++ b/src/application/SimulationCanvasWidget.h
@@ -51,6 +51,7 @@ protected:
     bool eventFilter(QObject* watched, QEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void keyReleaseEvent(QKeyEvent* event) override;
+    void leaveEvent(QEvent* event) override;
     void mouseDoubleClickEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
@@ -95,6 +96,8 @@ private:
     double layoutCacheZoom_{0.0};
     double layoutCacheDevicePixelRatio_{0.0};
     bool layoutCacheValid_{false};
+
+    std::string hoveredConnectionBlockId_{};
 };
 
 }  // namespace safecrowd::application

--- a/src/application/SimulationCanvasWidget.h
+++ b/src/application/SimulationCanvasWidget.h
@@ -10,6 +10,7 @@
 
 #include "application/LayoutCanvasRendering.h"
 #include "domain/FacilityLayout2D.h"
+#include "domain/ScenarioAuthoring.h"
 #include "domain/ScenarioResultArtifacts.h"
 #include "domain/ScenarioRiskMetrics.h"
 #include "domain/ScenarioSimulationRunner.h"
@@ -40,6 +41,7 @@ public:
 
     void setFrame(safecrowd::domain::SimulationFrame frame);
     void setConnectionBlocks(std::vector<safecrowd::domain::ConnectionBlockDraft> blocks);
+    void setRouteGuidances(std::vector<safecrowd::domain::RouteGuidanceDraft> guidances);
     void setDensityOverlay(std::vector<safecrowd::domain::DensityCellMetric> densityCells);
     void setHotspotOverlay(std::vector<safecrowd::domain::ScenarioCongestionHotspot> hotspots);
     void setBottleneckOverlay(std::vector<safecrowd::domain::ScenarioBottleneckMetric> bottlenecks);
@@ -67,6 +69,7 @@ private:
     QRectF previewViewport() const;
     void focusWorldPoint(const safecrowd::domain::Point2D& point, double zoom);
     void drawConnectionBlockOverlay(QPainter& painter, const LayoutCanvasTransform& transform) const;
+    void drawRouteGuidanceOverlay(QPainter& painter, const LayoutCanvasTransform& transform) const;
     void drawDensityOverlay(QPainter& painter, const LayoutCanvasTransform& transform) const;
     void drawHotspotOverlay(QPainter& painter, const LayoutCanvasTransform& transform) const;
     void drawBottleneckOverlay(QPainter& painter, const LayoutCanvasTransform& transform) const;
@@ -78,6 +81,7 @@ private:
     safecrowd::domain::FacilityLayout2D layout_{};
     safecrowd::domain::SimulationFrame frame_{};
     std::vector<safecrowd::domain::ConnectionBlockDraft> connectionBlocks_{};
+    std::vector<safecrowd::domain::RouteGuidanceDraft> routeGuidances_{};
     std::vector<safecrowd::domain::DensityCellMetric> densityOverlay_{};
     std::vector<safecrowd::domain::ScenarioCongestionHotspot> hotspotOverlay_{};
     std::vector<safecrowd::domain::ScenarioBottleneckMetric> bottleneckOverlay_{};
@@ -98,6 +102,7 @@ private:
     bool layoutCacheValid_{false};
 
     std::string hoveredConnectionBlockId_{};
+    std::string hoveredRouteGuidanceId_{};
 };
 
 }  // namespace safecrowd::application

--- a/src/domain/AgentComponents.h
+++ b/src/domain/AgentComponents.h
@@ -18,6 +18,7 @@ struct Agent {
     float maxSpeed{1.5f};
     std::string sourcePlacementId{};
     std::string sourceZoneId{};
+    double guidancePropensity{0.5};
 };
 
 struct Velocity {
@@ -46,7 +47,10 @@ struct EvacuationRoute {
     double nextSegmentReplanSeconds{0.0};
     std::uint64_t observedLayoutRevision{0};
     bool noExitAvailable{false};
+    bool followsGuidance{false};
     std::string destinationZoneId{};
+    std::string originalDestinationZoneId{};
+    std::string guidanceEventId{};
     std::string currentFloorId{};
     std::string displayFloorId{};
 };

--- a/src/domain/ScenarioAuthoring.h
+++ b/src/domain/ScenarioAuthoring.h
@@ -28,6 +28,23 @@ struct OperationalEventDraft {
     std::string targetSummary{};
 };
 
+struct RouteGuidancePeriodDraft {
+    double startSeconds{0.0};
+    double endSeconds{0.0};
+};
+
+struct RouteGuidanceDraft {
+    std::string id{};
+    double startSeconds{0.0};
+    double endSeconds{10.0};
+    std::vector<RouteGuidancePeriodDraft> periods{};
+    std::string guidedExitZoneId{};
+    std::string installConnectionId{};
+    double baseComplianceRate{0.5};
+    double guidanceStrength{0.55};
+    double maxDetourMeters{20.0};
+};
+
 struct ConnectionBlockIntervalDraft {
     double startSeconds{0.0};
     double endSeconds{0.0};
@@ -41,6 +58,7 @@ struct ConnectionBlockDraft {
 
 struct ControlPlan {
     std::vector<OperationalEventDraft> events{};
+    std::vector<RouteGuidanceDraft> routeGuidances{};
     std::vector<ConnectionBlockDraft> connectionBlocks{};
 };
 

--- a/src/domain/ScenarioSimulationInternal.cpp
+++ b/src/domain/ScenarioSimulationInternal.cpp
@@ -849,6 +849,154 @@ std::optional<ZoneRouteToExit> zoneRouteToNearestExit(
     return route;
 }
 
+std::optional<ZoneRouteResult> zoneRouteToExit(
+    const ScenarioLayoutCacheResource& cache,
+    const Point2D& startPosition,
+    const std::string& startZoneId,
+    const std::string& exitZoneId) {
+    if (startZoneId.empty() || exitZoneId.empty()) {
+        return std::nullopt;
+    }
+
+    if (startZoneId == exitZoneId) {
+        return ZoneRouteResult{.route = ZoneRouteToExit{.zoneIds = {startZoneId}}, .distance = 0.0};
+    }
+
+    if (const auto* exitZone = findCachedZone(cache, exitZoneId); exitZone == nullptr || exitZone->kind != ZoneKind::Exit) {
+        return std::nullopt;
+    }
+
+    auto stateKey = [](const std::string& zoneId, std::size_t entryConnectionIndex) {
+        return zoneId + '\x1f' + std::to_string(entryConnectionIndex);
+    };
+
+    constexpr double kDefaultVerticalRouteCost = 3.0;
+    constexpr std::size_t kStartConnectionIndex = static_cast<std::size_t>(-1);
+
+    auto verticalRouteCost = [&](const Connection2D& connection) {
+        if (!isVerticalConnection(connection)) {
+            return 0.0;
+        }
+
+        const auto fromFloorId = cachedFloorIdForZone(cache, connection.fromZoneId);
+        const auto toFloorId = cachedFloorIdForZone(cache, connection.toZoneId);
+        if (fromFloorId.empty() || toFloorId.empty() || fromFloorId == toFloorId) {
+            return kDefaultVerticalRouteCost;
+        }
+
+        const auto elevationDelta = std::fabs(floorElevation(cache.layout, fromFloorId) - floorElevation(cache.layout, toFloorId));
+        return elevationDelta > kGeometryEpsilon ? elevationDelta : kDefaultVerticalRouteCost;
+    };
+
+    struct QueueItem {
+        double distance{0.0};
+        std::string key{};
+        std::string zoneId{};
+        Point2D point{};
+        std::size_t entryConnectionIndex{static_cast<std::size_t>(-1)};
+
+        bool operator>(const QueueItem& other) const noexcept {
+            return distance > other.distance;
+        }
+    };
+
+    std::unordered_map<std::string, double> distances;
+    distances.reserve(cache.layout.connections.size() + 1);
+    std::unordered_map<std::string, std::string> previous;
+    previous.reserve(cache.layout.connections.size() + 1);
+    std::unordered_map<std::string, std::string> stateZones;
+    stateZones.reserve(cache.layout.connections.size() + 1);
+    std::unordered_map<std::string, std::size_t> stateConnectionIndices;
+    stateConnectionIndices.reserve(cache.layout.connections.size() + 1);
+    std::priority_queue<QueueItem, std::vector<QueueItem>, std::greater<QueueItem>> queue;
+
+    const auto startKey = stateKey(startZoneId, kStartConnectionIndex);
+    distances[startKey] = 0.0;
+    stateZones[startKey] = startZoneId;
+    stateConnectionIndices[startKey] = kStartConnectionIndex;
+    queue.push({
+        .distance = 0.0,
+        .key = startKey,
+        .zoneId = startZoneId,
+        .point = startPosition,
+        .entryConnectionIndex = kStartConnectionIndex,
+    });
+
+    double bestExitDistance = std::numeric_limits<double>::max();
+    std::string bestExitKey;
+
+    while (!queue.empty()) {
+        const auto current = queue.top();
+        queue.pop();
+
+        if (current.distance > bestExitDistance + 1e-12) {
+            continue;
+        }
+
+        const auto bestIt = distances.find(current.key);
+        if (bestIt == distances.end() || current.distance > bestIt->second + 1e-12) {
+            continue;
+        }
+
+        if (current.zoneId == exitZoneId) {
+            if (current.distance + 1e-12 < bestExitDistance) {
+                bestExitDistance = current.distance;
+                bestExitKey = current.key;
+            }
+            continue;
+        }
+
+        for (const auto& traversal : cachedTraversalsForZone(cache, current.zoneId)) {
+            if (traversal.nextZoneId.empty() || traversal.connectionIndex >= cache.layout.connections.size()) {
+                continue;
+            }
+
+            const auto& connection = cache.layout.connections[traversal.connectionIndex];
+            const auto portal = midpoint(connection.centerSpan);
+            const auto nextDistance = current.distance + distanceBetween(current.point, portal) + verticalRouteCost(connection);
+            const auto nextKey = stateKey(traversal.nextZoneId, traversal.connectionIndex);
+            const auto distanceIt = distances.find(nextKey);
+            if (distanceIt == distances.end() || nextDistance + 1e-12 < distanceIt->second) {
+                distances[nextKey] = nextDistance;
+                previous[nextKey] = current.key;
+                stateZones[nextKey] = traversal.nextZoneId;
+                stateConnectionIndices[nextKey] = traversal.connectionIndex;
+                queue.push({
+                    .distance = nextDistance,
+                    .key = nextKey,
+                    .zoneId = traversal.nextZoneId,
+                    .point = portal,
+                    .entryConnectionIndex = traversal.connectionIndex,
+                });
+            }
+        }
+    }
+
+    if (bestExitKey.empty()) {
+        return std::nullopt;
+    }
+
+    ZoneRouteToExit route;
+    for (auto key = bestExitKey; !key.empty();) {
+        const auto zoneIt = stateZones.find(key);
+        if (zoneIt != stateZones.end()) {
+            route.zoneIds.push_back(zoneIt->second);
+        }
+        const auto connectionIt = stateConnectionIndices.find(key);
+        if (connectionIt != stateConnectionIndices.end() && connectionIt->second != kStartConnectionIndex) {
+            route.connectionIndices.push_back(connectionIt->second);
+        }
+        const auto previousIt = previous.find(key);
+        key = previousIt == previous.end() ? std::string{} : previousIt->second;
+    }
+    std::reverse(route.zoneIds.begin(), route.zoneIds.end());
+    std::reverse(route.connectionIndices.begin(), route.connectionIndices.end());
+    if (route.zoneIds.empty() || route.connectionIndices.size() + 1 != route.zoneIds.size()) {
+        return std::nullopt;
+    }
+    return ZoneRouteResult{.route = std::move(route), .distance = bestExitDistance};
+}
+
 double speedOf(const Point2D& velocity) {
     const auto speed = std::hypot(velocity.x, velocity.y);
     return speed > 0.0 ? speed : kDefaultAgentSpeed;

--- a/src/domain/ScenarioSimulationInternal.h
+++ b/src/domain/ScenarioSimulationInternal.h
@@ -99,6 +99,11 @@ struct ZoneRouteToExit {
     }
 };
 
+struct ZoneRouteResult {
+    ZoneRouteToExit route{};
+    double distance{0.0};
+};
+
 long long spatialKey(const SpatialCell& cell);
 SpatialCell spatialCellFor(const Point2D& point, double cellSize);
 Bounds boundsOf(const Polygon2D& polygon);
@@ -127,6 +132,11 @@ std::optional<ZoneRouteToExit> zoneRouteToNearestExit(
     const ScenarioLayoutCacheResource& cache,
     const Point2D& startPosition,
     const std::string& startZoneId);
+std::optional<ZoneRouteResult> zoneRouteToExit(
+    const ScenarioLayoutCacheResource& cache,
+    const Point2D& startPosition,
+    const std::string& startZoneId,
+    const std::string& exitZoneId);
 std::string floorIdForZone(const FacilityLayout2D& layout, const std::string& zoneId);
 bool isVerticalConnection(const Connection2D& connection);
 bool canTraverseConnection(const FacilityLayout2D& layout, const Connection2D& connection);

--- a/src/domain/ScenarioSimulationMotionSystem.cpp
+++ b/src/domain/ScenarioSimulationMotionSystem.cpp
@@ -25,6 +25,11 @@ public:
         : layoutCache_(buildScenarioLayoutCache(std::move(layout))) {
     }
 
+    ScenarioSimulationMotionSystem(FacilityLayout2D layout, std::vector<RouteGuidanceDraft> routeGuidances)
+        : layoutCache_(buildScenarioLayoutCache(std::move(layout))),
+          routeGuidances_(std::move(routeGuidances)) {
+    }
+
     void configure(engine::EngineWorld& world) override {
         if (layoutCache_.has_value() && !world.resources().contains<ScenarioLayoutCacheResource>()) {
             world.resources().set(*layoutCache_);
@@ -32,8 +37,6 @@ public:
     }
 
     void update(engine::EngineWorld& world, const engine::EngineStepContext& step) override {
-        (void)step;
-
         auto& resources = world.resources();
         if (!resources.contains<ScenarioSimulationStepResource>()) {
             return;
@@ -64,6 +67,7 @@ public:
         std::vector<MovementPlan> plans;
         plans.reserve(entities.size());
 
+        applyRouteGuidance(query, entities, layoutCache, clock.elapsedSeconds, step.derivedSeed);
         advanceRoutesForCurrentZones(query, entities, layoutCache);
         advanceRoutesForWaypointProgress(query, 0.0, entities, layoutCache);
         replanBlockedExitRoutes(query, entities, layoutCache, clock.elapsedSeconds, layoutRevision);
@@ -523,6 +527,247 @@ private:
         return targetFloorId;
     }
 
+    static std::uint64_t fnv1a64(const std::string& value) {
+        std::uint64_t hash = 1469598103934665603ULL;
+        for (const unsigned char ch : value) {
+            hash ^= static_cast<std::uint64_t>(ch);
+            hash *= 1099511628211ULL;
+        }
+        return hash;
+    }
+
+    static std::uint64_t mix64(std::uint64_t value) {
+        value += 0x9e3779b97f4a7c15ULL;
+        value = (value ^ (value >> 30U)) * 0xbf58476d1ce4e5b9ULL;
+        value = (value ^ (value >> 27U)) * 0x94d049bb133111ebULL;
+        return value ^ (value >> 31U);
+    }
+
+    static double uniform01(std::uint64_t value) {
+        const auto mixed = mix64(value);
+        const auto mantissa = mixed >> 11U;
+        return static_cast<double>(mantissa) * (1.0 / 9007199254740992.0);
+    }
+
+    static double clamp01(double value) {
+        return std::clamp(value, 0.0, 1.0);
+    }
+
+    static double logit(double p) {
+        const auto clamped = std::clamp(p, 1e-6, 1.0 - 1e-6);
+        return std::log(clamped / (1.0 - clamped));
+    }
+
+    static double sigmoid(double x) {
+        if (x >= 0.0) {
+            const auto z = std::exp(-x);
+            return 1.0 / (1.0 + z);
+        }
+        const auto z = std::exp(x);
+        return z / (1.0 + z);
+    }
+
+    struct ActiveRouteGuidance {
+        const RouteGuidanceDraft* guidance{nullptr};
+        std::size_t periodIndex{0};
+        double startSeconds{0.0};
+        double endSeconds{0.0};
+    };
+
+    std::optional<ActiveRouteGuidance> activeRouteGuidance(double elapsedSeconds) const {
+        std::optional<ActiveRouteGuidance> best;
+        double bestStart = -1.0;
+
+        for (const auto& guidance : routeGuidances_) {
+            if (guidance.periods.empty()) {
+                // No periods configured => always active (like connection blocks with no intervals).
+                const double start = 0.0;
+                const double end = 1e18;
+                if (elapsedSeconds + 1e-9 < start || elapsedSeconds > end + 1e-9) {
+                    continue;
+                }
+                if (!best.has_value() || start >= bestStart) {
+                    bestStart = start;
+                    best = ActiveRouteGuidance{.guidance = &guidance, .periodIndex = 0, .startSeconds = start, .endSeconds = end};
+                }
+                continue;
+            }
+
+            for (std::size_t index = 0; index < guidance.periods.size(); ++index) {
+                const auto& period = guidance.periods[index];
+                const auto start = std::max(0.0, period.startSeconds);
+                const auto end = std::max(start, std::max(0.0, period.endSeconds));
+                if (elapsedSeconds + 1e-9 < start) {
+                    continue;
+                }
+                if (elapsedSeconds > end + 1e-9) {
+                    continue;
+                }
+                if (!best.has_value() || start >= bestStart) {
+                    bestStart = start;
+                    best = ActiveRouteGuidance{.guidance = &guidance, .periodIndex = index, .startSeconds = start, .endSeconds = end};
+                }
+            }
+        }
+
+        return best;
+    }
+
+    std::optional<double> zoneDistanceToExit(
+        const ScenarioLayoutCacheResource& layoutCache,
+        const Point2D& start,
+        const std::string& startZoneId,
+        const std::string& exitZoneId) const {
+        const auto result = zoneRouteToExit(layoutCache, start, startZoneId, exitZoneId);
+        if (!result.has_value()) {
+            return std::nullopt;
+        }
+        return result->distance;
+    }
+
+    double complianceProbability(
+        const RouteGuidanceDraft& guidance,
+        const Agent& agent,
+        double detourMeters) const {
+        constexpr double kStrengthBaseline = 0.55;
+        constexpr double kStrengthWeight = 4.0;
+        constexpr double kDetourWeight = 2.0;
+        constexpr double kPropensityWeight = 1.0;
+
+        const auto base = logit(clamp01(guidance.baseComplianceRate));
+        const auto strength = clamp01(guidance.guidanceStrength);
+        const auto detourRatio = guidance.maxDetourMeters > 1e-6
+            ? std::max(0.0, detourMeters) / std::max(1e-6, guidance.maxDetourMeters)
+            : 0.0;
+        const auto propensity = clamp01(agent.guidancePropensity);
+        const auto score =
+            base
+            + (kStrengthWeight * (strength - kStrengthBaseline))
+            - (kDetourWeight * detourRatio)
+            + (kPropensityWeight * logit(propensity));
+        return clamp01(sigmoid(score));
+    }
+
+    void applyRouteGuidance(
+        engine::WorldQuery& query,
+        const std::vector<engine::Entity>& entities,
+        const ScenarioLayoutCacheResource& layoutCache,
+        double elapsedSeconds,
+        std::uint64_t derivedSeed) {
+        const auto active = activeRouteGuidance(elapsedSeconds);
+        std::string activeId;
+        if (active.has_value() && active->guidance != nullptr) {
+            activeId = active->guidance->id;
+            if (!active->guidance->periods.empty()) {
+                activeId.append(":p");
+                activeId.append(std::to_string(active->periodIndex));
+            }
+        }
+        if (activeId == activeRouteGuidanceId_) {
+            return;
+        }
+        activeRouteGuidanceId_ = activeId;
+
+        if (!active.has_value() || active->guidance == nullptr) {
+            for (const auto entity : entities) {
+                const auto& status = query.get<EvacuationStatus>(entity);
+                if (status.evacuated) {
+                    continue;
+                }
+
+                const auto& position = query.get<Position>(entity);
+                auto& route = query.get<EvacuationRoute>(entity);
+                route.guidanceEventId.clear();
+                route.followsGuidance = false;
+
+                if (!route.originalDestinationZoneId.empty()) {
+                    const auto startZoneId = zoneAt(layoutCache, position.value, route.currentFloorId);
+                    if (!startZoneId.empty()) {
+                        RoutePlan plan = routePlanToExit(layoutCache, position.value, startZoneId, route.originalDestinationZoneId);
+                        if (plan.destinationZoneId.empty()) {
+                            plan = routePlanToNearestExit(layoutCache, position.value, startZoneId);
+                        }
+                        if (!plan.destinationZoneId.empty()) {
+                            replaceRouteWithPlan(route, plan, position.value);
+                        }
+                    }
+                }
+            }
+            return;
+        }
+
+        const auto* activeGuidance = active->guidance;
+        const auto activeIdHash = fnv1a64(activeId);
+        for (const auto entity : entities) {
+            const auto& status = query.get<EvacuationStatus>(entity);
+            if (status.evacuated) {
+                continue;
+            }
+
+            const auto& position = query.get<Position>(entity);
+            const auto& agent = query.get<Agent>(entity);
+            auto& route = query.get<EvacuationRoute>(entity);
+            if (route.originalDestinationZoneId.empty()) {
+                route.originalDestinationZoneId = route.destinationZoneId;
+            }
+
+            const auto startZoneId = zoneAt(layoutCache, position.value, route.currentFloorId);
+            if (startZoneId.empty()) {
+                continue;
+            }
+
+            bool guidedExitValid = false;
+            if (!activeGuidance->guidedExitZoneId.empty()) {
+                if (const auto* exitZone = findCachedZone(layoutCache, activeGuidance->guidedExitZoneId);
+                    exitZone != nullptr && exitZone->kind == ZoneKind::Exit) {
+                    guidedExitValid = true;
+                }
+            }
+
+            double detourMeters = 0.0;
+            if (guidedExitValid && !route.originalDestinationZoneId.empty()) {
+                const auto originalDistance =
+                    zoneDistanceToExit(layoutCache, position.value, startZoneId, route.originalDestinationZoneId);
+                const auto guidedDistance =
+                    zoneDistanceToExit(layoutCache, position.value, startZoneId, activeGuidance->guidedExitZoneId);
+                if (originalDistance.has_value() && guidedDistance.has_value()) {
+                    detourMeters = std::max(0.0, *guidedDistance - *originalDistance);
+                }
+            }
+
+            const auto pFollow = complianceProbability(*activeGuidance, agent, detourMeters);
+            const auto u = uniform01(
+                derivedSeed
+                ^ activeIdHash
+                ^ (static_cast<std::uint64_t>(entity.index) << 1U)
+                ^ static_cast<std::uint64_t>(entity.generation));
+            const bool follows = u < pFollow;
+
+            route.guidanceEventId = activeId;
+            route.followsGuidance = follows;
+
+            std::string desiredExit;
+            if (follows && guidedExitValid) {
+                desiredExit = activeGuidance->guidedExitZoneId;
+            } else if (!follows) {
+                desiredExit = route.originalDestinationZoneId;
+            }
+
+            RoutePlan plan;
+            if (!desiredExit.empty()) {
+                plan = routePlanToExit(layoutCache, position.value, startZoneId, desiredExit);
+            }
+            if (plan.destinationZoneId.empty()) {
+                plan = routePlanToNearestExit(layoutCache, position.value, startZoneId);
+            }
+            if (plan.destinationZoneId.empty()) {
+                continue;
+            }
+            replaceRouteWithPlan(route, plan, position.value);
+            route.nextExitReplanSeconds = elapsedSeconds + 0.25;
+        }
+    }
+
     RoutePlan routePlanToNearestExit(
         const ScenarioLayoutCacheResource& layoutCache,
         const Point2D& start,
@@ -601,6 +846,86 @@ private:
         return plan;
     }
 
+    RoutePlan routePlanToExit(
+        const ScenarioLayoutCacheResource& layoutCache,
+        const Point2D& start,
+        const std::string& startZoneId,
+        const std::string& exitZoneId) const {
+        RoutePlan plan;
+        const auto zoneRouteResult = zoneRouteToExit(layoutCache, start, startZoneId, exitZoneId);
+        if (!zoneRouteResult.has_value() || zoneRouteResult->route.empty()) {
+            return plan;
+        }
+
+        const auto& zoneRoute = zoneRouteResult->route;
+        plan.destinationZoneId = zoneRoute.zoneIds.back();
+
+        Point2D segmentStart = start;
+        auto appendSegment = [&](const std::vector<Point2D>& segment,
+                                 const LineSegment2D& finalPassage,
+                                 const std::string& finalFromZoneId,
+                                 const std::string& finalZoneId,
+                                 const std::string& finalFloorId,
+                                 const std::string& finalConnectionId,
+                                 bool finalVerticalTransition) {
+            for (std::size_t waypointIndex = 0; waypointIndex < segment.size(); ++waypointIndex) {
+                const bool isFinalWaypoint = waypointIndex + 1 == segment.size();
+                plan.waypoints.push_back(segment[waypointIndex]);
+                plan.waypointPassages.push_back(isFinalWaypoint ? finalPassage : pointPassage(segment[waypointIndex]));
+                plan.waypointFromZoneIds.push_back(isFinalWaypoint ? finalFromZoneId : std::string{});
+                plan.waypointZoneIds.push_back(isFinalWaypoint ? finalZoneId : std::string{});
+                plan.waypointFloorIds.push_back(isFinalWaypoint ? finalFloorId : std::string{});
+                plan.waypointConnectionIds.push_back(isFinalWaypoint ? finalConnectionId : std::string{});
+                plan.waypointVerticalTransitions.push_back(isFinalWaypoint && finalVerticalTransition);
+            }
+        };
+
+        for (std::size_t index = 1; index < zoneRoute.zoneIds.size(); ++index) {
+            const auto& fromZoneId = zoneRoute.zoneIds[index - 1];
+            const auto& toZoneId = zoneRoute.zoneIds[index];
+            const auto connectionIndex = zoneRoute.connectionIndices[index - 1];
+            if (connectionIndex < layoutCache.layout.connections.size()) {
+                const auto* connection = &layoutCache.layout.connections[connectionIndex];
+                const auto passage = passageWithClearance(*connection, kCandidateClearance);
+                const auto fromFloorId = cachedFloorIdForZone(layoutCache, fromZoneId);
+                const auto toFloorId = cachedFloorIdForZone(layoutCache, toZoneId);
+                const auto& segmentLayout = cachedLayoutForFloor(layoutCache, fromFloorId);
+                const auto target = closestPointOnSegment(segmentStart, passage.start, passage.end);
+                const auto segment = buildPath(segmentLayout, segmentStart, target, kCandidateClearance);
+                appendSegment(
+                    segment,
+                    passage,
+                    fromZoneId,
+                    toZoneId,
+                    toFloorId.empty() ? fromFloorId : toFloorId,
+                    connection->id,
+                    isVerticalConnection(*connection));
+                segmentStart = target;
+            }
+        }
+
+        if (const auto* exitZone = findCachedZone(layoutCache, zoneRoute.zoneIds.back())) {
+            const auto exitCenter = polygonCenter(exitZone->area);
+            if (distanceBetween(segmentStart, exitCenter) > kArrivalEpsilon) {
+                const auto exitFloorId = exitZone->floorId;
+                const auto& segmentLayout = cachedLayoutForFloor(layoutCache, exitFloorId);
+                const auto segment = buildPath(segmentLayout, segmentStart, exitCenter, kCandidateClearance);
+                appendSegment(segment, pointPassage(exitCenter), std::string{}, exitZone->id, exitFloorId, std::string{}, false);
+            }
+        }
+
+        if (!plan.waypoints.empty() && distanceBetween(start, plan.waypoints.front()) <= kArrivalEpsilon) {
+            plan.waypoints.erase(plan.waypoints.begin());
+            plan.waypointPassages.erase(plan.waypointPassages.begin());
+            plan.waypointFromZoneIds.erase(plan.waypointFromZoneIds.begin());
+            plan.waypointZoneIds.erase(plan.waypointZoneIds.begin());
+            plan.waypointFloorIds.erase(plan.waypointFloorIds.begin());
+            plan.waypointConnectionIds.erase(plan.waypointConnectionIds.begin());
+            plan.waypointVerticalTransitions.erase(plan.waypointVerticalTransitions.begin());
+        }
+        return plan;
+    }
+
     void replaceRouteWithPlan(EvacuationRoute& route, const RoutePlan& plan, const Point2D& start) const {
         route.destinationZoneId = plan.destinationZoneId;
         route.waypoints = plan.waypoints;
@@ -630,7 +955,13 @@ private:
             return false;
         }
 
-        const auto plan = routePlanToNearestExit(layoutCache, landingPoint, startZoneId);
+        RoutePlan plan;
+        if (route.followsGuidance && !route.destinationZoneId.empty()) {
+            plan = routePlanToExit(layoutCache, landingPoint, startZoneId, route.destinationZoneId);
+        }
+        if (plan.destinationZoneId.empty()) {
+            plan = routePlanToNearestExit(layoutCache, landingPoint, startZoneId);
+        }
         if (plan.destinationZoneId.empty()) {
             return false;
         }
@@ -908,7 +1239,13 @@ private:
                 continue;
             }
 
-            const auto plan = routePlanToNearestExit(layoutCache, position.value, startZoneId);
+            RoutePlan plan;
+            if (route.followsGuidance && !route.destinationZoneId.empty()) {
+                plan = routePlanToExit(layoutCache, position.value, startZoneId, route.destinationZoneId);
+            }
+            if (plan.destinationZoneId.empty()) {
+                plan = routePlanToNearestExit(layoutCache, position.value, startZoneId);
+            }
             if (plan.destinationZoneId.empty()) {
                 route.noExitAvailable = true;
                 route.destinationZoneId.clear();
@@ -1213,6 +1550,8 @@ private:
     }
 
     std::optional<ScenarioLayoutCacheResource> layoutCache_{};
+    std::vector<RouteGuidanceDraft> routeGuidances_{};
+    std::string activeRouteGuidanceId_{};
 };
 
 
@@ -1225,6 +1564,12 @@ std::unique_ptr<engine::EngineSystem> makeScenarioSimulationMotionSystem() {
 
 std::unique_ptr<engine::EngineSystem> makeScenarioSimulationMotionSystem(FacilityLayout2D layout) {
     return std::make_unique<ScenarioSimulationMotionSystem>(std::move(layout));
+}
+
+std::unique_ptr<engine::EngineSystem> makeScenarioSimulationMotionSystem(
+    FacilityLayout2D layout,
+    std::vector<RouteGuidanceDraft> routeGuidances) {
+    return std::make_unique<ScenarioSimulationMotionSystem>(std::move(layout), std::move(routeGuidances));
 }
 
 }  // namespace safecrowd::domain

--- a/src/domain/ScenarioSimulationMotionSystem.cpp
+++ b/src/domain/ScenarioSimulationMotionSystem.cpp
@@ -654,6 +654,10 @@ private:
         const ScenarioLayoutCacheResource& layoutCache,
         double elapsedSeconds,
         std::uint64_t derivedSeed) {
+        // Keep this small to avoid frame spikes when guidance toggles.
+        // Higher values converge faster but may cause noticeable hitching with many agents.
+        constexpr std::size_t kGuidanceReplanBudgetPerFrame = 50;
+
         const auto active = activeRouteGuidance(elapsedSeconds);
         std::string activeId;
         if (active.has_value() && active->guidance != nullptr) {
@@ -663,42 +667,32 @@ private:
                 activeId.append(std::to_string(active->periodIndex));
             }
         }
-        if (activeId == activeRouteGuidanceId_) {
-            return;
-        }
-        activeRouteGuidanceId_ = activeId;
 
-        if (!active.has_value() || active->guidance == nullptr) {
-            for (const auto entity : entities) {
-                const auto& status = query.get<EvacuationStatus>(entity);
-                if (status.evacuated) {
-                    continue;
-                }
-
-                const auto& position = query.get<Position>(entity);
-                auto& route = query.get<EvacuationRoute>(entity);
-                route.guidanceEventId.clear();
-                route.followsGuidance = false;
-
-                if (!route.originalDestinationZoneId.empty()) {
-                    const auto startZoneId = zoneAt(layoutCache, position.value, route.currentFloorId);
-                    if (!startZoneId.empty()) {
-                        RoutePlan plan = routePlanToExit(layoutCache, position.value, startZoneId, route.originalDestinationZoneId);
-                        if (plan.destinationZoneId.empty()) {
-                            plan = routePlanToNearestExit(layoutCache, position.value, startZoneId);
-                        }
-                        if (!plan.destinationZoneId.empty()) {
-                            replaceRouteWithPlan(route, plan, position.value);
-                        }
-                    }
-                }
+        if (activeId != activeRouteGuidanceId_) {
+            activeRouteGuidanceId_ = activeId;
+            guidanceReplanCursor_ = 0;
+            guidanceReplanSeed_ = derivedSeed;
+            if (active.has_value() && active->guidance != nullptr) {
+                guidanceReplanGuidance_ = *active->guidance;
+            } else {
+                guidanceReplanGuidance_.reset();
             }
+            guidanceReplanIdHash_ = fnv1a64(activeId);
+            guidanceReplanPending_ = true;
+        }
+
+        if (!guidanceReplanPending_ || guidanceReplanCursor_ >= entities.size()) {
             return;
         }
 
-        const auto* activeGuidance = active->guidance;
-        const auto activeIdHash = fnv1a64(activeId);
-        for (const auto entity : entities) {
+        const auto endIndex = std::min<std::size_t>(entities.size(), guidanceReplanCursor_ + kGuidanceReplanBudgetPerFrame);
+
+        const RouteGuidanceDraft* activeGuidance = guidanceReplanGuidance_.has_value() ? &*guidanceReplanGuidance_ : nullptr;
+        const auto activeIdHash = guidanceReplanIdHash_;
+        const auto stableSeed = guidanceReplanSeed_;
+
+        for (std::size_t i = guidanceReplanCursor_; i < endIndex; ++i) {
+            const auto entity = entities[i];
             const auto& status = query.get<EvacuationStatus>(entity);
             if (status.evacuated) {
                 continue;
@@ -716,6 +710,31 @@ private:
                 continue;
             }
 
+            if (activeGuidance == nullptr) {
+                route.guidanceEventId.clear();
+                route.followsGuidance = false;
+
+                std::string desiredExit = route.originalDestinationZoneId;
+                if (desiredExit.empty()) {
+                    continue;
+                }
+
+                if (route.destinationZoneId == desiredExit && !route.waypoints.empty()) {
+                    continue;
+                }
+
+                RoutePlan plan = routePlanToExit(layoutCache, position.value, startZoneId, desiredExit);
+                if (plan.destinationZoneId.empty()) {
+                    plan = routePlanToNearestExit(layoutCache, position.value, startZoneId);
+                }
+                if (plan.destinationZoneId.empty()) {
+                    continue;
+                }
+                replaceRouteWithPlan(route, plan, position.value);
+                route.nextExitReplanSeconds = elapsedSeconds + 0.25;
+                continue;
+            }
+
             bool guidedExitValid = false;
             if (!activeGuidance->guidedExitZoneId.empty()) {
                 if (const auto* exitZone = findCachedZone(layoutCache, activeGuidance->guidedExitZoneId);
@@ -724,20 +743,24 @@ private:
                 }
             }
 
+            // Detour estimation can be expensive; skip it unless guidance has a detour limit.
             double detourMeters = 0.0;
             if (guidedExitValid && !route.originalDestinationZoneId.empty()) {
-                const auto originalDistance =
-                    zoneDistanceToExit(layoutCache, position.value, startZoneId, route.originalDestinationZoneId);
-                const auto guidedDistance =
-                    zoneDistanceToExit(layoutCache, position.value, startZoneId, activeGuidance->guidedExitZoneId);
-                if (originalDistance.has_value() && guidedDistance.has_value()) {
-                    detourMeters = std::max(0.0, *guidedDistance - *originalDistance);
+                // Use a cheap approximation for detour to avoid expensive graph searches when guidance toggles.
+                // This detour is only used for compliance probability; the actual route still uses full planning.
+                const auto* originalExit = findCachedZone(layoutCache, route.originalDestinationZoneId);
+                const auto* guidedExit = findCachedZone(layoutCache, activeGuidance->guidedExitZoneId);
+                if (originalExit != nullptr && guidedExit != nullptr && originalExit->kind == ZoneKind::Exit
+                    && guidedExit->kind == ZoneKind::Exit) {
+                    const auto originalDistance = distanceBetween(position.value, polygonCenter(originalExit->area));
+                    const auto guidedDistance = distanceBetween(position.value, polygonCenter(guidedExit->area));
+                    detourMeters = std::max(0.0, guidedDistance - originalDistance);
                 }
             }
 
             const auto pFollow = complianceProbability(*activeGuidance, agent, detourMeters);
             const auto u = uniform01(
-                derivedSeed
+                stableSeed
                 ^ activeIdHash
                 ^ (static_cast<std::uint64_t>(entity.index) << 1U)
                 ^ static_cast<std::uint64_t>(entity.generation));
@@ -753,6 +776,10 @@ private:
                 desiredExit = route.originalDestinationZoneId;
             }
 
+            if (!desiredExit.empty() && route.destinationZoneId == desiredExit && !route.waypoints.empty()) {
+                continue;
+            }
+
             RoutePlan plan;
             if (!desiredExit.empty()) {
                 plan = routePlanToExit(layoutCache, position.value, startZoneId, desiredExit);
@@ -765,6 +792,11 @@ private:
             }
             replaceRouteWithPlan(route, plan, position.value);
             route.nextExitReplanSeconds = elapsedSeconds + 0.25;
+        }
+
+        guidanceReplanCursor_ = endIndex;
+        if (guidanceReplanCursor_ >= entities.size()) {
+            guidanceReplanPending_ = false;
         }
     }
 
@@ -1552,8 +1584,14 @@ private:
     std::optional<ScenarioLayoutCacheResource> layoutCache_{};
     std::vector<RouteGuidanceDraft> routeGuidances_{};
     std::string activeRouteGuidanceId_{};
+    bool guidanceReplanPending_{false};
+    std::size_t guidanceReplanCursor_{0};
+    std::optional<RouteGuidanceDraft> guidanceReplanGuidance_{};
+    std::uint64_t guidanceReplanSeed_{0U};
+    std::uint64_t guidanceReplanIdHash_{0U};
 };
-
+
+
 
 
 }  // namespace

--- a/src/domain/ScenarioSimulationRunner.cpp
+++ b/src/domain/ScenarioSimulationRunner.cpp
@@ -81,6 +81,40 @@ bool ScenarioSimulationRunner::complete() const noexcept {
 
 std::vector<ScenarioAgentSeed> ScenarioSimulationRunner::createAgentSeeds() const {
     std::vector<ScenarioAgentSeed> seeds;
+    const std::uint64_t baseSeed = scenario_.execution.baseSeed != 0 ? scenario_.execution.baseSeed : 1;
+    auto fnv1a64 = [](const std::string& value) {
+        std::uint64_t hash = 1469598103934665603ULL;
+        for (const unsigned char ch : value) {
+            hash ^= static_cast<std::uint64_t>(ch);
+            hash *= 1099511628211ULL;
+        }
+        return hash;
+    };
+    auto mix64 = [](std::uint64_t v) {
+        v += 0x9e3779b97f4a7c15ULL;
+        v = (v ^ (v >> 30U)) * 0xbf58476d1ce4e5b9ULL;
+        v = (v ^ (v >> 27U)) * 0x94d049bb133111ebULL;
+        return v ^ (v >> 31U);
+    };
+    auto uniform01 = [&](std::uint64_t v) {
+        const auto mixed = mix64(v);
+        const auto mantissa = mixed >> 11U;
+        return static_cast<double>(mantissa) * (1.0 / 9007199254740992.0);
+    };
+    auto beta22 = [&](std::uint64_t salt) {
+        const auto u1 = std::max(1e-12, uniform01(baseSeed ^ salt ^ 0xA341316CULL));
+        const auto u2 = std::max(1e-12, uniform01(baseSeed ^ salt ^ 0xC8013EA4ULL));
+        const auto u3 = std::max(1e-12, uniform01(baseSeed ^ salt ^ 0xAD90777DULL));
+        const auto u4 = std::max(1e-12, uniform01(baseSeed ^ salt ^ 0x7E95761EULL));
+        const auto x = -std::log(u1 * u2);
+        const auto y = -std::log(u3 * u4);
+        if (!(x > 0.0) && !(y > 0.0)) {
+            return 0.5;
+        }
+        return x / (x + y);
+    };
+
+    std::uint64_t agentSerial = 0;
     for (const auto& placement : scenario_.population.initialPlacements) {
         const auto count = placement.explicitPositions.empty()
             ? placement.targetAgentCount
@@ -122,10 +156,17 @@ std::vector<ScenarioAgentSeed> ScenarioSimulationRunner::createAgentSeeds() cons
                 .destinationZoneId = route.destinationZoneId,
                 .currentFloorId = placementFloorId,
             };
+            evacuationRoute.originalDestinationZoneId = evacuationRoute.destinationZoneId;
             evacuationRoute.displayFloorId = evacuationRoute.currentFloorId;
             evacuationRoute.previousDistanceToWaypoint = route.waypoints.empty()
                 ? 0.0
                 : distanceToRouteWaypoint(evacuationRoute, position);
+            const auto propensitySalt =
+                mix64(static_cast<std::uint64_t>(++agentSerial))
+                ^ mix64(fnv1a64(placement.id))
+                ^ mix64(fnv1a64(startZoneId))
+                ^ mix64(static_cast<std::uint64_t>(evacuationRoute.destinationZoneId.size()));
+            const auto guidancePropensity = beta22(propensitySalt);
             seeds.push_back({
                 .position = {.value = position},
                 .agent = {
@@ -133,6 +174,7 @@ std::vector<ScenarioAgentSeed> ScenarioSimulationRunner::createAgentSeeds() cons
                     .maxSpeed = static_cast<float>(speed),
                     .sourcePlacementId = placement.id,
                     .sourceZoneId = startZoneId,
+                    .guidancePropensity = guidancePropensity,
                 },
                 .velocity = {.value = {}},
                 .route = std::move(evacuationRoute),
@@ -147,7 +189,7 @@ void ScenarioSimulationRunner::initializeRuntime() {
     runtime_ = std::make_unique<engine::EngineRuntime>(engine::EngineConfig{
         .fixedDeltaTime = 1.0 / 30.0,
         .maxCatchUpSteps = 1,
-        .baseSeed = 1,
+        .baseSeed = scenario_.execution.baseSeed != 0 ? scenario_.execution.baseSeed : 1,
     });
     runtime_->addSystem(std::make_unique<ScenarioAgentSpawnSystem>(createAgentSeeds(), timeLimitSeconds_));
     runtime_->addSystem(
@@ -159,7 +201,7 @@ void ScenarioSimulationRunner::initializeRuntime() {
         {.phase = engine::UpdatePhase::PreSimulation,
          .triggerPolicy = engine::TriggerPolicy::EveryFrame});
     runtime_->addSystem(
-        makeScenarioSimulationMotionSystem(layout_),
+        makeScenarioSimulationMotionSystem(layout_, scenario_.control.routeGuidances),
         {.phase = engine::UpdatePhase::PostSimulation,
          .triggerPolicy = engine::TriggerPolicy::EveryFrame});
     runtime_->addSystem(

--- a/src/domain/ScenarioSimulationSystems.h
+++ b/src/domain/ScenarioSimulationSystems.h
@@ -92,6 +92,9 @@ std::unique_ptr<engine::EngineSystem> makeScenarioControlSystem(
     FacilityLayout2D baseLayout,
     std::vector<ConnectionBlockDraft> blocks);
 std::unique_ptr<engine::EngineSystem> makeScenarioSimulationMotionSystem(FacilityLayout2D layout);
+std::unique_ptr<engine::EngineSystem> makeScenarioSimulationMotionSystem(
+    FacilityLayout2D layout,
+    std::vector<RouteGuidanceDraft> routeGuidances);
 std::unique_ptr<engine::EngineSystem> makeScenarioRiskMetricsSystem(FacilityLayout2D layout);
 
 class ScenarioAgentSpawnSystem final : public engine::EngineSystem {


### PR DESCRIPTION
## Summary

- Add Route guidance authoring tool (installable on exit zones and doors) + overlay marker.
- Support multiple active time ranges via `periods[]`; empty periods => Always active.
- Persist `periods` in project JSON (backward compatible with legacy `startSeconds/endSeconds`).
- Apply guidance compliance using a logistic probability model driven by:
  - `baseComplianceRate` (0~1)
  - `guidanceStrength` (0~1)
  - `maxDetourMeters` (>=0)
  - per-agent `guidancePropensity ~ Beta(2,2)`
- Improve tooltips and settings dialog copy/formatting; tooltip now shows *all* configured periods with line breaks.
- Fix door-installed guidance “not working” cases by auto-selecting a valid `guidedExitZoneId` (adjacent exit or nearest exit).

## Related Issue

- Closes #195

## Area

- [ ] Engine
- [x] Domain
- [x] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [x] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug`
- [x] `ctest --preset test-debug`
- [ ] Not run (reason below)

Additionally ran (CI no-app path):
- `cmake --build --preset build-no-app-debug`
- `ctest --preset test-no-app-debug`

## Risks / Follow-up

- The compliance model weights are heuristic defaults and may need calibration:
  - `kStrengthBaseline = 0.55`, `kStrengthWeight = 4.0`, `kDetourWeight = 2.0`, `kPropensityWeight = 1.0`
- Tooltip and authoring currently list all configured periods; run-time view could be extended later to highlight the currently active period.

---

## Compliance model details

Let:
- `detourMeters = max(0, guidedDistance - originalDistance)` where distances are zone-route shortest path distances.
- `detourRatio = detourMeters / max(1e-6, maxDetourMeters)`

Then:
- `pFollow = sigmoid( logit(baseComplianceRate)
  + 4.0 * (guidanceStrength - 0.55)
  - 2.0 * detourRatio
  + 1.0 * logit(guidancePropensity) )`

`pFollow` is clamped to `[0,1]`.

Agents sample follow/not-follow when the active guidance/period changes (active id includes `:p<periodIndex>`).