### PR TITLE
[Application] Allow layout tool deselection

### DIFF
--- a/src/application/LayoutPreviewWidget.cpp
+++ b/src/application/LayoutPreviewWidget.cpp
@@ -2615,6 +2615,12 @@ void LayoutPreviewWidget::keyPressEvent(QKeyEvent* event) {
         }
     }
 
+    if (event->key() == Qt::Key_Escape && toolMode_ != ToolMode::Select) {
+        setToolMode(ToolMode::Select);
+        event->accept();
+        return;
+    }
+
     QWidget::keyPressEvent(event);
 }
 
@@ -5081,13 +5087,16 @@ void LayoutPreviewWidget::setupToolbars() {
         gridSpacingMeters_ = gridSpacingComboBox_->itemData(index).toDouble();
         update();
     });
-    connect(roomToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::DrawRoom); });
-    connect(exitToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::DrawExit); });
-    connect(wallToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::DrawWall); });
-    connect(obstructionToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::DrawObstruction); });
-    connect(doorToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::DrawDoor); });
-    connect(stairToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::DrawStair); });
-    connect(uStairToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::DrawUStair); });
+    const auto toggleToolMode = [this](ToolMode mode) {
+        setToolMode(toolMode_ == mode ? ToolMode::Select : mode);
+    };
+    connect(roomToolButton_, &QToolButton::clicked, this, [this, toggleToolMode]() { toggleToolMode(ToolMode::DrawRoom); });
+    connect(exitToolButton_, &QToolButton::clicked, this, [this, toggleToolMode]() { toggleToolMode(ToolMode::DrawExit); });
+    connect(wallToolButton_, &QToolButton::clicked, this, [this, toggleToolMode]() { toggleToolMode(ToolMode::DrawWall); });
+    connect(obstructionToolButton_, &QToolButton::clicked, this, [this, toggleToolMode]() { toggleToolMode(ToolMode::DrawObstruction); });
+    connect(doorToolButton_, &QToolButton::clicked, this, [this, toggleToolMode]() { toggleToolMode(ToolMode::DrawDoor); });
+    connect(stairToolButton_, &QToolButton::clicked, this, [this, toggleToolMode]() { toggleToolMode(ToolMode::DrawStair); });
+    connect(uStairToolButton_, &QToolButton::clicked, this, [this, toggleToolMode]() { toggleToolMode(ToolMode::DrawUStair); });
     connect(roomAutoWallsCheckBox_, &QCheckBox::toggled, this, [this](bool checked) {
         roomAutoWallsEnabled_ = checked;
     });


### PR DESCRIPTION
## Summary

- 레이아웃 편집 툴 버튼을 다시 눌렀을 때 `Select` 모드로 돌아가도록 수정한다.
- `Esc` 키로도 현재 그리기 툴에서 `Select` 모드로 빠져나올 수 있게 한다.
- Draw Room 같은 생성 툴이 계속 선택된 상태라 Wall/Door 등 기존 개체 선택이 어려운 문제를 완화한다.

## Related Issue

- None (application-only PR)

## Area

- [ ] Engine
- [ ] Domain
- [x] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [ ] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug --target safecrowd_app`
- [ ] `ctest --preset test-debug`
- [ ] Not run (reason below)

## Risks / Follow-up

- 변경 범위는 `LayoutPreviewWidget`의 툴 모드 전환에 한정된다.
- UI 동작 변경이라 버튼 재클릭과 `Esc` 복귀는 앱에서 수동 확인하면 더 좋다.