### PR TITLE
[Application] Add scenario result skip action

### DIFF
--- a/src/application/ScenarioResultWidget.cpp
+++ b/src/application/ScenarioResultWidget.cpp
@@ -1459,6 +1459,9 @@ void ScenarioResultWidget::rerunScenario() {
         saveProjectHandler_,
         openProjectHandler_,
         backToLayoutReviewHandler_,
+        frame_,
+        risk_,
+        artifacts_,
         this);
 
     rootLayout->replaceWidget(shell_, runWidget);

--- a/src/application/ScenarioRunWidget.cpp
+++ b/src/application/ScenarioRunWidget.cpp
@@ -181,6 +181,35 @@ ScenarioRunWidget::ScenarioRunWidget(
       saveProjectHandler_(std::move(saveProjectHandler)),
       openProjectHandler_(std::move(openProjectHandler)),
       backToLayoutReviewHandler_(std::move(backToLayoutReviewHandler)) {
+    setupUi();
+}
+
+ScenarioRunWidget::ScenarioRunWidget(
+    const QString& projectName,
+    const safecrowd::domain::FacilityLayout2D& layout,
+    const safecrowd::domain::ScenarioDraft& scenario,
+    std::function<void()> saveProjectHandler,
+    std::function<void()> openProjectHandler,
+    std::function<void()> backToLayoutReviewHandler,
+    safecrowd::domain::SimulationFrame cachedResultFrame,
+    safecrowd::domain::ScenarioRiskSnapshot cachedResultRisk,
+    safecrowd::domain::ScenarioResultArtifacts cachedResultArtifacts,
+    QWidget* parent)
+    : QWidget(parent),
+      projectName_(projectName),
+      layout_(layout),
+      scenario_(scenario),
+      runner_(layout_, scenario_),
+      cachedResultFrame_(std::move(cachedResultFrame)),
+      cachedResultRisk_(std::move(cachedResultRisk)),
+      cachedResultArtifacts_(std::move(cachedResultArtifacts)),
+      saveProjectHandler_(std::move(saveProjectHandler)),
+      openProjectHandler_(std::move(openProjectHandler)),
+      backToLayoutReviewHandler_(std::move(backToLayoutReviewHandler)) {
+    setupUi();
+}
+
+void ScenarioRunWidget::setupUi() {
     auto* rootLayout = new QVBoxLayout(this);
     rootLayout->setContentsMargins(0, 0, 0, 0);
     rootLayout->setSpacing(0);
@@ -275,6 +304,12 @@ QWidget* ScenarioRunWidget::createRunPanel() {
 
     layout->addStretch(1);
 
+    skipResultButton_ = new QPushButton("Skip for Result", panel);
+    skipResultButton_->setFont(ui::font(ui::FontRole::Body));
+    skipResultButton_->setStyleSheet(ui::secondaryButtonStyleSheet());
+    skipResultButton_->setEnabled(false);
+    layout->addWidget(skipResultButton_);
+
     resultButton_ = new QPushButton("View Results", panel);
     resultButton_->setFont(ui::font(ui::FontRole::Body));
     resultButton_->setStyleSheet(ui::primaryButtonStyleSheet());
@@ -286,6 +321,9 @@ QWidget* ScenarioRunWidget::createRunPanel() {
     });
     connect(stopButton_, &QPushButton::clicked, this, [this]() {
         stopRun();
+    });
+    connect(skipResultButton_, &QPushButton::clicked, this, [this]() {
+        runToCompletion();
     });
     connect(resultButton_, &QPushButton::clicked, this, [this]() {
         showResults();
@@ -324,6 +362,12 @@ void ScenarioRunWidget::returnToAuthoring() {
     shell_->deleteLater();
     shell_ = nullptr;
     canvas_ = nullptr;
+}
+
+bool ScenarioRunWidget::hasCachedResult() const noexcept {
+    return cachedResultFrame_.has_value()
+        && cachedResultRisk_.has_value()
+        && cachedResultArtifacts_.has_value();
 }
 
 void ScenarioRunWidget::refreshStatus() {
@@ -390,24 +434,75 @@ void ScenarioRunWidget::refreshStatus() {
     if (stopButton_ != nullptr) {
         stopButton_->setEnabled(frame.totalAgentCount > 0);
     }
-    if (resultButton_ != nullptr) {
-        resultButton_->setEnabled(frame.complete && frame.totalAgentCount > 0);
+    if (skipResultButton_ != nullptr) {
+        skipResultButton_->setEnabled(frame.totalAgentCount > 0 && !frame.complete && !hasCachedResult());
     }
+    if (resultButton_ != nullptr) {
+        const auto cachedAgentCount = hasCachedResult() ? cachedResultFrame_->totalAgentCount : 0;
+        resultButton_->setEnabled(
+            (frame.complete && frame.totalAgentCount > 0)
+            || cachedAgentCount > 0);
+    }
+}
+
+bool ScenarioRunWidget::runToCompletion() {
+    if (timer_ != nullptr) {
+        timer_->stop();
+    }
+
+    const auto remainingSeconds = std::max(0.0, runner_.timeLimitSeconds() - runner_.frame().elapsedSeconds);
+    const auto maxSteps = static_cast<int>(std::ceil(remainingSeconds / kSimulationDeltaSeconds)) + 2;
+    for (int step = 0; step < maxSteps && !runner_.complete(); ++step) {
+        runner_.step(kSimulationDeltaSeconds);
+    }
+
+    if (canvas_ != nullptr) {
+        canvas_->setFrame(runner_.frame());
+    }
+    if (runner_.complete()) {
+        storeResultCache(runner_);
+    }
+    refreshStatus();
+    return runner_.complete();
+}
+
+void ScenarioRunWidget::storeResultCache(const safecrowd::domain::ScenarioSimulationRunner& runner) {
+    cachedResultFrame_ = runner.frame();
+    cachedResultRisk_ = runner.resultRiskSnapshot();
+    cachedResultArtifacts_ = runner.resultArtifacts();
 }
 
 void ScenarioRunWidget::stopRun() {
     paused_ = true;
     runner_.reset(layout_, scenario_);
+    cachedResultFrame_.reset();
+    cachedResultRisk_.reset();
+    cachedResultArtifacts_.reset();
     canvas_->setFrame(runner_.frame());
     refreshStatus();
     timer_->start();
 }
 
 void ScenarioRunWidget::showResults() {
-    const auto& frame = runner_.frame();
-    if (frame.totalAgentCount == 0 || !frame.complete) {
+    if (runner_.frame().totalAgentCount == 0 && !hasCachedResult()) {
         return;
     }
+
+    const auto* resultFrame = &runner_.frame();
+    const auto* resultRisk = &runner_.resultRiskSnapshot();
+    const auto* resultArtifacts = &runner_.resultArtifacts();
+    if (!runner_.complete() && hasCachedResult()) {
+        resultFrame = &*cachedResultFrame_;
+        resultRisk = &*cachedResultRisk_;
+        resultArtifacts = &*cachedResultArtifacts_;
+    } else if (!runner_.complete()) {
+        return;
+    } else {
+        resultFrame = &runner_.frame();
+        resultRisk = &runner_.resultRiskSnapshot();
+        resultArtifacts = &runner_.resultArtifacts();
+    }
+
     if (timer_ != nullptr) {
         timer_->stop();
     }
@@ -421,9 +516,9 @@ void ScenarioRunWidget::showResults() {
         projectName_,
         layout_,
         scenario_,
-        runner_.frame(),
-        runner_.resultRiskSnapshot(),
-        runner_.resultArtifacts(),
+        *resultFrame,
+        *resultRisk,
+        *resultArtifacts,
         [this]() {
             if (saveProjectHandler_) {
                 saveProjectHandler_();

--- a/src/application/ScenarioRunWidget.h
+++ b/src/application/ScenarioRunWidget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 
 #include <QString>
 #include <QWidget>
@@ -29,13 +30,28 @@ public:
         std::function<void()> openProjectHandler,
         std::function<void()> backToLayoutReviewHandler,
         QWidget* parent = nullptr);
+    explicit ScenarioRunWidget(
+        const QString& projectName,
+        const safecrowd::domain::FacilityLayout2D& layout,
+        const safecrowd::domain::ScenarioDraft& scenario,
+        std::function<void()> saveProjectHandler,
+        std::function<void()> openProjectHandler,
+        std::function<void()> backToLayoutReviewHandler,
+        safecrowd::domain::SimulationFrame cachedResultFrame,
+        safecrowd::domain::ScenarioRiskSnapshot cachedResultRisk,
+        safecrowd::domain::ScenarioResultArtifacts cachedResultArtifacts,
+        QWidget* parent = nullptr);
 
     const safecrowd::domain::ScenarioDraft& scenario() const noexcept;
 
 private:
     QWidget* createRunPanel();
     void returnToAuthoring();
+    bool hasCachedResult() const noexcept;
     void refreshStatus();
+    bool runToCompletion();
+    void storeResultCache(const safecrowd::domain::ScenarioSimulationRunner& runner);
+    void setupUi();
     void showResults();
     void stopRun();
     void togglePaused();
@@ -44,6 +60,9 @@ private:
     safecrowd::domain::FacilityLayout2D layout_{};
     safecrowd::domain::ScenarioDraft scenario_{};
     safecrowd::domain::ScenarioSimulationRunner runner_{};
+    std::optional<safecrowd::domain::SimulationFrame> cachedResultFrame_{};
+    std::optional<safecrowd::domain::ScenarioRiskSnapshot> cachedResultRisk_{};
+    std::optional<safecrowd::domain::ScenarioResultArtifacts> cachedResultArtifacts_{};
     std::function<void()> saveProjectHandler_{};
     std::function<void()> openProjectHandler_{};
     std::function<void()> backToLayoutReviewHandler_{};
@@ -61,6 +80,7 @@ private:
     QLabel* bottleneckLabel_{nullptr};
     QPushButton* pauseButton_{nullptr};
     QPushButton* stopButton_{nullptr};
+    QPushButton* skipResultButton_{nullptr};
     QPushButton* resultButton_{nullptr};
     bool paused_{false};
 };


### PR DESCRIPTION
## Summary

- 시나리오 실행 화면의 `View Results` 위에 `Skip for Result` 버튼을 추가한다.
- 시뮬레이션 재생 중에는 추가 결과 계산을 자동으로 병행하지 않고, 사용자가 `Skip for Result`를 누른 경우에만 남은 시뮬레이션을 끝까지 계산한다.
- 결과 계산이 완료되거나 기존 결과 캐시가 있는 경우에만 `View Results`를 활성화한다.
- `Run Again`으로 실행 화면에 돌아온 경우 기존 `frame`/`risk`/`artifacts`를 캐시로 넘겨, 다시 처음부터 계산하지 않고 바로 결과창으로 돌아갈 수 있게 한다.

## Related Issue

- None (application-only PR)

## Area

- [ ] Engine
- [ ] Domain
- [x] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [x] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug`
- [x] `ctest --preset test-debug`
- [ ] Not run (reason below)

## Risks / Follow-up

- UI 흐름 변경이라 앱에서 `Run Staged Scenarios` → `Skip for Result` → `View Results` 및 `Run Again` → `View Results` 수동 확인이 필요하다.
- 열린 PR #193, #196도 `ScenarioRunWidget` 주변을 수정하므로 merge 순서에 따라 충돌이 날 수 있다.