### PR TITLE
[Application] Run staged scenarios as batch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,8 @@ add_library(safecrowd_domain STATIC
     src/domain/PopulationSpec.h
     src/domain/ScenarioAuthoring.h
     src/domain/ScenarioAuthoring.cpp
+    src/domain/ScenarioBatchRunner.h
+    src/domain/ScenarioBatchRunner.cpp
     src/domain/ScenarioRiskMetrics.h
     src/domain/ScenarioRiskMetrics.cpp
     src/domain/ScenarioRiskMetricsSystem.cpp
@@ -156,6 +158,7 @@ if (BUILD_TESTING)
         tests/DeterministicRngTests.cpp
         tests/ScenarioSimulationRunnerTests.cpp
         tests/ScenarioAuthoringTests.cpp
+        tests/ScenarioBatchRunnerTests.cpp
     )
 
     target_include_directories(safecrowd_tests
@@ -191,6 +194,7 @@ if (SAFECROWD_BUILD_APP)
         src/application/ProjectNavigatorWidget.h
         src/application/ProjectPersistence.h
         src/application/ScenarioAuthoringWidget.h
+        src/application/ScenarioBatchResultWidget.h
         src/application/ScenarioCanvasWidget.h
         src/application/ScenarioResultWidget.h
         src/application/ScenarioRunWidget.h
@@ -213,6 +217,7 @@ if (SAFECROWD_BUILD_APP)
         src/application/ProjectNavigatorWidget.cpp
         src/application/ProjectPersistence.cpp
         src/application/ScenarioAuthoringWidget.cpp
+        src/application/ScenarioBatchResultWidget.cpp
         src/application/ScenarioCanvasWidget.cpp
         src/application/ScenarioResultWidget.cpp
         src/application/ScenarioRunWidget.cpp

--- a/src/application/MainWindow.cpp
+++ b/src/application/MainWindow.cpp
@@ -12,6 +12,7 @@
 #include "application/ProjectPersistence.h"
 #include "application/ProjectNavigatorWidget.h"
 #include "application/ScenarioAuthoringWidget.h"
+#include "application/ScenarioBatchResultWidget.h"
 #include "application/ScenarioResultWidget.h"
 #include "application/ScenarioRunWidget.h"
 #include "domain/DemoFixtureService.h"
@@ -73,11 +74,16 @@ ProjectWorkspaceState makeEvacuationScenarioDemoWorkspace() {
     workspace.activeView = ProjectWorkspaceView::ScenarioResult;
     workspace.authoring = std::move(authoring);
     workspace.runningScenario = fixture.alternativeScenario;
+    workspace.runningScenarios = {fixture.baselineScenario, fixture.alternativeScenario};
     workspace.result = SavedScenarioResultState{
-        .scenario = std::move(fixture.alternativeScenario),
+        .scenario = fixture.alternativeScenario,
         .frame = std::move(fixture.frame),
         .risk = std::move(fixture.risk),
         .artifacts = std::move(fixture.artifacts),
+    };
+    workspace.batchResult = SavedScenarioBatchResultState{
+        .results = {*workspace.result},
+        .currentResultIndex = 0,
     };
     return workspace;
 }
@@ -410,6 +416,15 @@ void MainWindow::openProject(const ProjectMetadata& metadata) {
         }
         break;
     case ProjectWorkspaceView::ScenarioRun:
+        if (!workspace.runningScenarios.empty()) {
+            showScenarioRun(
+                *importResult.layout,
+                std::move(workspace.runningScenarios),
+                workspace.authoring.has_value()
+                    ? std::make_optional(initialStateFromSaved(*workspace.authoring, *importResult.layout))
+                    : std::nullopt);
+            return;
+        }
         if (workspace.runningScenario.has_value()) {
             showScenarioRun(
                 *importResult.layout,
@@ -421,6 +436,16 @@ void MainWindow::openProject(const ProjectMetadata& metadata) {
         }
         break;
     case ProjectWorkspaceView::ScenarioResult:
+        if (workspace.batchResult.has_value() && workspace.batchResult->results.size() > 1) {
+            showScenarioBatchResult(
+                *importResult.layout,
+                workspace.batchResult->results,
+                workspace.batchResult->currentResultIndex,
+                workspace.authoring.has_value()
+                    ? std::make_optional(initialStateFromSaved(*workspace.authoring, *importResult.layout))
+                    : std::nullopt);
+            return;
+        }
         if (workspace.result.has_value()) {
             showScenarioResult(
                 *importResult.layout,
@@ -477,6 +502,22 @@ void MainWindow::saveCurrentProject() {
     if (auto* authoringWidget = visibleChild<ScenarioAuthoringWidget>(centralWidget())) {
         workspace.activeView = ProjectWorkspaceView::ScenarioAuthoring;
         workspace.authoring = authoringWidget->currentSavedState();
+    } else if (auto* batchResultWidget = visibleChild<ScenarioBatchResultWidget>(centralWidget())) {
+        workspace.activeView = ProjectWorkspaceView::ScenarioResult;
+        if (auto authoring = batchResultWidget->returnAuthoringState(); authoring.has_value()) {
+            workspace.authoring = savedStateFromInitial(*authoring);
+        }
+        workspace.batchResult = SavedScenarioBatchResultState{
+            .results = batchResultWidget->results(),
+            .currentResultIndex = batchResultWidget->currentResultIndex(),
+        };
+        if (!workspace.batchResult->results.empty()) {
+            const auto index = std::clamp(
+                workspace.batchResult->currentResultIndex,
+                0,
+                static_cast<int>(workspace.batchResult->results.size()) - 1);
+            workspace.result = workspace.batchResult->results[static_cast<std::size_t>(index)];
+        }
     } else if (auto* resultWidget = visibleChild<ScenarioResultWidget>(centralWidget())) {
         workspace.activeView = ProjectWorkspaceView::ScenarioResult;
         if (resultWidget->returnAuthoringState().has_value()) {
@@ -494,6 +535,7 @@ void MainWindow::saveCurrentProject() {
             workspace.authoring = savedStateFromInitial(*runWidget->returnAuthoringState());
         }
         workspace.runningScenario = runWidget->scenario();
+        workspace.runningScenarios = runWidget->scenarios();
     }
 
     if (!ProjectPersistence::saveProjectWorkspace(currentProject_, workspace, &errorMessage)) {
@@ -603,10 +645,20 @@ void MainWindow::showScenarioRun(
     const safecrowd::domain::FacilityLayout2D& layout,
     const safecrowd::domain::ScenarioDraft& scenario,
     std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState) {
+    showScenarioRun(
+        layout,
+        std::vector<safecrowd::domain::ScenarioDraft>{scenario},
+        std::move(returnAuthoringState));
+}
+
+void MainWindow::showScenarioRun(
+    const safecrowd::domain::FacilityLayout2D& layout,
+    std::vector<safecrowd::domain::ScenarioDraft> scenarios,
+    std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState) {
     setCentralWidget(new ScenarioRunWidget(
         currentProject_.name,
         layout,
-        scenario,
+        std::move(scenarios),
         [this]() {
             saveCurrentProject();
         },
@@ -622,8 +674,37 @@ void MainWindow::showScenarioRun(
                 showLayoutReview(currentProject_);
             }
         },
-        this,
-        std::move(returnAuthoringState)));
+        std::move(returnAuthoringState),
+        this));
+}
+
+void MainWindow::showScenarioBatchResult(
+    const safecrowd::domain::FacilityLayout2D& layout,
+    std::vector<SavedScenarioResultState> results,
+    int currentResultIndex,
+    std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState) {
+    setCentralWidget(new ScenarioBatchResultWidget(
+        currentProject_.name,
+        layout,
+        std::move(results),
+        [this]() {
+            saveCurrentProject();
+        },
+        [this]() {
+            hasCurrentProject_ = false;
+            currentProject_ = {};
+            showProjectNavigator();
+        },
+        [this]() {
+            if (lastApprovedImportResult_.has_value()) {
+                showLayoutReview(currentProject_, *lastApprovedImportResult_);
+            } else {
+                showLayoutReview(currentProject_);
+            }
+        },
+        std::move(returnAuthoringState),
+        currentResultIndex,
+        this));
 }
 
 void MainWindow::showScenarioResult(

--- a/src/application/MainWindow.h
+++ b/src/application/MainWindow.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <optional>
+#include <vector>
 
 #include <QMainWindow>
 
 #include "application/ProjectMetadata.h"
+#include "application/ProjectWorkspaceState.h"
 #include "application/ScenarioAuthoringWidget.h"
 #include "domain/ImportResult.h"
 #include "domain/ScenarioResultArtifacts.h"
@@ -40,6 +42,15 @@ private:
     void showScenarioRun(
         const safecrowd::domain::FacilityLayout2D& layout,
         const safecrowd::domain::ScenarioDraft& scenario,
+        std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState = std::nullopt);
+    void showScenarioRun(
+        const safecrowd::domain::FacilityLayout2D& layout,
+        std::vector<safecrowd::domain::ScenarioDraft> scenarios,
+        std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState = std::nullopt);
+    void showScenarioBatchResult(
+        const safecrowd::domain::FacilityLayout2D& layout,
+        std::vector<SavedScenarioResultState> results,
+        int currentResultIndex,
         std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState = std::nullopt);
     void showScenarioResult(
         const safecrowd::domain::FacilityLayout2D& layout,

--- a/src/application/ProjectPersistence.cpp
+++ b/src/application/ProjectPersistence.cpp
@@ -1,6 +1,8 @@
 #include "application/ProjectPersistence.h"
 
 #include <algorithm>
+#include <cstddef>
+#include <vector>
 
 #include <QDateTime>
 #include <QDebug>
@@ -1137,6 +1139,46 @@ SavedScenarioResultState resultStateFromJson(const QJsonObject& object) {
     };
 }
 
+QJsonArray scenarioDraftsToJson(const std::vector<safecrowd::domain::ScenarioDraft>& scenarios) {
+    QJsonArray array;
+    for (const auto& scenario : scenarios) {
+        array.append(scenarioDraftToJson(scenario));
+    }
+    return array;
+}
+
+std::vector<safecrowd::domain::ScenarioDraft> scenarioDraftsFromJson(const QJsonArray& array) {
+    std::vector<safecrowd::domain::ScenarioDraft> scenarios;
+    scenarios.reserve(static_cast<std::size_t>(array.size()));
+    for (const auto& value : array) {
+        scenarios.push_back(scenarioDraftFromJson(value.toObject()));
+    }
+    return scenarios;
+}
+
+QJsonObject batchResultStateToJson(const SavedScenarioBatchResultState& batch) {
+    QJsonObject object;
+    QJsonArray results;
+    for (const auto& result : batch.results) {
+        results.append(resultStateToJson(result));
+    }
+    object["results"] = results;
+    object["currentResultIndex"] = batch.currentResultIndex;
+    return object;
+}
+
+SavedScenarioBatchResultState batchResultStateFromJson(const QJsonObject& object) {
+    SavedScenarioBatchResultState batch;
+    for (const auto& value : object.value("results").toArray()) {
+        batch.results.push_back(resultStateFromJson(value.toObject()));
+    }
+    batch.currentResultIndex = object.value("currentResultIndex").toInt(0);
+    if (batch.currentResultIndex < 0 || batch.currentResultIndex >= static_cast<int>(batch.results.size())) {
+        batch.currentResultIndex = 0;
+    }
+    return batch;
+}
+
 QJsonObject workspaceStateToJson(const ProjectWorkspaceState& state) {
     QJsonObject object;
     object["version"] = 1;
@@ -1147,8 +1189,14 @@ QJsonObject workspaceStateToJson(const ProjectWorkspaceState& state) {
     if (state.runningScenario.has_value()) {
         object["runningScenario"] = scenarioDraftToJson(*state.runningScenario);
     }
+    if (!state.runningScenarios.empty()) {
+        object["runningScenarios"] = scenarioDraftsToJson(state.runningScenarios);
+    }
     if (state.result.has_value()) {
         object["result"] = resultStateToJson(*state.result);
+    }
+    if (state.batchResult.has_value()) {
+        object["batchResult"] = batchResultStateToJson(*state.batchResult);
     }
     return object;
 }
@@ -1162,8 +1210,21 @@ ProjectWorkspaceState workspaceStateFromJson(const QJsonObject& object) {
     if (object.value("runningScenario").isObject()) {
         state.runningScenario = scenarioDraftFromJson(object.value("runningScenario").toObject());
     }
+    if (object.value("runningScenarios").isArray()) {
+        state.runningScenarios = scenarioDraftsFromJson(object.value("runningScenarios").toArray());
+    } else if (state.runningScenario.has_value()) {
+        state.runningScenarios.push_back(*state.runningScenario);
+    }
     if (object.value("result").isObject()) {
         state.result = resultStateFromJson(object.value("result").toObject());
+    }
+    if (object.value("batchResult").isObject()) {
+        state.batchResult = batchResultStateFromJson(object.value("batchResult").toObject());
+    } else if (state.result.has_value()) {
+        state.batchResult = SavedScenarioBatchResultState{
+            .results = {*state.result},
+            .currentResultIndex = 0,
+        };
     }
     return state;
 }

--- a/src/application/ProjectWorkspaceState.h
+++ b/src/application/ProjectWorkspaceState.h
@@ -50,11 +50,18 @@ struct SavedScenarioResultState {
     safecrowd::domain::ScenarioResultArtifacts artifacts{};
 };
 
+struct SavedScenarioBatchResultState {
+    std::vector<SavedScenarioResultState> results{};
+    int currentResultIndex{0};
+};
+
 struct ProjectWorkspaceState {
     ProjectWorkspaceView activeView{ProjectWorkspaceView::LayoutReview};
     std::optional<SavedScenarioAuthoringState> authoring{};
     std::optional<safecrowd::domain::ScenarioDraft> runningScenario{};
+    std::vector<safecrowd::domain::ScenarioDraft> runningScenarios{};
     std::optional<SavedScenarioResultState> result{};
+    std::optional<SavedScenarioBatchResultState> batchResult{};
 };
 
 }  // namespace safecrowd::application

--- a/src/application/ScenarioAuthoringWidget.cpp
+++ b/src/application/ScenarioAuthoringWidget.cpp
@@ -1060,12 +1060,12 @@ void ScenarioAuthoringWidget::refreshScenarioSwitcher() {
     scenarioSwitcher_->blockSignals(false);
 }
 
-void ScenarioAuthoringWidget::runFirstStagedBaselineScenario() {
-    const auto* scenario = firstStagedBaselineScenario();
-    if (scenario == nullptr) {
+void ScenarioAuthoringWidget::runStagedScenarios() {
+    auto scenarios = stagedRunnableScenarios();
+    if (scenarios.empty()) {
         if (stagedScenariosLabel_ != nullptr) {
             stagedScenariosLabel_->setText(stagedScenariosLabel_->text()
-                + "\n\nNo staged baseline scenario is ready to run.");
+                + "\n\nNo staged scenario is ready to run.");
         }
         return;
     }
@@ -1078,12 +1078,12 @@ void ScenarioAuthoringWidget::runFirstStagedBaselineScenario() {
     auto* runWidget = new ScenarioRunWidget(
         projectName_,
         layout_,
-        scenario->draft,
+        std::move(scenarios),
         saveProjectHandler_,
         openProjectHandler_,
         backToLayoutReviewHandler_,
-        this,
-        currentInitialState());
+        currentInitialState(),
+        this);
     rootLayout->replaceWidget(shell_, runWidget);
     shell_->hide();
     shell_->deleteLater();
@@ -1307,7 +1307,7 @@ QWidget* ScenarioAuthoringWidget::createScenarioPanel() {
         stageCurrentScenario();
     });
     connect(executeRunButton_, &QPushButton::clicked, this, [this]() {
-        runFirstStagedBaselineScenario();
+        runStagedScenarios();
     });
 
     return inspector;
@@ -1327,13 +1327,16 @@ const ScenarioAuthoringWidget::ScenarioState* ScenarioAuthoringWidget::currentSc
     return &scenarios_[currentScenarioIndex_];
 }
 
-const ScenarioAuthoringWidget::ScenarioState* ScenarioAuthoringWidget::firstStagedBaselineScenario() const {
-    const auto it = std::find_if(scenarios_.begin(), scenarios_.end(), [](const auto& scenario) {
-        return scenario.stagedForRun
-            && scenarioHasOccupants(scenario)
-            && scenario.draft.role == safecrowd::domain::ScenarioRole::Baseline;
-    });
-    return it == scenarios_.end() ? nullptr : &(*it);
+std::vector<safecrowd::domain::ScenarioDraft> ScenarioAuthoringWidget::stagedRunnableScenarios() const {
+    std::vector<safecrowd::domain::ScenarioDraft> staged;
+    for (const auto& scenario : scenarios_) {
+        if (scenario.stagedForRun && scenarioHasOccupants(scenario)) {
+            auto draft = scenario.draft;
+            draft.control.events = scenario.events;
+            staged.push_back(std::move(draft));
+        }
+    }
+    return staged;
 }
 
 }  // namespace safecrowd::application

--- a/src/application/ScenarioAuthoringWidget.h
+++ b/src/application/ScenarioAuthoringWidget.h
@@ -85,7 +85,7 @@ private:
     void recomputeDiffKeysAfterScenarioChanged(ScenarioState& scenario);
     void recomputeDependentVariationDiffKeys(const QString& baselineId);
     void recomputeVariationDiffKeysIfAlternative(ScenarioState& scenario) const;
-    void runFirstStagedBaselineScenario();
+    void runStagedScenarios();
     void stageCurrentScenario();
     void updateCurrentScenarioPlacements(const std::vector<ScenarioCrowdPlacement>& placements);
     void showEmptyCanvas();
@@ -93,7 +93,7 @@ private:
     QWidget* createScenarioPanel();
     ScenarioState* currentScenario();
     const ScenarioState* currentScenario() const;
-    const ScenarioState* firstStagedBaselineScenario() const;
+    std::vector<safecrowd::domain::ScenarioDraft> stagedRunnableScenarios() const;
 
     QString projectName_{};
     safecrowd::domain::FacilityLayout2D layout_{};

--- a/src/application/ScenarioBatchResultWidget.cpp
+++ b/src/application/ScenarioBatchResultWidget.cpp
@@ -1,0 +1,326 @@
+#include "application/ScenarioBatchResultWidget.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <utility>
+
+#include <QHeaderView>
+#include <QLabel>
+#include <QAbstractItemView>
+#include <QPushButton>
+#include <QTableWidget>
+#include <QTableWidgetItem>
+#include <QVBoxLayout>
+
+#include "application/ScenarioRunWidget.h"
+#include "application/SimulationCanvasWidget.h"
+#include "application/UiStyle.h"
+#include "application/WorkspaceShell.h"
+
+namespace safecrowd::application {
+namespace {
+
+QLabel* createLabel(const QString& text, QWidget* parent, ui::FontRole role = ui::FontRole::Body) {
+    auto* label = new QLabel(text, parent);
+    label->setFont(ui::font(role));
+    label->setWordWrap(true);
+    return label;
+}
+
+QString formatSeconds(const std::optional<double>& seconds) {
+    return seconds.has_value() ? QString("%1 sec").arg(*seconds, 0, 'f', 1) : QString("Pending");
+}
+
+QString formatSeconds(double seconds) {
+    return QString("%1 sec").arg(seconds, 0, 'f', 1);
+}
+
+QString formatPercent(std::size_t numerator, std::size_t denominator) {
+    if (denominator == 0) {
+        return "0%";
+    }
+    const auto ratio = std::clamp(static_cast<double>(numerator) / static_cast<double>(denominator), 0.0, 1.0);
+    return QString("%1%").arg(ratio * 100.0, 0, 'f', 0);
+}
+
+QTableWidgetItem* readonlyItem(const QString& text) {
+    auto* item = new QTableWidgetItem(text);
+    item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+    return item;
+}
+
+std::vector<safecrowd::domain::ScenarioDraft> scenariosFromResults(
+    const std::vector<SavedScenarioResultState>& results) {
+    std::vector<safecrowd::domain::ScenarioDraft> scenarios;
+    scenarios.reserve(results.size());
+    for (const auto& result : results) {
+        scenarios.push_back(result.scenario);
+    }
+    return scenarios;
+}
+
+QString zoneLabel(const safecrowd::domain::Zone2D& zone) {
+    const auto id = QString::fromStdString(zone.id);
+    const auto label = QString::fromStdString(zone.label);
+    return label.isEmpty() ? id : QString("%1  -  %2").arg(label, id);
+}
+
+const safecrowd::domain::Zone2D* firstStartZone(const safecrowd::domain::FacilityLayout2D& layout) {
+    const auto it = std::find_if(layout.zones.begin(), layout.zones.end(), [](const auto& zone) {
+        return zone.kind == safecrowd::domain::ZoneKind::Room || zone.kind == safecrowd::domain::ZoneKind::Unknown;
+    });
+    return it == layout.zones.end() ? nullptr : &(*it);
+}
+
+const safecrowd::domain::Zone2D* firstDestinationZone(const safecrowd::domain::FacilityLayout2D& layout) {
+    const auto exitIt = std::find_if(layout.zones.begin(), layout.zones.end(), [](const auto& zone) {
+        return zone.kind == safecrowd::domain::ZoneKind::Exit;
+    });
+    if (exitIt != layout.zones.end()) {
+        return &(*exitIt);
+    }
+    return layout.zones.empty() ? nullptr : &layout.zones.back();
+}
+
+ScenarioAuthoringWidget::ScenarioState scenarioStateFromDraft(
+    const safecrowd::domain::ScenarioDraft& scenario,
+    const safecrowd::domain::FacilityLayout2D& layout) {
+    ScenarioAuthoringWidget::ScenarioState state;
+    state.draft = scenario;
+    state.events = scenario.control.events;
+    state.stagedForRun = true;
+
+    if (const auto* startZone = firstStartZone(layout); startZone != nullptr) {
+        state.startText = zoneLabel(*startZone);
+    }
+    if (const auto* destinationZone = firstDestinationZone(layout); destinationZone != nullptr) {
+        state.destinationText = zoneLabel(*destinationZone);
+    }
+
+    for (const auto& placement : scenario.population.initialPlacements) {
+        ScenarioCrowdPlacement uiPlacement;
+        uiPlacement.id = QString::fromStdString(placement.id);
+        uiPlacement.name = uiPlacement.id;
+        uiPlacement.kind = (placement.targetAgentCount <= 1 && placement.area.outline.size() <= 1)
+            ? ScenarioCrowdPlacementKind::Individual
+            : ScenarioCrowdPlacementKind::Group;
+        uiPlacement.zoneId = QString::fromStdString(placement.zoneId);
+        uiPlacement.floorId = QString::fromStdString(placement.floorId);
+        uiPlacement.area = placement.area.outline;
+        uiPlacement.occupantCount = static_cast<int>(placement.targetAgentCount);
+        uiPlacement.velocity = placement.initialVelocity;
+        uiPlacement.distribution = placement.distribution;
+        uiPlacement.generatedPositions = placement.explicitPositions;
+        state.crowdPlacements.push_back(std::move(uiPlacement));
+    }
+
+    return state;
+}
+
+}  // namespace
+
+ScenarioBatchResultWidget::ScenarioBatchResultWidget(
+    QString projectName,
+    safecrowd::domain::FacilityLayout2D layout,
+    std::vector<SavedScenarioResultState> results,
+    std::function<void()> saveProjectHandler,
+    std::function<void()> openProjectHandler,
+    std::function<void()> backToLayoutReviewHandler,
+    std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState,
+    int currentResultIndex,
+    QWidget* parent)
+    : QWidget(parent),
+      projectName_(std::move(projectName)),
+      layout_(std::move(layout)),
+      results_(std::move(results)),
+      returnAuthoringState_(std::move(returnAuthoringState)),
+      saveProjectHandler_(std::move(saveProjectHandler)),
+      openProjectHandler_(std::move(openProjectHandler)),
+      backToLayoutReviewHandler_(std::move(backToLayoutReviewHandler)),
+      currentResultIndex_(currentResultIndex) {
+    if (currentResultIndex_ < 0 || currentResultIndex_ >= static_cast<int>(results_.size())) {
+        currentResultIndex_ = 0;
+    }
+
+    auto* rootLayout = new QVBoxLayout(this);
+    rootLayout->setContentsMargins(0, 0, 0, 0);
+    rootLayout->setSpacing(0);
+
+    shell_ = new WorkspaceShell(WorkspaceShellOptions{
+        .showTopBar = true,
+        .navigationMode = WorkspaceNavigationMode::PanelOnly,
+        .showReviewPanel = true,
+        .reviewPanelWidth = 360,
+    }, this);
+    shell_->setTools({"Project"});
+    shell_->setSaveProjectHandler(saveProjectHandler_);
+    shell_->setOpenProjectHandler(openProjectHandler_);
+    shell_->setBackHandler([this]() {
+        navigateToAuthoring();
+    });
+
+    canvas_ = new SimulationCanvasWidget(layout_, shell_);
+    shell_->setCanvas(canvas_);
+    shell_->setReviewPanel(createSummaryPanel());
+    shell_->setReviewPanelVisible(true);
+    rootLayout->addWidget(shell_);
+    refreshSelectedResult();
+}
+
+const std::vector<SavedScenarioResultState>& ScenarioBatchResultWidget::results() const noexcept {
+    return results_;
+}
+
+int ScenarioBatchResultWidget::currentResultIndex() const noexcept {
+    return currentResultIndex_;
+}
+
+std::optional<ScenarioAuthoringWidget::InitialState> ScenarioBatchResultWidget::returnAuthoringState() const {
+    return returnAuthoringState_;
+}
+
+QWidget* ScenarioBatchResultWidget::createSummaryPanel() {
+    auto* panel = new QWidget(shell_);
+    auto* layout = new QVBoxLayout(panel);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(12);
+    layout->addWidget(shell_ != nullptr ? shell_->createPanelHeader("Comparison", panel, false) : createLabel("Comparison", panel, ui::FontRole::Title));
+
+    table_ = new QTableWidget(static_cast<int>(results_.size()), 7, panel);
+    table_->setHorizontalHeaderLabels({"Scenario", "Final", "Evac.", "Risk", "Bottlenecks", "T90", "T95"});
+    table_->verticalHeader()->setVisible(false);
+    table_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    table_->setSelectionMode(QAbstractItemView::SingleSelection);
+    table_->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    table_->setAlternatingRowColors(true);
+    table_->horizontalHeader()->setStretchLastSection(true);
+    table_->setStyleSheet(
+        "QTableWidget { background: #ffffff; border: 1px solid #d7e0ea; border-radius: 8px; gridline-color: #e4ebf3; }"
+        "QHeaderView::section { background: #eef3f8; border: 0; padding: 6px; color: #4f5d6b; }"
+        "QTableWidget::item { padding: 6px; }");
+    for (int row = 0; row < static_cast<int>(results_.size()); ++row) {
+        const auto& result = results_[row];
+        table_->setItem(row, 0, readonlyItem(QString::fromStdString(result.scenario.name)));
+        table_->setItem(row, 1, readonlyItem(formatSeconds(
+            result.artifacts.timingSummary.finalEvacuationTimeSeconds.value_or(result.frame.elapsedSeconds))));
+        table_->setItem(row, 2, readonlyItem(formatPercent(result.frame.evacuatedAgentCount, result.frame.totalAgentCount)));
+        table_->setItem(row, 3, readonlyItem(safecrowd::domain::scenarioRiskLevelLabel(result.risk.completionRisk)));
+        table_->setItem(row, 4, readonlyItem(QString::number(static_cast<int>(result.risk.bottlenecks.size()))));
+        table_->setItem(row, 5, readonlyItem(formatSeconds(result.artifacts.timingSummary.t90Seconds)));
+        table_->setItem(row, 6, readonlyItem(formatSeconds(result.artifacts.timingSummary.t95Seconds)));
+    }
+    table_->resizeColumnsToContents();
+    layout->addWidget(table_, 1);
+
+    detailLabel_ = createLabel("", panel);
+    detailLabel_->setStyleSheet(ui::mutedTextStyleSheet());
+    layout->addWidget(detailLabel_);
+    layout->addStretch(1);
+
+    auto* rerunButton = new QPushButton("Run Again", panel);
+    rerunButton->setFont(ui::font(ui::FontRole::Body));
+    rerunButton->setStyleSheet(ui::secondaryButtonStyleSheet());
+    layout->addWidget(rerunButton);
+    auto* editButton = new QPushButton("Edit Scenarios", panel);
+    editButton->setFont(ui::font(ui::FontRole::Body));
+    editButton->setStyleSheet(ui::secondaryButtonStyleSheet());
+    layout->addWidget(editButton);
+
+    connect(table_, &QTableWidget::currentCellChanged, this, [this](int currentRow, int, int, int) {
+        if (currentRow >= 0 && currentRow < static_cast<int>(results_.size())) {
+            currentResultIndex_ = currentRow;
+            refreshSelectedResult();
+        }
+    });
+    connect(rerunButton, &QPushButton::clicked, this, [this]() {
+        rerunBatch();
+    });
+    connect(editButton, &QPushButton::clicked, this, [this]() {
+        navigateToAuthoring();
+    });
+    if (!results_.empty()) {
+        table_->selectRow(currentResultIndex_);
+    }
+    return panel;
+}
+
+void ScenarioBatchResultWidget::navigateToAuthoring() {
+    auto* rootLayout = qobject_cast<QVBoxLayout*>(layout());
+    if (rootLayout == nullptr || shell_ == nullptr) {
+        return;
+    }
+
+    auto initial = returnAuthoringState_.value_or(ScenarioAuthoringWidget::InitialState{});
+    if (initial.scenarios.empty()) {
+        for (const auto& result : results_) {
+            initial.scenarios.push_back(scenarioStateFromDraft(result.scenario, layout_));
+        }
+        initial.currentScenarioIndex = currentResultIndex_;
+    }
+    initial.rightPanelMode = ScenarioAuthoringWidget::RightPanelMode::Scenario;
+
+    auto* authoringWidget = new ScenarioAuthoringWidget(
+        projectName_,
+        layout_,
+        std::move(initial),
+        saveProjectHandler_,
+        openProjectHandler_,
+        backToLayoutReviewHandler_,
+        this);
+    rootLayout->replaceWidget(shell_, authoringWidget);
+    shell_->hide();
+    shell_->deleteLater();
+    shell_ = nullptr;
+    canvas_ = nullptr;
+}
+
+void ScenarioBatchResultWidget::refreshSelectedResult() {
+    if (results_.empty() || currentResultIndex_ < 0 || currentResultIndex_ >= static_cast<int>(results_.size())) {
+        return;
+    }
+    const auto& result = results_[currentResultIndex_];
+    if (canvas_ != nullptr) {
+        canvas_->setFrame(result.frame);
+        canvas_->setHotspotOverlay(result.risk.hotspots);
+        canvas_->setBottleneckOverlay(result.risk.bottlenecks);
+        canvas_->setDensityOverlay(result.artifacts.densitySummary.peakField.cells.empty()
+            ? result.artifacts.densitySummary.peakCells
+            : result.artifacts.densitySummary.peakField.cells);
+        canvas_->setResultOverlayMode(ResultOverlayMode::Density);
+    }
+    if (detailLabel_ != nullptr) {
+        const auto finalSeconds = result.artifacts.timingSummary.finalEvacuationTimeSeconds.value_or(result.frame.elapsedSeconds);
+        detailLabel_->setText(QString("Selected: %1\nFinal: %2\nEvacuated: %3 / %4\nPeak Risk: %5\nBottlenecks: %6")
+            .arg(QString::fromStdString(result.scenario.name))
+            .arg(formatSeconds(finalSeconds))
+            .arg(static_cast<int>(result.frame.evacuatedAgentCount))
+            .arg(static_cast<int>(result.frame.totalAgentCount))
+            .arg(safecrowd::domain::scenarioRiskLevelLabel(result.risk.completionRisk))
+            .arg(static_cast<int>(result.risk.bottlenecks.size())));
+    }
+}
+
+void ScenarioBatchResultWidget::rerunBatch() {
+    auto* rootLayout = qobject_cast<QVBoxLayout*>(layout());
+    if (rootLayout == nullptr || shell_ == nullptr) {
+        return;
+    }
+    auto* runWidget = new ScenarioRunWidget(
+        projectName_,
+        layout_,
+        scenariosFromResults(results_),
+        results_,
+        saveProjectHandler_,
+        openProjectHandler_,
+        backToLayoutReviewHandler_,
+        returnAuthoringState_,
+        this);
+    rootLayout->replaceWidget(shell_, runWidget);
+    shell_->hide();
+    shell_->deleteLater();
+    shell_ = nullptr;
+    canvas_ = nullptr;
+}
+
+}  // namespace safecrowd::application

--- a/src/application/ScenarioBatchResultWidget.cpp
+++ b/src/application/ScenarioBatchResultWidget.cpp
@@ -5,10 +5,20 @@
 #include <cstddef>
 #include <utility>
 
-#include <QHeaderView>
-#include <QLabel>
+#include <QAbstractButton>
 #include <QAbstractItemView>
+#include <QButtonGroup>
+#include <QFrame>
+#include <QGridLayout>
+#include <QHeaderView>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPen>
 #include <QPushButton>
+#include <QScrollArea>
+#include <QSizePolicy>
 #include <QTableWidget>
 #include <QTableWidgetItem>
 #include <QVBoxLayout>
@@ -17,6 +27,7 @@
 #include "application/SimulationCanvasWidget.h"
 #include "application/UiStyle.h"
 #include "application/WorkspaceShell.h"
+#include "domain/ScenarioAuthoring.h"
 
 namespace safecrowd::application {
 namespace {
@@ -36,6 +47,19 @@ QString formatSeconds(double seconds) {
     return QString("%1 sec").arg(seconds, 0, 'f', 1);
 }
 
+double finalSeconds(const SavedScenarioResultState& result) {
+    return result.artifacts.timingSummary.finalEvacuationTimeSeconds.value_or(result.frame.elapsedSeconds);
+}
+
+QString formatDeltaSeconds(double deltaSeconds) {
+    if (std::abs(deltaSeconds) < 0.05) {
+        return "0.0 sec";
+    }
+    return QString("%1%2 sec")
+        .arg(deltaSeconds > 0.0 ? "+" : "")
+        .arg(deltaSeconds, 0, 'f', 1);
+}
+
 QString formatPercent(std::size_t numerator, std::size_t denominator) {
     if (denominator == 0) {
         return "0%";
@@ -44,11 +68,186 @@ QString formatPercent(std::size_t numerator, std::size_t denominator) {
     return QString("%1%").arg(ratio * 100.0, 0, 'f', 0);
 }
 
-QTableWidgetItem* readonlyItem(const QString& text) {
+QString scenarioRoleLabel(safecrowd::domain::ScenarioRole role) {
+    switch (role) {
+    case safecrowd::domain::ScenarioRole::Baseline:
+        return "Baseline";
+    case safecrowd::domain::ScenarioRole::Alternative:
+    default:
+        return "Alternative";
+    }
+}
+
+int riskRank(safecrowd::domain::ScenarioRiskLevel level) noexcept {
+    switch (level) {
+    case safecrowd::domain::ScenarioRiskLevel::High:
+        return 2;
+    case safecrowd::domain::ScenarioRiskLevel::Medium:
+        return 1;
+    case safecrowd::domain::ScenarioRiskLevel::Low:
+    default:
+        return 0;
+    }
+}
+
+QColor deltaColor(double deltaSeconds) {
+    if (deltaSeconds < -0.05) {
+        return QColor("#166534");
+    }
+    if (deltaSeconds > 0.05) {
+        return QColor("#b42318");
+    }
+    return QColor("#4f5d6b");
+}
+
+QTableWidgetItem* readonlyItem(const QString& text, Qt::Alignment alignment = Qt::AlignLeft | Qt::AlignVCenter) {
     auto* item = new QTableWidgetItem(text);
     item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+    item->setTextAlignment(alignment);
     return item;
 }
+
+QFrame* createMetricCard(const QString& title, const QString& value, const QString& caption, QWidget* parent) {
+    auto* card = new QFrame(parent);
+    card->setStyleSheet(ui::panelStyleSheet());
+    auto* layout = new QVBoxLayout(card);
+    layout->setContentsMargins(12, 10, 12, 10);
+    layout->setSpacing(4);
+
+    auto* titleLabel = createLabel(title, card, ui::FontRole::Caption);
+    titleLabel->setStyleSheet(ui::mutedTextStyleSheet());
+    layout->addWidget(titleLabel);
+
+    auto* valueLabel = createLabel(value, card, ui::FontRole::SectionTitle);
+    layout->addWidget(valueLabel);
+
+    auto* captionLabel = createLabel(caption, card, ui::FontRole::Caption);
+    captionLabel->setStyleSheet(ui::subtleTextStyleSheet());
+    layout->addWidget(captionLabel);
+    return card;
+}
+
+std::vector<std::pair<double, double>> progressSeries(const SavedScenarioResultState& result) {
+    std::vector<std::pair<double, double>> series;
+    if (!result.artifacts.evacuationProgress.empty()) {
+        series.reserve(result.artifacts.evacuationProgress.size());
+        for (const auto& sample : result.artifacts.evacuationProgress) {
+            series.emplace_back(sample.timeSeconds, std::clamp(sample.evacuatedRatio, 0.0, 1.0));
+        }
+        return series;
+    }
+
+    const double ratio = result.frame.totalAgentCount == 0
+        ? 0.0
+        : std::clamp(
+            static_cast<double>(result.frame.evacuatedAgentCount) / static_cast<double>(result.frame.totalAgentCount),
+            0.0,
+            1.0);
+    series.emplace_back(0.0, 0.0);
+    series.emplace_back(finalSeconds(result), ratio);
+    return series;
+}
+
+class EvacuationProgressChartWidget final : public QWidget {
+public:
+    explicit EvacuationProgressChartWidget(QWidget* parent = nullptr)
+        : QWidget(parent) {
+        setMinimumHeight(150);
+        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    }
+
+    void setResults(
+        const std::vector<SavedScenarioResultState>& results,
+        int baselineIndex,
+        int selectedIndex) {
+        results_ = &results;
+        baselineIndex_ = baselineIndex;
+        selectedIndex_ = selectedIndex;
+        update();
+    }
+
+    void setSelectedIndex(int selectedIndex) {
+        selectedIndex_ = selectedIndex;
+        update();
+    }
+
+protected:
+    void paintEvent(QPaintEvent* event) override {
+        (void)event;
+
+        QPainter painter(this);
+        painter.setRenderHint(QPainter::Antialiasing, true);
+        painter.fillRect(rect(), QColor("#ffffff"));
+
+        const QRectF bounds = rect().adjusted(12, 12, -12, -22);
+        painter.setPen(QPen(QColor("#d7e0ea"), 1));
+        painter.drawRoundedRect(rect().adjusted(0, 0, -1, -1), 8, 8);
+
+        if (results_ == nullptr || results_->empty() || bounds.width() <= 1.0 || bounds.height() <= 1.0) {
+            painter.setPen(QColor("#6b7785"));
+            painter.setFont(ui::font(ui::FontRole::Caption));
+            painter.drawText(rect(), Qt::AlignCenter, "No evacuation progress data");
+            return;
+        }
+
+        double maxTime = 1.0;
+        for (const auto& result : *results_) {
+            maxTime = std::max(maxTime, finalSeconds(result));
+            for (const auto& sample : result.artifacts.evacuationProgress) {
+                maxTime = std::max(maxTime, sample.timeSeconds);
+            }
+        }
+
+        painter.setPen(QPen(QColor("#e2e8f0"), 1));
+        painter.drawLine(bounds.bottomLeft(), bounds.bottomRight());
+        painter.drawLine(bounds.bottomLeft(), bounds.topLeft());
+
+        painter.setFont(ui::font(ui::FontRole::Caption));
+        painter.setPen(QColor("#6b7785"));
+        painter.drawText(QRectF(bounds.left(), bounds.bottom() + 2, bounds.width(), 18), Qt::AlignLeft, "0%");
+        painter.drawText(QRectF(bounds.left(), bounds.top() - 3, bounds.width(), 18), Qt::AlignLeft, "100%");
+        painter.drawText(QRectF(bounds.left(), bounds.bottom() + 2, bounds.width(), 18), Qt::AlignRight, formatSeconds(maxTime));
+
+        for (int index = 0; index < static_cast<int>(results_->size()); ++index) {
+            const auto series = progressSeries((*results_)[static_cast<std::size_t>(index)]);
+            if (series.empty()) {
+                continue;
+            }
+
+            QPainterPath path;
+            bool started = false;
+            for (const auto& [time, ratio] : series) {
+                const auto x = bounds.left() + std::clamp(time / maxTime, 0.0, 1.0) * bounds.width();
+                const auto y = bounds.bottom() - std::clamp(ratio, 0.0, 1.0) * bounds.height();
+                if (!started) {
+                    path.moveTo(x, y);
+                    started = true;
+                } else {
+                    path.lineTo(x, y);
+                }
+            }
+
+            QColor color("#94a3b8");
+            double width = 1.4;
+            if (index == baselineIndex_) {
+                color = QColor("#16202b");
+                width = 2.0;
+            }
+            if (index == selectedIndex_) {
+                color = QColor("#2563eb");
+                width = 2.8;
+            }
+
+            painter.setPen(QPen(color, width, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+            painter.drawPath(path);
+        }
+    }
+
+private:
+    const std::vector<SavedScenarioResultState>* results_{nullptr};
+    int baselineIndex_{0};
+    int selectedIndex_{0};
+};
 
 std::vector<safecrowd::domain::ScenarioDraft> scenariosFromResults(
     const std::vector<SavedScenarioResultState>& results) {
@@ -182,19 +381,80 @@ std::optional<ScenarioAuthoringWidget::InitialState> ScenarioBatchResultWidget::
 
 QWidget* ScenarioBatchResultWidget::createSummaryPanel() {
     auto* panel = new QWidget(shell_);
-    auto* layout = new QVBoxLayout(panel);
+    auto* panelLayout = new QVBoxLayout(panel);
+    panelLayout->setContentsMargins(0, 0, 0, 0);
+    panelLayout->setSpacing(12);
+    panelLayout->addWidget(shell_ != nullptr ? shell_->createPanelHeader("Comparison", panel, false) : createLabel("Comparison", panel, ui::FontRole::Title));
+
+    auto* scrollArea = new QScrollArea(panel);
+    scrollArea->setWidgetResizable(true);
+    scrollArea->setFrameShape(QFrame::NoFrame);
+    scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    ui::polishScrollArea(scrollArea);
+    auto* content = new QWidget(scrollArea);
+    auto* layout = new QVBoxLayout(content);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(12);
-    layout->addWidget(shell_ != nullptr ? shell_->createPanelHeader("Comparison", panel, false) : createLabel("Comparison", panel, ui::FontRole::Title));
 
-    table_ = new QTableWidget(static_cast<int>(results_.size()), 7, panel);
-    table_->setHorizontalHeaderLabels({"Scenario", "Final", "Evac.", "Risk", "Bottlenecks", "T90", "T95"});
+    const auto baselineIndex = baselineResultIndex();
+    int bestIndex = results_.empty() ? -1 : 0;
+    int highestRiskIndex = results_.empty() ? -1 : 0;
+    for (int index = 0; index < static_cast<int>(results_.size()); ++index) {
+        const auto& result = results_[static_cast<std::size_t>(index)];
+        if (bestIndex < 0 || finalSeconds(result) < finalSeconds(results_[static_cast<std::size_t>(bestIndex)])) {
+            bestIndex = index;
+        }
+        const auto& currentRisk = results_[static_cast<std::size_t>(highestRiskIndex)].risk;
+        if (riskRank(result.risk.completionRisk) > riskRank(currentRisk.completionRisk)
+            || (riskRank(result.risk.completionRisk) == riskRank(currentRisk.completionRisk)
+                && result.risk.bottlenecks.size() > currentRisk.bottlenecks.size())) {
+            highestRiskIndex = index;
+        }
+    }
+
+    auto* cardsHost = new QWidget(content);
+    auto* cards = new QGridLayout(cardsHost);
+    cards->setContentsMargins(0, 0, 0, 0);
+    cards->setHorizontalSpacing(8);
+    cards->setVerticalSpacing(8);
+    const auto baselineName = baselineIndex >= 0
+        ? QString::fromStdString(results_[static_cast<std::size_t>(baselineIndex)].scenario.name)
+        : QString("None");
+    cards->addWidget(createMetricCard("Runs", QString::number(static_cast<int>(results_.size())), "Staged scenarios completed", cardsHost), 0, 0);
+    cards->addWidget(createMetricCard("Baseline", baselineName, "Comparison reference", cardsHost), 0, 1);
+    if (bestIndex >= 0) {
+        const auto& best = results_[static_cast<std::size_t>(bestIndex)];
+        const auto bestDelta = baselineIndex >= 0
+            ? finalSeconds(best) - finalSeconds(results_[static_cast<std::size_t>(baselineIndex)])
+            : 0.0;
+        cards->addWidget(createMetricCard(
+            "Fastest",
+            formatSeconds(finalSeconds(best)),
+            QString("%1  -  %2").arg(formatDeltaSeconds(bestDelta), QString::fromStdString(best.scenario.name)),
+            cardsHost), 1, 0);
+    }
+    if (highestRiskIndex >= 0) {
+        const auto& riskiest = results_[static_cast<std::size_t>(highestRiskIndex)];
+        cards->addWidget(createMetricCard(
+            "Highest Risk",
+            safecrowd::domain::scenarioRiskLevelLabel(riskiest.risk.completionRisk),
+            QString("%1 hotspots / %2 bottlenecks")
+                .arg(static_cast<int>(riskiest.risk.hotspots.size()))
+                .arg(static_cast<int>(riskiest.risk.bottlenecks.size())),
+            cardsHost), 1, 1);
+    }
+    layout->addWidget(cardsHost);
+
+    table_ = new QTableWidget(static_cast<int>(results_.size()), 8, content);
+    table_->setHorizontalHeaderLabels({"Scenario", "Role", "Final", "Delta", "Evac.", "Risk", "Hotspots", "Bottlenecks"});
     table_->verticalHeader()->setVisible(false);
     table_->setSelectionBehavior(QAbstractItemView::SelectRows);
     table_->setSelectionMode(QAbstractItemView::SingleSelection);
     table_->setEditTriggers(QAbstractItemView::NoEditTriggers);
     table_->setAlternatingRowColors(true);
-    table_->horizontalHeader()->setStretchLastSection(true);
+    table_->setMinimumHeight(190);
+    table_->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    table_->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
     table_->setStyleSheet(
         "QTableWidget { background: #ffffff; border: 1px solid #d7e0ea; border-radius: 8px; gridline-color: #e4ebf3; }"
         "QHeaderView::section { background: #eef3f8; border: 0; padding: 6px; color: #4f5d6b; }"
@@ -202,30 +462,81 @@ QWidget* ScenarioBatchResultWidget::createSummaryPanel() {
     for (int row = 0; row < static_cast<int>(results_.size()); ++row) {
         const auto& result = results_[row];
         table_->setItem(row, 0, readonlyItem(QString::fromStdString(result.scenario.name)));
-        table_->setItem(row, 1, readonlyItem(formatSeconds(
-            result.artifacts.timingSummary.finalEvacuationTimeSeconds.value_or(result.frame.elapsedSeconds))));
-        table_->setItem(row, 2, readonlyItem(formatPercent(result.frame.evacuatedAgentCount, result.frame.totalAgentCount)));
-        table_->setItem(row, 3, readonlyItem(safecrowd::domain::scenarioRiskLevelLabel(result.risk.completionRisk)));
-        table_->setItem(row, 4, readonlyItem(QString::number(static_cast<int>(result.risk.bottlenecks.size()))));
-        table_->setItem(row, 5, readonlyItem(formatSeconds(result.artifacts.timingSummary.t90Seconds)));
-        table_->setItem(row, 6, readonlyItem(formatSeconds(result.artifacts.timingSummary.t95Seconds)));
+        table_->setItem(row, 1, readonlyItem(scenarioRoleLabel(result.scenario.role)));
+        table_->setItem(row, 2, readonlyItem(formatSeconds(finalSeconds(result)), Qt::AlignRight | Qt::AlignVCenter));
+        const auto deltaSeconds = baselineIndex >= 0
+            ? finalSeconds(result) - finalSeconds(results_[static_cast<std::size_t>(baselineIndex)])
+            : 0.0;
+        auto* deltaItem = readonlyItem(row == baselineIndex ? "Baseline" : formatDeltaSeconds(deltaSeconds), Qt::AlignRight | Qt::AlignVCenter);
+        deltaItem->setForeground(deltaColor(deltaSeconds));
+        table_->setItem(row, 3, deltaItem);
+        table_->setItem(row, 4, readonlyItem(formatPercent(result.frame.evacuatedAgentCount, result.frame.totalAgentCount), Qt::AlignRight | Qt::AlignVCenter));
+        table_->setItem(row, 5, readonlyItem(safecrowd::domain::scenarioRiskLevelLabel(result.risk.completionRisk)));
+        table_->setItem(row, 6, readonlyItem(QString::number(static_cast<int>(result.risk.hotspots.size())), Qt::AlignRight | Qt::AlignVCenter));
+        table_->setItem(row, 7, readonlyItem(QString::number(static_cast<int>(result.risk.bottlenecks.size())), Qt::AlignRight | Qt::AlignVCenter));
     }
     table_->resizeColumnsToContents();
-    layout->addWidget(table_, 1);
+    layout->addWidget(table_);
 
-    detailLabel_ = createLabel("", panel);
+    auto* overlayLabel = createLabel("Overlay", content, ui::FontRole::SectionTitle);
+    layout->addWidget(overlayLabel);
+
+    auto* overlayRow = new QWidget(content);
+    auto* overlayLayout = new QHBoxLayout(overlayRow);
+    overlayLayout->setContentsMargins(0, 0, 0, 0);
+    overlayLayout->setSpacing(8);
+    overlayButtonGroup_ = new QButtonGroup(overlayRow);
+    overlayButtonGroup_->setExclusive(true);
+    const auto addOverlayButton = [this, overlayLayout, overlayRow](OverlayMode mode, const QString& text) {
+        auto* button = new QPushButton(text, overlayRow);
+        button->setCheckable(true);
+        button->setFont(ui::font(ui::FontRole::Caption));
+        button->setStyleSheet(ui::secondaryButtonStyleSheet()
+            + "QPushButton:checked { background: #e8f1ff; border-color: #2563eb; color: #1d4ed8; }");
+        overlayButtonGroup_->addButton(button, static_cast<int>(mode));
+        overlayLayout->addWidget(button);
+    };
+    addOverlayButton(OverlayMode::Density, "Density");
+    addOverlayButton(OverlayMode::Hotspots, "Hotspots");
+    addOverlayButton(OverlayMode::Bottlenecks, "Bottlenecks");
+    if (auto* button = overlayButtonGroup_->button(static_cast<int>(overlayMode_)); button != nullptr) {
+        button->setChecked(true);
+    }
+    connect(overlayButtonGroup_, &QButtonGroup::idClicked, this, [this](int id) {
+        overlayMode_ = static_cast<OverlayMode>(id);
+        refreshSelectedResult();
+    });
+    layout->addWidget(overlayRow);
+
+    layout->addWidget(createLabel("Evacuation Progress", content, ui::FontRole::SectionTitle));
+    auto* chart = new EvacuationProgressChartWidget(content);
+    chart->setResults(results_, baselineIndex, currentResultIndex_);
+    progressChart_ = chart;
+    layout->addWidget(chart);
+
+    auto* detailCard = new QFrame(content);
+    detailCard->setStyleSheet(ui::panelStyleSheet());
+    auto* detailLayout = new QVBoxLayout(detailCard);
+    detailLayout->setContentsMargins(12, 10, 12, 10);
+    detailLayout->setSpacing(6);
+    detailLayout->addWidget(createLabel("Selected Scenario", detailCard, ui::FontRole::SectionTitle));
+    detailLabel_ = createLabel("", detailCard);
     detailLabel_->setStyleSheet(ui::mutedTextStyleSheet());
-    layout->addWidget(detailLabel_);
+    detailLayout->addWidget(detailLabel_);
+    layout->addWidget(detailCard);
     layout->addStretch(1);
+
+    scrollArea->setWidget(content);
+    panelLayout->addWidget(scrollArea, 1);
 
     auto* rerunButton = new QPushButton("Run Again", panel);
     rerunButton->setFont(ui::font(ui::FontRole::Body));
     rerunButton->setStyleSheet(ui::secondaryButtonStyleSheet());
-    layout->addWidget(rerunButton);
+    panelLayout->addWidget(rerunButton);
     auto* editButton = new QPushButton("Edit Scenarios", panel);
     editButton->setFont(ui::font(ui::FontRole::Body));
     editButton->setStyleSheet(ui::secondaryButtonStyleSheet());
-    layout->addWidget(editButton);
+    panelLayout->addWidget(editButton);
 
     connect(table_, &QTableWidget::currentCellChanged, this, [this](int currentRow, int, int, int) {
         if (currentRow >= 0 && currentRow < static_cast<int>(results_.size())) {
@@ -280,25 +591,61 @@ void ScenarioBatchResultWidget::refreshSelectedResult() {
         return;
     }
     const auto& result = results_[currentResultIndex_];
+    const auto baselineIndex = baselineResultIndex();
     if (canvas_ != nullptr) {
+        canvas_->setConnectionBlocks(result.scenario.control.connectionBlocks);
         canvas_->setFrame(result.frame);
         canvas_->setHotspotOverlay(result.risk.hotspots);
         canvas_->setBottleneckOverlay(result.risk.bottlenecks);
         canvas_->setDensityOverlay(result.artifacts.densitySummary.peakField.cells.empty()
             ? result.artifacts.densitySummary.peakCells
             : result.artifacts.densitySummary.peakField.cells);
-        canvas_->setResultOverlayMode(ResultOverlayMode::Density);
+        switch (overlayMode_) {
+        case OverlayMode::Hotspots:
+            canvas_->setResultOverlayMode(ResultOverlayMode::Hotspots);
+            break;
+        case OverlayMode::Bottlenecks:
+            canvas_->setResultOverlayMode(ResultOverlayMode::Bottlenecks);
+            break;
+        case OverlayMode::Density:
+        default:
+            canvas_->setResultOverlayMode(ResultOverlayMode::Density);
+            break;
+        }
+    }
+    if (progressChart_ != nullptr) {
+        static_cast<EvacuationProgressChartWidget*>(progressChart_)->setSelectedIndex(currentResultIndex_);
     }
     if (detailLabel_ != nullptr) {
-        const auto finalSeconds = result.artifacts.timingSummary.finalEvacuationTimeSeconds.value_or(result.frame.elapsedSeconds);
-        detailLabel_->setText(QString("Selected: %1\nFinal: %2\nEvacuated: %3 / %4\nPeak Risk: %5\nBottlenecks: %6")
+        const auto selectedFinalSeconds = finalSeconds(result);
+        const auto deltaText = baselineIndex >= 0
+            ? (currentResultIndex_ == baselineIndex
+                ? QString("Baseline")
+                : formatDeltaSeconds(selectedFinalSeconds - finalSeconds(results_[static_cast<std::size_t>(baselineIndex)])))
+            : QString("No baseline");
+        detailLabel_->setText(QString("%1 (%2)\nFinal: %3\nDelta vs baseline: %4\nEvacuated: %5 / %6 (%7)\nRisk: %8\nHotspots: %9\nBottlenecks: %10\nT90 / T95: %11 / %12")
             .arg(QString::fromStdString(result.scenario.name))
-            .arg(formatSeconds(finalSeconds))
+            .arg(scenarioRoleLabel(result.scenario.role))
+            .arg(formatSeconds(selectedFinalSeconds))
+            .arg(deltaText)
             .arg(static_cast<int>(result.frame.evacuatedAgentCount))
             .arg(static_cast<int>(result.frame.totalAgentCount))
+            .arg(formatPercent(result.frame.evacuatedAgentCount, result.frame.totalAgentCount))
             .arg(safecrowd::domain::scenarioRiskLevelLabel(result.risk.completionRisk))
-            .arg(static_cast<int>(result.risk.bottlenecks.size())));
+            .arg(static_cast<int>(result.risk.hotspots.size()))
+            .arg(static_cast<int>(result.risk.bottlenecks.size()))
+            .arg(formatSeconds(result.artifacts.timingSummary.t90Seconds))
+            .arg(formatSeconds(result.artifacts.timingSummary.t95Seconds)));
     }
+}
+
+int ScenarioBatchResultWidget::baselineResultIndex() const noexcept {
+    for (int index = 0; index < static_cast<int>(results_.size()); ++index) {
+        if (results_[static_cast<std::size_t>(index)].scenario.role == safecrowd::domain::ScenarioRole::Baseline) {
+            return index;
+        }
+    }
+    return results_.empty() ? -1 : 0;
 }
 
 void ScenarioBatchResultWidget::rerunBatch() {

--- a/src/application/ScenarioBatchResultWidget.cpp
+++ b/src/application/ScenarioBatchResultWidget.cpp
@@ -5,12 +5,9 @@
 #include <cstddef>
 #include <utility>
 
-#include <QAbstractButton>
-#include <QAbstractItemView>
-#include <QButtonGroup>
+#include <QCheckBox>
+#include <QComboBox>
 #include <QFrame>
-#include <QGridLayout>
-#include <QHeaderView>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QPainter>
@@ -18,9 +15,11 @@
 #include <QPen>
 #include <QPushButton>
 #include <QScrollArea>
+#include <QSignalBlocker>
 #include <QSizePolicy>
-#include <QTableWidget>
-#include <QTableWidgetItem>
+#include <QSlider>
+#include <QTabWidget>
+#include <QTimer>
 #include <QVBoxLayout>
 
 #include "application/ScenarioRunWidget.h"
@@ -78,55 +77,6 @@ QString scenarioRoleLabel(safecrowd::domain::ScenarioRole role) {
     }
 }
 
-int riskRank(safecrowd::domain::ScenarioRiskLevel level) noexcept {
-    switch (level) {
-    case safecrowd::domain::ScenarioRiskLevel::High:
-        return 2;
-    case safecrowd::domain::ScenarioRiskLevel::Medium:
-        return 1;
-    case safecrowd::domain::ScenarioRiskLevel::Low:
-    default:
-        return 0;
-    }
-}
-
-QColor deltaColor(double deltaSeconds) {
-    if (deltaSeconds < -0.05) {
-        return QColor("#166534");
-    }
-    if (deltaSeconds > 0.05) {
-        return QColor("#b42318");
-    }
-    return QColor("#4f5d6b");
-}
-
-QTableWidgetItem* readonlyItem(const QString& text, Qt::Alignment alignment = Qt::AlignLeft | Qt::AlignVCenter) {
-    auto* item = new QTableWidgetItem(text);
-    item->setFlags(item->flags() & ~Qt::ItemIsEditable);
-    item->setTextAlignment(alignment);
-    return item;
-}
-
-QFrame* createMetricCard(const QString& title, const QString& value, const QString& caption, QWidget* parent) {
-    auto* card = new QFrame(parent);
-    card->setStyleSheet(ui::panelStyleSheet());
-    auto* layout = new QVBoxLayout(card);
-    layout->setContentsMargins(12, 10, 12, 10);
-    layout->setSpacing(4);
-
-    auto* titleLabel = createLabel(title, card, ui::FontRole::Caption);
-    titleLabel->setStyleSheet(ui::mutedTextStyleSheet());
-    layout->addWidget(titleLabel);
-
-    auto* valueLabel = createLabel(value, card, ui::FontRole::SectionTitle);
-    layout->addWidget(valueLabel);
-
-    auto* captionLabel = createLabel(caption, card, ui::FontRole::Caption);
-    captionLabel->setStyleSheet(ui::subtleTextStyleSheet());
-    layout->addWidget(captionLabel);
-    return card;
-}
-
 std::vector<std::pair<double, double>> progressSeries(const SavedScenarioResultState& result) {
     std::vector<std::pair<double, double>> series;
     if (!result.artifacts.evacuationProgress.empty()) {
@@ -148,26 +98,32 @@ std::vector<std::pair<double, double>> progressSeries(const SavedScenarioResultS
     return series;
 }
 
-class EvacuationProgressChartWidget final : public QWidget {
+enum class ComparisonGraphMode {
+    Remaining,
+    Exits,
+};
+
+class ComparisonGraphWidget final : public QWidget {
 public:
-    explicit EvacuationProgressChartWidget(QWidget* parent = nullptr)
-        : QWidget(parent) {
-        setMinimumHeight(150);
-        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    explicit ComparisonGraphWidget(ComparisonGraphMode mode, QWidget* parent = nullptr)
+        : QWidget(parent),
+          mode_(mode) {
+        setMinimumHeight(190);
+        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     }
 
     void setResults(
         const std::vector<SavedScenarioResultState>& results,
-        int baselineIndex,
-        int selectedIndex) {
+        std::vector<int> selectedIndices,
+        int displayIndex) {
         results_ = &results;
-        baselineIndex_ = baselineIndex;
-        selectedIndex_ = selectedIndex;
+        selectedIndices_ = std::move(selectedIndices);
+        displayIndex_ = displayIndex;
         update();
     }
 
-    void setSelectedIndex(int selectedIndex) {
-        selectedIndex_ = selectedIndex;
+    void setCurrentTimeSeconds(double seconds) {
+        currentTimeSeconds_ = seconds;
         update();
     }
 
@@ -178,47 +134,79 @@ protected:
         QPainter painter(this);
         painter.setRenderHint(QPainter::Antialiasing, true);
         painter.fillRect(rect(), QColor("#ffffff"));
-
-        const QRectF bounds = rect().adjusted(12, 12, -12, -22);
         painter.setPen(QPen(QColor("#d7e0ea"), 1));
         painter.drawRoundedRect(rect().adjusted(0, 0, -1, -1), 8, 8);
 
-        if (results_ == nullptr || results_->empty() || bounds.width() <= 1.0 || bounds.height() <= 1.0) {
+        const QRectF plot = rect().adjusted(40, 16, -18, -44);
+        if (results_ == nullptr || selectedIndices_.empty() || plot.width() <= 1.0 || plot.height() <= 1.0) {
             painter.setPen(QColor("#6b7785"));
             painter.setFont(ui::font(ui::FontRole::Caption));
-            painter.drawText(rect(), Qt::AlignCenter, "No evacuation progress data");
+            painter.drawText(rect(), Qt::AlignCenter, "Select scenarios to compare");
             return;
         }
 
+        painter.setPen(QPen(QColor("#e2e8f0"), 1));
+        painter.drawLine(plot.bottomLeft(), plot.bottomRight());
+        painter.drawLine(plot.bottomLeft(), plot.topLeft());
+
+        if (mode_ == ComparisonGraphMode::Remaining) {
+            drawRemaining(painter, plot);
+        } else {
+            drawExits(painter, plot);
+        }
+        drawLegend(painter, QRectF(rect().left() + 12, rect().bottom() - 34, rect().width() - 24, 24));
+    }
+
+private:
+    QColor colorForSeries(int index) const {
+        static const std::vector<QColor> colors{
+            QColor("#2563eb"),
+            QColor("#16a34a"),
+            QColor("#dc2626"),
+            QColor("#7c3aed"),
+            QColor("#ea580c"),
+        };
+        if (index == displayIndex_) {
+            return QColor("#1d4ed8");
+        }
+        return colors[static_cast<std::size_t>(std::abs(index)) % colors.size()];
+    }
+
+    void drawRemaining(QPainter& painter, const QRectF& plot) {
         double maxTime = 1.0;
-        for (const auto& result : *results_) {
+        for (const auto index : selectedIndices_) {
+            if (!validIndex(index)) {
+                continue;
+            }
+            const auto& result = (*results_)[static_cast<std::size_t>(index)];
             maxTime = std::max(maxTime, finalSeconds(result));
             for (const auto& sample : result.artifacts.evacuationProgress) {
                 maxTime = std::max(maxTime, sample.timeSeconds);
             }
         }
 
-        painter.setPen(QPen(QColor("#e2e8f0"), 1));
-        painter.drawLine(bounds.bottomLeft(), bounds.bottomRight());
-        painter.drawLine(bounds.bottomLeft(), bounds.topLeft());
-
         painter.setFont(ui::font(ui::FontRole::Caption));
         painter.setPen(QColor("#6b7785"));
-        painter.drawText(QRectF(bounds.left(), bounds.bottom() + 2, bounds.width(), 18), Qt::AlignLeft, "0%");
-        painter.drawText(QRectF(bounds.left(), bounds.top() - 3, bounds.width(), 18), Qt::AlignLeft, "100%");
-        painter.drawText(QRectF(bounds.left(), bounds.bottom() + 2, bounds.width(), 18), Qt::AlignRight, formatSeconds(maxTime));
+        painter.drawText(QRectF(4, plot.top() - 5, 32, 18), Qt::AlignRight | Qt::AlignVCenter, "100%");
+        painter.drawText(QRectF(4, plot.bottom() - 10, 32, 18), Qt::AlignRight | Qt::AlignVCenter, "0%");
+        painter.drawText(QRectF(plot.left(), plot.bottom() + 4, plot.width(), 18), Qt::AlignRight, formatSeconds(maxTime));
 
-        for (int index = 0; index < static_cast<int>(results_->size()); ++index) {
-            const auto series = progressSeries((*results_)[static_cast<std::size_t>(index)]);
+        for (const auto index : selectedIndices_) {
+            if (!validIndex(index)) {
+                continue;
+            }
+            const auto& result = (*results_)[static_cast<std::size_t>(index)];
+            const auto series = progressSeries(result);
             if (series.empty()) {
                 continue;
             }
 
             QPainterPath path;
             bool started = false;
-            for (const auto& [time, ratio] : series) {
-                const auto x = bounds.left() + std::clamp(time / maxTime, 0.0, 1.0) * bounds.width();
-                const auto y = bounds.bottom() - std::clamp(ratio, 0.0, 1.0) * bounds.height();
+            for (const auto& [time, evacuatedRatio] : series) {
+                const auto remainingRatio = 1.0 - std::clamp(evacuatedRatio, 0.0, 1.0);
+                const auto x = plot.left() + std::clamp(time / maxTime, 0.0, 1.0) * plot.width();
+                const auto y = plot.bottom() - remainingRatio * plot.height();
                 if (!started) {
                     path.moveTo(x, y);
                     started = true;
@@ -226,28 +214,140 @@ protected:
                     path.lineTo(x, y);
                 }
             }
-
-            QColor color("#94a3b8");
-            double width = 1.4;
-            if (index == baselineIndex_) {
-                color = QColor("#16202b");
-                width = 2.0;
-            }
-            if (index == selectedIndex_) {
-                color = QColor("#2563eb");
-                width = 2.8;
-            }
-
-            painter.setPen(QPen(color, width, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+            painter.setPen(QPen(colorForSeries(index), index == displayIndex_ ? 2.8 : 2.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
             painter.drawPath(path);
+        }
+
+        if (currentTimeSeconds_ >= 0.0) {
+            const auto x = plot.left() + std::clamp(currentTimeSeconds_ / maxTime, 0.0, 1.0) * plot.width();
+            painter.setPen(QPen(QColor("#0f172a"), 1, Qt::DashLine));
+            painter.drawLine(QPointF(x, plot.top()), QPointF(x, plot.bottom()));
         }
     }
 
-private:
+    void drawExits(QPainter& painter, const QRectF& plot) {
+        std::vector<QString> exits;
+        for (const auto index : selectedIndices_) {
+            if (!validIndex(index)) {
+                continue;
+            }
+            for (const auto& exit : (*results_)[static_cast<std::size_t>(index)].artifacts.exitUsage) {
+                const auto label = QString::fromStdString(exit.exitLabel.empty() ? exit.exitZoneId : exit.exitLabel);
+                if (std::find(exits.begin(), exits.end(), label) == exits.end()) {
+                    exits.push_back(label);
+                }
+            }
+        }
+        if (exits.empty()) {
+            painter.setPen(QColor("#6b7785"));
+            painter.setFont(ui::font(ui::FontRole::Caption));
+            painter.drawText(plot, Qt::AlignCenter, "No exit usage data");
+            return;
+        }
+
+        painter.setFont(ui::font(ui::FontRole::Caption));
+        painter.setPen(QColor("#6b7785"));
+        painter.drawText(QRectF(4, plot.top() - 5, 32, 18), Qt::AlignRight | Qt::AlignVCenter, "100%");
+        painter.drawText(QRectF(4, plot.bottom() - 10, 32, 18), Qt::AlignRight | Qt::AlignVCenter, "0%");
+
+        for (int exitIndex = 0; exitIndex < static_cast<int>(exits.size()); ++exitIndex) {
+            const auto x = exits.size() == 1
+                ? plot.center().x()
+                : plot.left() + (static_cast<double>(exitIndex) / static_cast<double>(exits.size() - 1)) * plot.width();
+            painter.setPen(QPen(QColor("#edf2f7"), 1));
+            painter.drawLine(QPointF(x, plot.top()), QPointF(x, plot.bottom()));
+            painter.setPen(QColor("#6b7785"));
+            painter.drawText(QRectF(x - 38, plot.bottom() + 4, 76, 18), Qt::AlignCenter, exits[static_cast<std::size_t>(exitIndex)]);
+        }
+
+        for (const auto index : selectedIndices_) {
+            if (!validIndex(index)) {
+                continue;
+            }
+            const auto& result = (*results_)[static_cast<std::size_t>(index)];
+            QPainterPath path;
+            bool started = false;
+            for (int exitIndex = 0; exitIndex < static_cast<int>(exits.size()); ++exitIndex) {
+                double usageRatio = 0.0;
+                const auto& exitLabel = exits[static_cast<std::size_t>(exitIndex)];
+                for (const auto& exit : result.artifacts.exitUsage) {
+                    const auto label = QString::fromStdString(exit.exitLabel.empty() ? exit.exitZoneId : exit.exitLabel);
+                    if (label == exitLabel) {
+                        usageRatio = std::clamp(exit.usageRatio, 0.0, 1.0);
+                        break;
+                    }
+                }
+                const auto x = exits.size() == 1
+                    ? plot.center().x()
+                    : plot.left() + (static_cast<double>(exitIndex) / static_cast<double>(exits.size() - 1)) * plot.width();
+                const auto y = plot.bottom() - usageRatio * plot.height();
+                if (!started) {
+                    path.moveTo(x, y);
+                    started = true;
+                } else {
+                    path.lineTo(x, y);
+                }
+            }
+            painter.setPen(QPen(colorForSeries(index), index == displayIndex_ ? 2.8 : 2.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+            painter.drawPath(path);
+            for (int exitIndex = 0; exitIndex < static_cast<int>(exits.size()); ++exitIndex) {
+                double usageRatio = 0.0;
+                const auto& exitLabel = exits[static_cast<std::size_t>(exitIndex)];
+                for (const auto& exit : result.artifacts.exitUsage) {
+                    const auto label = QString::fromStdString(exit.exitLabel.empty() ? exit.exitZoneId : exit.exitLabel);
+                    if (label == exitLabel) {
+                        usageRatio = std::clamp(exit.usageRatio, 0.0, 1.0);
+                        break;
+                    }
+                }
+                const auto x = exits.size() == 1
+                    ? plot.center().x()
+                    : plot.left() + (static_cast<double>(exitIndex) / static_cast<double>(exits.size() - 1)) * plot.width();
+                const auto y = plot.bottom() - usageRatio * plot.height();
+                painter.setBrush(colorForSeries(index));
+                painter.setPen(Qt::NoPen);
+                painter.drawEllipse(QPointF(x, y), 3.5, 3.5);
+            }
+        }
+    }
+
+    void drawLegend(QPainter& painter, const QRectF& legendRect) {
+        painter.setFont(ui::font(ui::FontRole::Caption));
+        double x = legendRect.left();
+        const auto y = legendRect.center().y();
+        for (const auto index : selectedIndices_) {
+            if (!validIndex(index)) {
+                continue;
+            }
+            const auto name = QString::fromStdString((*results_)[static_cast<std::size_t>(index)].scenario.name);
+            painter.setPen(QPen(colorForSeries(index), index == displayIndex_ ? 2.8 : 2.0));
+            painter.drawLine(QPointF(x, y), QPointF(x + 18, y));
+            painter.setPen(QColor("#344256"));
+            painter.drawText(QRectF(x + 24, legendRect.top(), 120, legendRect.height()), Qt::AlignLeft | Qt::AlignVCenter, name);
+            x += 148;
+            if (x > legendRect.right() - 120) {
+                break;
+            }
+        }
+    }
+
+    bool validIndex(int index) const noexcept {
+        return results_ != nullptr && index >= 0 && index < static_cast<int>(results_->size());
+    }
+
+    ComparisonGraphMode mode_{ComparisonGraphMode::Remaining};
     const std::vector<SavedScenarioResultState>* results_{nullptr};
-    int baselineIndex_{0};
-    int selectedIndex_{0};
+    std::vector<int> selectedIndices_{};
+    int displayIndex_{0};
+    double currentTimeSeconds_{-1.0};
 };
+
+std::vector<safecrowd::domain::SimulationFrame> replayFramesForResult(const SavedScenarioResultState& result) {
+    if (!result.artifacts.replayFrames.empty()) {
+        return result.artifacts.replayFrames;
+    }
+    return {result.frame};
+}
 
 std::vector<safecrowd::domain::ScenarioDraft> scenariosFromResults(
     const std::vector<SavedScenarioResultState>& results) {
@@ -341,6 +441,25 @@ ScenarioBatchResultWidget::ScenarioBatchResultWidget(
     if (currentResultIndex_ < 0 || currentResultIndex_ >= static_cast<int>(results_.size())) {
         currentResultIndex_ = 0;
     }
+    const auto baselineIndex = baselineResultIndex();
+    if (results_.size() <= 2) {
+        for (int index = 0; index < static_cast<int>(results_.size()); ++index) {
+            selectedCompareIndices_.push_back(index);
+        }
+    } else {
+        if (baselineIndex >= 0) {
+            selectedCompareIndices_.push_back(baselineIndex);
+        }
+        if (currentResultIndex_ >= 0
+            && std::find(selectedCompareIndices_.begin(), selectedCompareIndices_.end(), currentResultIndex_) == selectedCompareIndices_.end()) {
+            selectedCompareIndices_.push_back(currentResultIndex_);
+        }
+        for (int index = 0; selectedCompareIndices_.size() < 2 && index < static_cast<int>(results_.size()); ++index) {
+            if (std::find(selectedCompareIndices_.begin(), selectedCompareIndices_.end(), index) == selectedCompareIndices_.end()) {
+                selectedCompareIndices_.push_back(index);
+            }
+        }
+    }
 
     auto* rootLayout = new QVBoxLayout(this);
     rootLayout->setContentsMargins(0, 0, 0, 0);
@@ -359,8 +478,7 @@ ScenarioBatchResultWidget::ScenarioBatchResultWidget(
         navigateToAuthoring();
     });
 
-    canvas_ = new SimulationCanvasWidget(layout_, shell_);
-    shell_->setCanvas(canvas_);
+    shell_->setCanvas(createCanvasPanel());
     shell_->setReviewPanel(createSummaryPanel());
     shell_->setReviewPanelVisible(true);
     rootLayout->addWidget(shell_);
@@ -379,12 +497,138 @@ std::optional<ScenarioAuthoringWidget::InitialState> ScenarioBatchResultWidget::
     return returnAuthoringState_;
 }
 
+QWidget* ScenarioBatchResultWidget::createCanvasPanel() {
+    auto* panel = new QWidget(shell_);
+    auto* layout = new QVBoxLayout(panel);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+
+    auto* selectorBar = new QFrame(panel);
+    selectorBar->setStyleSheet(
+        "QFrame { background: #ffffff; border-bottom: 1px solid #d7e0ea; }"
+        "QLabel { background: transparent; border: 0; }"
+        "QComboBox { background: #ffffff; border: 1px solid #c9d5e2; border-radius: 7px; padding: 5px 24px 5px 8px; }");
+    auto* selectorLayout = new QHBoxLayout(selectorBar);
+    selectorLayout->setContentsMargins(16, 8, 16, 8);
+    selectorLayout->setSpacing(8);
+
+    auto* scenarioLabel = createLabel("Scenario playback", selectorBar, ui::FontRole::Caption);
+    scenarioLabel->setStyleSheet(ui::mutedTextStyleSheet());
+    selectorLayout->addWidget(scenarioLabel);
+
+    displayScenarioCombo_ = new QComboBox(selectorBar);
+    for (const auto& result : results_) {
+        displayScenarioCombo_->addItem(QString::fromStdString(result.scenario.name));
+    }
+    displayScenarioCombo_->setCurrentIndex(currentResultIndex_);
+    selectorLayout->addWidget(displayScenarioCombo_, 1);
+
+    auto* overlayLabel = createLabel("Map overlay", selectorBar, ui::FontRole::Caption);
+    overlayLabel->setStyleSheet(ui::mutedTextStyleSheet());
+    selectorLayout->addWidget(overlayLabel);
+
+    overlayCombo_ = new QComboBox(selectorBar);
+    overlayCombo_->addItem("Density", static_cast<int>(OverlayMode::Density));
+    overlayCombo_->addItem("Hotspots", static_cast<int>(OverlayMode::Hotspots));
+    overlayCombo_->addItem("Bottlenecks", static_cast<int>(OverlayMode::Bottlenecks));
+    overlayCombo_->addItem("None", static_cast<int>(OverlayMode::None));
+    overlayCombo_->setCurrentIndex(0);
+    selectorLayout->addWidget(overlayCombo_);
+    layout->addWidget(selectorBar);
+
+    canvas_ = new SimulationCanvasWidget(layout_, panel);
+    layout->addWidget(canvas_, 1);
+
+    auto* replayBar = new QFrame(panel);
+    replayBar->setStyleSheet(
+        "QFrame { background: #ffffff; border-top: 1px solid #d7e0ea; border-bottom: 1px solid #d7e0ea; }"
+        "QPushButton { border: 1px solid #c9d5e2; border-radius: 6px; padding: 5px 12px; background: #ffffff; color: #344256; }"
+        "QPushButton:hover { background: #eef3f8; }"
+        "QSlider::groove:horizontal { height: 6px; background: #d7e0ea; border-radius: 3px; }"
+        "QSlider::handle:horizontal { width: 16px; margin: -5px 0; border-radius: 8px; background: #1f5fae; }"
+        "QLabel { background: transparent; border: 0; }");
+    auto* replayLayout = new QHBoxLayout(replayBar);
+    replayLayout->setContentsMargins(16, 8, 16, 8);
+    replayLayout->setSpacing(10);
+    playButton_ = new QPushButton("Play", replayBar);
+    replaySlider_ = new QSlider(Qt::Horizontal, replayBar);
+    replaySlider_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    replayTimeLabel_ = createLabel("", replayBar, ui::FontRole::Caption);
+    replayTimeLabel_->setStyleSheet(ui::mutedTextStyleSheet());
+    replayLayout->addWidget(playButton_);
+    replayLayout->addWidget(replaySlider_, 1);
+    replayLayout->addWidget(replayTimeLabel_);
+    layout->addWidget(replayBar);
+
+    auto* graphPanel = new QFrame(panel);
+    graphPanel->setStyleSheet(
+        "QFrame { background: #ffffff; border-top: 1px solid #d7e0ea; }"
+        "QLabel { border: 0; }"
+        "QTabWidget::pane { border: 0; }"
+        "QTabBar::tab { background: #ffffff; border: 1px solid #c9d5e2; padding: 6px 12px; margin-right: 4px; }"
+        "QTabBar::tab:selected { background: #e6eef8; color: #1f5fae; }");
+    graphPanel->setMinimumHeight(260);
+    auto* graphLayout = new QVBoxLayout(graphPanel);
+    graphLayout->setContentsMargins(16, 10, 16, 16);
+    graphLayout->setSpacing(8);
+    graphLayout->addWidget(createLabel("Comparison Graphs", graphPanel, ui::FontRole::SectionTitle));
+    auto* tabs = new QTabWidget(graphPanel);
+    remainingChart_ = new ComparisonGraphWidget(ComparisonGraphMode::Remaining, tabs);
+    exitsChart_ = new ComparisonGraphWidget(ComparisonGraphMode::Exits, tabs);
+    static_cast<ComparisonGraphWidget*>(remainingChart_)->setResults(results_, selectedCompareIndices_, currentResultIndex_);
+    static_cast<ComparisonGraphWidget*>(exitsChart_)->setResults(results_, selectedCompareIndices_, currentResultIndex_);
+    tabs->addTab(remainingChart_, "Remaining");
+    tabs->addTab(exitsChart_, "Exits");
+    graphLayout->addWidget(tabs, 1);
+    layout->addWidget(graphPanel, 1);
+
+    replayTimer_ = new QTimer(this);
+    replayTimer_->setInterval(500);
+
+    connect(displayScenarioCombo_, &QComboBox::currentIndexChanged, this, [this](int index) {
+        if (index >= 0 && index < static_cast<int>(results_.size())) {
+            currentResultIndex_ = index;
+            refreshSelectedResult();
+        }
+    });
+    connect(overlayCombo_, &QComboBox::currentIndexChanged, this, [this](int index) {
+        overlayMode_ = static_cast<OverlayMode>(overlayCombo_->itemData(index).toInt());
+        if (!replayFrames_.empty()) {
+            applyReplayFrame(replayFrameIndex_);
+        }
+    });
+    connect(playButton_, &QPushButton::clicked, this, [this]() {
+        if (replayTimer_ == nullptr || replayFrames_.size() <= 1) {
+            return;
+        }
+        if (replayTimer_->isActive()) {
+            pauseReplay();
+            return;
+        }
+        if (replayFrameIndex_ >= static_cast<int>(replayFrames_.size()) - 1) {
+            replayFrameIndex_ = 0;
+            applyReplayFrame(replayFrameIndex_);
+        }
+        playButton_->setText("Pause");
+        replayTimer_->start();
+    });
+    connect(replaySlider_, &QSlider::valueChanged, this, [this](int value) {
+        pauseReplay();
+        applyReplayFrame(value);
+    });
+    connect(replayTimer_, &QTimer::timeout, this, [this]() {
+        advanceReplay();
+    });
+
+    return panel;
+}
+
 QWidget* ScenarioBatchResultWidget::createSummaryPanel() {
     auto* panel = new QWidget(shell_);
     auto* panelLayout = new QVBoxLayout(panel);
     panelLayout->setContentsMargins(0, 0, 0, 0);
     panelLayout->setSpacing(12);
-    panelLayout->addWidget(shell_ != nullptr ? shell_->createPanelHeader("Comparison", panel, false) : createLabel("Comparison", panel, ui::FontRole::Title));
+    panelLayout->addWidget(shell_ != nullptr ? shell_->createPanelHeader("Compare", panel, false) : createLabel("Compare", panel, ui::FontRole::Title));
 
     auto* scrollArea = new QScrollArea(panel);
     scrollArea->setWidgetResizable(true);
@@ -396,123 +640,32 @@ QWidget* ScenarioBatchResultWidget::createSummaryPanel() {
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(12);
 
-    const auto baselineIndex = baselineResultIndex();
-    int bestIndex = results_.empty() ? -1 : 0;
-    int highestRiskIndex = results_.empty() ? -1 : 0;
-    for (int index = 0; index < static_cast<int>(results_.size()); ++index) {
-        const auto& result = results_[static_cast<std::size_t>(index)];
-        if (bestIndex < 0 || finalSeconds(result) < finalSeconds(results_[static_cast<std::size_t>(bestIndex)])) {
-            bestIndex = index;
-        }
-        const auto& currentRisk = results_[static_cast<std::size_t>(highestRiskIndex)].risk;
-        if (riskRank(result.risk.completionRisk) > riskRank(currentRisk.completionRisk)
-            || (riskRank(result.risk.completionRisk) == riskRank(currentRisk.completionRisk)
-                && result.risk.bottlenecks.size() > currentRisk.bottlenecks.size())) {
-            highestRiskIndex = index;
-        }
-    }
+    auto* intro = createLabel("Choose which completed scenarios appear together in the Remaining and Exits graphs.", content, ui::FontRole::Caption);
+    intro->setStyleSheet(ui::mutedTextStyleSheet());
+    layout->addWidget(intro);
 
-    auto* cardsHost = new QWidget(content);
-    auto* cards = new QGridLayout(cardsHost);
-    cards->setContentsMargins(0, 0, 0, 0);
-    cards->setHorizontalSpacing(8);
-    cards->setVerticalSpacing(8);
-    const auto baselineName = baselineIndex >= 0
-        ? QString::fromStdString(results_[static_cast<std::size_t>(baselineIndex)].scenario.name)
-        : QString("None");
-    cards->addWidget(createMetricCard("Runs", QString::number(static_cast<int>(results_.size())), "Staged scenarios completed", cardsHost), 0, 0);
-    cards->addWidget(createMetricCard("Baseline", baselineName, "Comparison reference", cardsHost), 0, 1);
-    if (bestIndex >= 0) {
-        const auto& best = results_[static_cast<std::size_t>(bestIndex)];
-        const auto bestDelta = baselineIndex >= 0
-            ? finalSeconds(best) - finalSeconds(results_[static_cast<std::size_t>(baselineIndex)])
-            : 0.0;
-        cards->addWidget(createMetricCard(
-            "Fastest",
-            formatSeconds(finalSeconds(best)),
-            QString("%1  -  %2").arg(formatDeltaSeconds(bestDelta), QString::fromStdString(best.scenario.name)),
-            cardsHost), 1, 0);
-    }
-    if (highestRiskIndex >= 0) {
-        const auto& riskiest = results_[static_cast<std::size_t>(highestRiskIndex)];
-        cards->addWidget(createMetricCard(
-            "Highest Risk",
-            safecrowd::domain::scenarioRiskLevelLabel(riskiest.risk.completionRisk),
-            QString("%1 hotspots / %2 bottlenecks")
-                .arg(static_cast<int>(riskiest.risk.hotspots.size()))
-                .arg(static_cast<int>(riskiest.risk.bottlenecks.size())),
-            cardsHost), 1, 1);
-    }
-    layout->addWidget(cardsHost);
-
-    table_ = new QTableWidget(static_cast<int>(results_.size()), 8, content);
-    table_->setHorizontalHeaderLabels({"Scenario", "Role", "Final", "Delta", "Evac.", "Risk", "Hotspots", "Bottlenecks"});
-    table_->verticalHeader()->setVisible(false);
-    table_->setSelectionBehavior(QAbstractItemView::SelectRows);
-    table_->setSelectionMode(QAbstractItemView::SingleSelection);
-    table_->setEditTriggers(QAbstractItemView::NoEditTriggers);
-    table_->setAlternatingRowColors(true);
-    table_->setMinimumHeight(190);
-    table_->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
-    table_->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
-    table_->setStyleSheet(
-        "QTableWidget { background: #ffffff; border: 1px solid #d7e0ea; border-radius: 8px; gridline-color: #e4ebf3; }"
-        "QHeaderView::section { background: #eef3f8; border: 0; padding: 6px; color: #4f5d6b; }"
-        "QTableWidget::item { padding: 6px; }");
+    compareCheckBoxes_.clear();
     for (int row = 0; row < static_cast<int>(results_.size()); ++row) {
         const auto& result = results_[row];
-        table_->setItem(row, 0, readonlyItem(QString::fromStdString(result.scenario.name)));
-        table_->setItem(row, 1, readonlyItem(scenarioRoleLabel(result.scenario.role)));
-        table_->setItem(row, 2, readonlyItem(formatSeconds(finalSeconds(result)), Qt::AlignRight | Qt::AlignVCenter));
-        const auto deltaSeconds = baselineIndex >= 0
-            ? finalSeconds(result) - finalSeconds(results_[static_cast<std::size_t>(baselineIndex)])
-            : 0.0;
-        auto* deltaItem = readonlyItem(row == baselineIndex ? "Baseline" : formatDeltaSeconds(deltaSeconds), Qt::AlignRight | Qt::AlignVCenter);
-        deltaItem->setForeground(deltaColor(deltaSeconds));
-        table_->setItem(row, 3, deltaItem);
-        table_->setItem(row, 4, readonlyItem(formatPercent(result.frame.evacuatedAgentCount, result.frame.totalAgentCount), Qt::AlignRight | Qt::AlignVCenter));
-        table_->setItem(row, 5, readonlyItem(safecrowd::domain::scenarioRiskLevelLabel(result.risk.completionRisk)));
-        table_->setItem(row, 6, readonlyItem(QString::number(static_cast<int>(result.risk.hotspots.size())), Qt::AlignRight | Qt::AlignVCenter));
-        table_->setItem(row, 7, readonlyItem(QString::number(static_cast<int>(result.risk.bottlenecks.size())), Qt::AlignRight | Qt::AlignVCenter));
+        auto* checkbox = new QCheckBox(
+            QString("%1\n%2  -  %3  -  %4")
+                .arg(QString::fromStdString(result.scenario.name))
+                .arg(scenarioRoleLabel(result.scenario.role))
+                .arg(formatSeconds(finalSeconds(result)))
+                .arg(safecrowd::domain::scenarioRiskLevelLabel(result.risk.completionRisk)),
+            content);
+        checkbox->setFont(ui::font(ui::FontRole::Body));
+        checkbox->setChecked(std::find(selectedCompareIndices_.begin(), selectedCompareIndices_.end(), row) != selectedCompareIndices_.end());
+        checkbox->setStyleSheet(
+            "QCheckBox { background: #ffffff; border: 1px solid #d7e0ea; border-radius: 8px; padding: 8px; color: #16202b; }"
+            "QCheckBox:hover { background: #f8fafc; }"
+            "QCheckBox::indicator { width: 16px; height: 16px; }");
+        compareCheckBoxes_.push_back(checkbox);
+        layout->addWidget(checkbox);
+        connect(checkbox, &QCheckBox::toggled, this, [this]() {
+            refreshComparisonSelection();
+        });
     }
-    table_->resizeColumnsToContents();
-    layout->addWidget(table_);
-
-    auto* overlayLabel = createLabel("Overlay", content, ui::FontRole::SectionTitle);
-    layout->addWidget(overlayLabel);
-
-    auto* overlayRow = new QWidget(content);
-    auto* overlayLayout = new QHBoxLayout(overlayRow);
-    overlayLayout->setContentsMargins(0, 0, 0, 0);
-    overlayLayout->setSpacing(8);
-    overlayButtonGroup_ = new QButtonGroup(overlayRow);
-    overlayButtonGroup_->setExclusive(true);
-    const auto addOverlayButton = [this, overlayLayout, overlayRow](OverlayMode mode, const QString& text) {
-        auto* button = new QPushButton(text, overlayRow);
-        button->setCheckable(true);
-        button->setFont(ui::font(ui::FontRole::Caption));
-        button->setStyleSheet(ui::secondaryButtonStyleSheet()
-            + "QPushButton:checked { background: #e8f1ff; border-color: #2563eb; color: #1d4ed8; }");
-        overlayButtonGroup_->addButton(button, static_cast<int>(mode));
-        overlayLayout->addWidget(button);
-    };
-    addOverlayButton(OverlayMode::Density, "Density");
-    addOverlayButton(OverlayMode::Hotspots, "Hotspots");
-    addOverlayButton(OverlayMode::Bottlenecks, "Bottlenecks");
-    if (auto* button = overlayButtonGroup_->button(static_cast<int>(overlayMode_)); button != nullptr) {
-        button->setChecked(true);
-    }
-    connect(overlayButtonGroup_, &QButtonGroup::idClicked, this, [this](int id) {
-        overlayMode_ = static_cast<OverlayMode>(id);
-        refreshSelectedResult();
-    });
-    layout->addWidget(overlayRow);
-
-    layout->addWidget(createLabel("Evacuation Progress", content, ui::FontRole::SectionTitle));
-    auto* chart = new EvacuationProgressChartWidget(content);
-    chart->setResults(results_, baselineIndex, currentResultIndex_);
-    progressChart_ = chart;
-    layout->addWidget(chart);
 
     auto* detailCard = new QFrame(content);
     detailCard->setStyleSheet(ui::panelStyleSheet());
@@ -538,21 +691,12 @@ QWidget* ScenarioBatchResultWidget::createSummaryPanel() {
     editButton->setStyleSheet(ui::secondaryButtonStyleSheet());
     panelLayout->addWidget(editButton);
 
-    connect(table_, &QTableWidget::currentCellChanged, this, [this](int currentRow, int, int, int) {
-        if (currentRow >= 0 && currentRow < static_cast<int>(results_.size())) {
-            currentResultIndex_ = currentRow;
-            refreshSelectedResult();
-        }
-    });
     connect(rerunButton, &QPushButton::clicked, this, [this]() {
         rerunBatch();
     });
     connect(editButton, &QPushButton::clicked, this, [this]() {
         navigateToAuthoring();
     });
-    if (!results_.empty()) {
-        table_->selectRow(currentResultIndex_);
-    }
     return panel;
 }
 
@@ -561,6 +705,7 @@ void ScenarioBatchResultWidget::navigateToAuthoring() {
     if (rootLayout == nullptr || shell_ == nullptr) {
         return;
     }
+    pauseReplay();
 
     auto initial = returnAuthoringState_.value_or(ScenarioAuthoringWidget::InitialState{});
     if (initial.scenarios.empty()) {
@@ -586,15 +731,42 @@ void ScenarioBatchResultWidget::navigateToAuthoring() {
     canvas_ = nullptr;
 }
 
-void ScenarioBatchResultWidget::refreshSelectedResult() {
-    if (results_.empty() || currentResultIndex_ < 0 || currentResultIndex_ >= static_cast<int>(results_.size())) {
+void ScenarioBatchResultWidget::pauseReplay() {
+    if (replayTimer_ != nullptr) {
+        replayTimer_->stop();
+    }
+    if (playButton_ != nullptr) {
+        playButton_->setText("Play");
+    }
+}
+
+void ScenarioBatchResultWidget::advanceReplay() {
+    if (replayFrames_.empty()) {
+        pauseReplay();
         return;
     }
-    const auto& result = results_[currentResultIndex_];
-    const auto baselineIndex = baselineResultIndex();
+    if (replayFrameIndex_ >= static_cast<int>(replayFrames_.size()) - 1) {
+        pauseReplay();
+        return;
+    }
+    applyReplayFrame(replayFrameIndex_ + 1);
+}
+
+void ScenarioBatchResultWidget::applyReplayFrame(int frameIndex) {
+    if (replayFrames_.empty()) {
+        if (replayTimeLabel_ != nullptr) {
+            replayTimeLabel_->setText("No replay");
+        }
+        return;
+    }
+
+    replayFrameIndex_ = std::clamp(frameIndex, 0, static_cast<int>(replayFrames_.size()) - 1);
+    const auto& frame = replayFrames_[static_cast<std::size_t>(replayFrameIndex_)];
+    const auto& result = results_[static_cast<std::size_t>(currentResultIndex_)];
+
     if (canvas_ != nullptr) {
         canvas_->setConnectionBlocks(result.scenario.control.connectionBlocks);
-        canvas_->setFrame(result.frame);
+        canvas_->setFrame(frame);
         canvas_->setHotspotOverlay(result.risk.hotspots);
         canvas_->setBottleneckOverlay(result.risk.bottlenecks);
         canvas_->setDensityOverlay(result.artifacts.densitySummary.peakField.cells.empty()
@@ -607,14 +779,97 @@ void ScenarioBatchResultWidget::refreshSelectedResult() {
         case OverlayMode::Bottlenecks:
             canvas_->setResultOverlayMode(ResultOverlayMode::Bottlenecks);
             break;
+        case OverlayMode::None:
+            canvas_->setResultOverlayMode(ResultOverlayMode::None);
+            break;
         case OverlayMode::Density:
         default:
             canvas_->setResultOverlayMode(ResultOverlayMode::Density);
             break;
         }
     }
-    if (progressChart_ != nullptr) {
-        static_cast<EvacuationProgressChartWidget*>(progressChart_)->setSelectedIndex(currentResultIndex_);
+    if (replaySlider_ != nullptr && replaySlider_->value() != replayFrameIndex_) {
+        const QSignalBlocker blocker(replaySlider_);
+        replaySlider_->setValue(replayFrameIndex_);
+    }
+    if (remainingChart_ != nullptr) {
+        static_cast<ComparisonGraphWidget*>(remainingChart_)->setCurrentTimeSeconds(frame.elapsedSeconds);
+    }
+    if (exitsChart_ != nullptr) {
+        static_cast<ComparisonGraphWidget*>(exitsChart_)->setCurrentTimeSeconds(frame.elapsedSeconds);
+    }
+    if (replayTimeLabel_ != nullptr) {
+        const auto totalSeconds = replayFrames_.empty() ? frame.elapsedSeconds : replayFrames_.back().elapsedSeconds;
+        replayTimeLabel_->setText(QString("%1 / %2 sec")
+            .arg(frame.elapsedSeconds, 0, 'f', 1)
+            .arg(totalSeconds, 0, 'f', 1));
+    }
+}
+
+void ScenarioBatchResultWidget::loadReplayForSelectedResult() {
+    pauseReplay();
+    if (results_.empty() || currentResultIndex_ < 0 || currentResultIndex_ >= static_cast<int>(results_.size())) {
+        replayFrames_.clear();
+        return;
+    }
+    replayFrames_ = replayFramesForResult(results_[static_cast<std::size_t>(currentResultIndex_)]);
+    replayFrameIndex_ = replayFrames_.empty() ? 0 : static_cast<int>(replayFrames_.size()) - 1;
+    if (replaySlider_ != nullptr) {
+        replaySlider_->setEnabled(replayFrames_.size() > 1);
+        replaySlider_->setRange(0, replayFrames_.empty() ? 0 : static_cast<int>(replayFrames_.size()) - 1);
+        const QSignalBlocker blocker(replaySlider_);
+        replaySlider_->setValue(replayFrameIndex_);
+    }
+    if (playButton_ != nullptr) {
+        playButton_->setEnabled(replayFrames_.size() > 1);
+        playButton_->setText("Play");
+    }
+    applyReplayFrame(replayFrameIndex_);
+}
+
+void ScenarioBatchResultWidget::refreshComparisonSelection() {
+    selectedCompareIndices_.clear();
+    for (int index = 0; index < static_cast<int>(compareCheckBoxes_.size()); ++index) {
+        if (compareCheckBoxes_[static_cast<std::size_t>(index)] != nullptr
+            && compareCheckBoxes_[static_cast<std::size_t>(index)]->isChecked()) {
+            selectedCompareIndices_.push_back(index);
+        }
+    }
+    if (selectedCompareIndices_.empty() && !compareCheckBoxes_.empty()) {
+        const auto fallbackIndex = std::clamp(currentResultIndex_, 0, static_cast<int>(compareCheckBoxes_.size()) - 1);
+        if (auto* checkbox = compareCheckBoxes_[static_cast<std::size_t>(fallbackIndex)]; checkbox != nullptr) {
+            const QSignalBlocker blocker(checkbox);
+            checkbox->setChecked(true);
+        }
+        selectedCompareIndices_.push_back(fallbackIndex);
+    }
+    if (remainingChart_ != nullptr) {
+        static_cast<ComparisonGraphWidget*>(remainingChart_)->setResults(results_, selectedCompareIndices_, currentResultIndex_);
+    }
+    if (exitsChart_ != nullptr) {
+        static_cast<ComparisonGraphWidget*>(exitsChart_)->setResults(results_, selectedCompareIndices_, currentResultIndex_);
+    }
+}
+
+void ScenarioBatchResultWidget::refreshSelectedResult() {
+    if (results_.empty() || currentResultIndex_ < 0 || currentResultIndex_ >= static_cast<int>(results_.size())) {
+        return;
+    }
+    const auto& result = results_[currentResultIndex_];
+    const auto baselineIndex = baselineResultIndex();
+
+    if (displayScenarioCombo_ != nullptr && displayScenarioCombo_->currentIndex() != currentResultIndex_) {
+        const QSignalBlocker blocker(displayScenarioCombo_);
+        displayScenarioCombo_->setCurrentIndex(currentResultIndex_);
+    }
+
+    loadReplayForSelectedResult();
+
+    if (remainingChart_ != nullptr) {
+        static_cast<ComparisonGraphWidget*>(remainingChart_)->setResults(results_, selectedCompareIndices_, currentResultIndex_);
+    }
+    if (exitsChart_ != nullptr) {
+        static_cast<ComparisonGraphWidget*>(exitsChart_)->setResults(results_, selectedCompareIndices_, currentResultIndex_);
     }
     if (detailLabel_ != nullptr) {
         const auto selectedFinalSeconds = finalSeconds(result);
@@ -653,6 +908,7 @@ void ScenarioBatchResultWidget::rerunBatch() {
     if (rootLayout == nullptr || shell_ == nullptr) {
         return;
     }
+    pauseReplay();
     auto* runWidget = new ScenarioRunWidget(
         projectName_,
         layout_,

--- a/src/application/ScenarioBatchResultWidget.h
+++ b/src/application/ScenarioBatchResultWidget.h
@@ -12,6 +12,7 @@
 #include "domain/FacilityLayout2D.h"
 
 class QLabel;
+class QButtonGroup;
 class QTableWidget;
 
 namespace safecrowd::application {
@@ -37,10 +38,17 @@ public:
     std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState() const;
 
 private:
+    enum class OverlayMode {
+        Density = 0,
+        Hotspots = 1,
+        Bottlenecks = 2,
+    };
+
     QWidget* createSummaryPanel();
     void navigateToAuthoring();
     void refreshSelectedResult();
     void rerunBatch();
+    int baselineResultIndex() const noexcept;
 
     QString projectName_{};
     safecrowd::domain::FacilityLayout2D layout_{};
@@ -52,8 +60,11 @@ private:
     int currentResultIndex_{0};
     WorkspaceShell* shell_{nullptr};
     SimulationCanvasWidget* canvas_{nullptr};
+    QButtonGroup* overlayButtonGroup_{nullptr};
     QTableWidget* table_{nullptr};
     QLabel* detailLabel_{nullptr};
+    QWidget* progressChart_{nullptr};
+    OverlayMode overlayMode_{OverlayMode::Density};
 };
 
 }  // namespace safecrowd::application

--- a/src/application/ScenarioBatchResultWidget.h
+++ b/src/application/ScenarioBatchResultWidget.h
@@ -12,8 +12,11 @@
 #include "domain/FacilityLayout2D.h"
 
 class QLabel;
-class QButtonGroup;
-class QTableWidget;
+class QCheckBox;
+class QComboBox;
+class QPushButton;
+class QSlider;
+class QTimer;
 
 namespace safecrowd::application {
 
@@ -42,10 +45,17 @@ private:
         Density = 0,
         Hotspots = 1,
         Bottlenecks = 2,
+        None = 3,
     };
 
+    QWidget* createCanvasPanel();
     QWidget* createSummaryPanel();
+    void advanceReplay();
+    void applyReplayFrame(int frameIndex);
+    void loadReplayForSelectedResult();
     void navigateToAuthoring();
+    void pauseReplay();
+    void refreshComparisonSelection();
     void refreshSelectedResult();
     void rerunBatch();
     int baselineResultIndex() const noexcept;
@@ -58,12 +68,21 @@ private:
     std::function<void()> openProjectHandler_{};
     std::function<void()> backToLayoutReviewHandler_{};
     int currentResultIndex_{0};
+    std::vector<int> selectedCompareIndices_{};
+    std::vector<safecrowd::domain::SimulationFrame> replayFrames_{};
+    int replayFrameIndex_{0};
     WorkspaceShell* shell_{nullptr};
     SimulationCanvasWidget* canvas_{nullptr};
-    QButtonGroup* overlayButtonGroup_{nullptr};
-    QTableWidget* table_{nullptr};
+    QComboBox* displayScenarioCombo_{nullptr};
+    QComboBox* overlayCombo_{nullptr};
+    QPushButton* playButton_{nullptr};
+    QSlider* replaySlider_{nullptr};
+    QLabel* replayTimeLabel_{nullptr};
     QLabel* detailLabel_{nullptr};
-    QWidget* progressChart_{nullptr};
+    std::vector<QCheckBox*> compareCheckBoxes_{};
+    QWidget* remainingChart_{nullptr};
+    QWidget* exitsChart_{nullptr};
+    QTimer* replayTimer_{nullptr};
     OverlayMode overlayMode_{OverlayMode::Density};
 };
 

--- a/src/application/ScenarioBatchResultWidget.h
+++ b/src/application/ScenarioBatchResultWidget.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <vector>
+
+#include <QString>
+#include <QWidget>
+
+#include "application/ScenarioAuthoringWidget.h"
+#include "application/ProjectWorkspaceState.h"
+#include "domain/FacilityLayout2D.h"
+
+class QLabel;
+class QTableWidget;
+
+namespace safecrowd::application {
+
+class SimulationCanvasWidget;
+class WorkspaceShell;
+
+class ScenarioBatchResultWidget : public QWidget {
+public:
+    explicit ScenarioBatchResultWidget(
+        QString projectName,
+        safecrowd::domain::FacilityLayout2D layout,
+        std::vector<SavedScenarioResultState> results,
+        std::function<void()> saveProjectHandler,
+        std::function<void()> openProjectHandler,
+        std::function<void()> backToLayoutReviewHandler,
+        std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState = std::nullopt,
+        int currentResultIndex = 0,
+        QWidget* parent = nullptr);
+
+    const std::vector<SavedScenarioResultState>& results() const noexcept;
+    int currentResultIndex() const noexcept;
+    std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState() const;
+
+private:
+    QWidget* createSummaryPanel();
+    void navigateToAuthoring();
+    void refreshSelectedResult();
+    void rerunBatch();
+
+    QString projectName_{};
+    safecrowd::domain::FacilityLayout2D layout_{};
+    std::vector<SavedScenarioResultState> results_{};
+    std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState_{};
+    std::function<void()> saveProjectHandler_{};
+    std::function<void()> openProjectHandler_{};
+    std::function<void()> backToLayoutReviewHandler_{};
+    int currentResultIndex_{0};
+    WorkspaceShell* shell_{nullptr};
+    SimulationCanvasWidget* canvas_{nullptr};
+    QTableWidget* table_{nullptr};
+    QLabel* detailLabel_{nullptr};
+};
+
+}  // namespace safecrowd::application

--- a/src/application/ScenarioRunWidget.cpp
+++ b/src/application/ScenarioRunWidget.cpp
@@ -7,17 +7,22 @@
 
 #include <QColor>
 #include <QElapsedTimer>
-#include <QIcon>
-#include <QLabel>
+#include <QGridLayout>
 #include <QHBoxLayout>
+#include <QIcon>
+#include <QImage>
+#include <QLabel>
 #include <QPainter>
 #include <QPixmap>
 #include <QProgressBar>
 #include <QPushButton>
+#include <QSizePolicy>
 #include <QTimer>
+#include <QVariant>
 #include <QVBoxLayout>
 
 #include "application/ScenarioAuthoringWidget.h"
+#include "application/ScenarioBatchResultWidget.h"
 #include "application/ScenarioResultWidget.h"
 #include "application/SimulationCanvasWidget.h"
 #include "application/UiStyle.h"
@@ -70,10 +75,10 @@ QProgressBar* createProgressBar(const QString& tooltip, QWidget* parent) {
 }
 
 QIcon makeTransportIcon(TransportIconKind kind, const QColor& color) {
-    QPixmap pixmap(40, 40);
-    pixmap.fill(Qt::transparent);
+    QImage image(QSize(40, 40), QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
 
-    QPainter painter(&pixmap);
+    QPainter painter(&image);
     painter.setRenderHint(QPainter::Antialiasing, true);
     painter.setPen(Qt::NoPen);
     painter.setBrush(color);
@@ -89,17 +94,31 @@ QIcon makeTransportIcon(TransportIconKind kind, const QColor& color) {
         painter.drawRoundedRect(QRectF(13, 13, 14, 14), 2, 2);
     }
 
-    return QIcon(pixmap);
+    painter.end();
+    return QIcon(QPixmap::fromImage(image));
+}
+
+void setTransportIcon(QPushButton* button, TransportIconKind kind, const QColor& color) {
+    if (button == nullptr) {
+        return;
+    }
+    const auto iconKind = static_cast<int>(kind);
+    const auto previousKind = button->property("transportIconKind");
+    if (previousKind.isValid() && previousKind.toInt() == iconKind) {
+        return;
+    }
+    button->setIcon(makeTransportIcon(kind, color));
+    button->setProperty("transportIconKind", iconKind);
 }
 
 QPushButton* createIconButton(TransportIconKind icon, const QString& tooltip, QWidget* parent) {
     auto* button = new QPushButton(parent);
-    button->setIcon(makeTransportIcon(icon, QColor("#16202b")));
     button->setIconSize(QSize(22, 22));
     button->setToolTip(tooltip);
     button->setAccessibleName(tooltip);
     button->setFixedSize(40, 36);
     button->setStyleSheet(ui::secondaryButtonStyleSheet());
+    setTransportIcon(button, icon, QColor("#16202b"));
     return button;
 }
 
@@ -180,17 +199,15 @@ ScenarioRunWidget::ScenarioRunWidget(
     std::function<void()> backToLayoutReviewHandler,
     QWidget* parent,
     std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState)
-    : QWidget(parent),
-      projectName_(projectName),
-      layout_(layout),
-      scenario_(scenario),
-      runner_(layout_, scenario_),
-      saveProjectHandler_(std::move(saveProjectHandler)),
-      openProjectHandler_(std::move(openProjectHandler)),
-      backToLayoutReviewHandler_(std::move(backToLayoutReviewHandler)),
-      returnAuthoringState_(std::move(returnAuthoringState)) {
-    setupUi();
-}
+    : ScenarioRunWidget(
+          projectName,
+          layout,
+          std::vector<safecrowd::domain::ScenarioDraft>{scenario},
+          std::move(saveProjectHandler),
+          std::move(openProjectHandler),
+          std::move(backToLayoutReviewHandler),
+          std::move(returnAuthoringState),
+          parent) {}
 
 ScenarioRunWidget::ScenarioRunWidget(
     const QString& projectName,
@@ -204,22 +221,63 @@ ScenarioRunWidget::ScenarioRunWidget(
     safecrowd::domain::ScenarioResultArtifacts cachedResultArtifacts,
     QWidget* parent,
     std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState)
+    : ScenarioRunWidget(
+          projectName,
+          layout,
+          std::vector<safecrowd::domain::ScenarioDraft>{scenario},
+          std::vector<SavedScenarioResultState>{{
+              .scenario = scenario,
+              .frame = std::move(cachedResultFrame),
+              .risk = std::move(cachedResultRisk),
+              .artifacts = std::move(cachedResultArtifacts),
+          }},
+          std::move(saveProjectHandler),
+          std::move(openProjectHandler),
+          std::move(backToLayoutReviewHandler),
+          std::move(returnAuthoringState),
+          parent) {}
+
+ScenarioRunWidget::ScenarioRunWidget(
+    const QString& projectName,
+    const safecrowd::domain::FacilityLayout2D& layout,
+    std::vector<safecrowd::domain::ScenarioDraft> scenarios,
+    std::function<void()> saveProjectHandler,
+    std::function<void()> openProjectHandler,
+    std::function<void()> backToLayoutReviewHandler,
+    std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState,
+    QWidget* parent)
+    : ScenarioRunWidget(
+          projectName,
+          layout,
+          std::move(scenarios),
+          {},
+          std::move(saveProjectHandler),
+          std::move(openProjectHandler),
+          std::move(backToLayoutReviewHandler),
+          std::move(returnAuthoringState),
+          parent) {}
+
+ScenarioRunWidget::ScenarioRunWidget(
+    const QString& projectName,
+    const safecrowd::domain::FacilityLayout2D& layout,
+    std::vector<safecrowd::domain::ScenarioDraft> scenarios,
+    std::vector<SavedScenarioResultState> cachedResults,
+    std::function<void()> saveProjectHandler,
+    std::function<void()> openProjectHandler,
+    std::function<void()> backToLayoutReviewHandler,
+    std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState,
+    QWidget* parent)
     : QWidget(parent),
       projectName_(projectName),
       layout_(layout),
-      scenario_(scenario),
-      runner_(layout_, scenario_),
-      cachedResultFrame_(std::move(cachedResultFrame)),
-      cachedResultRisk_(std::move(cachedResultRisk)),
-      cachedResultArtifacts_(std::move(cachedResultArtifacts)),
+      scenario_(scenarios.empty() ? safecrowd::domain::ScenarioDraft{} : scenarios.front()),
+      scenarios_(std::move(scenarios)),
+      cachedResults_(std::move(cachedResults)),
+      batchRunner_(layout_, scenarios_),
+      returnAuthoringState_(std::move(returnAuthoringState)),
       saveProjectHandler_(std::move(saveProjectHandler)),
       openProjectHandler_(std::move(openProjectHandler)),
-      backToLayoutReviewHandler_(std::move(backToLayoutReviewHandler)),
-      returnAuthoringState_(std::move(returnAuthoringState)) {
-    setupUi();
-}
-
-void ScenarioRunWidget::setupUi() {
+      backToLayoutReviewHandler_(std::move(backToLayoutReviewHandler)) {
     auto* rootLayout = new QVBoxLayout(this);
     rootLayout->setContentsMargins(0, 0, 0, 0);
     rootLayout->setSpacing(0);
@@ -236,10 +294,7 @@ void ScenarioRunWidget::setupUi() {
     shell_->setBackHandler([this]() {
         returnToAuthoring();
     });
-    canvas_ = new SimulationCanvasWidget(layout_, shell_);
-    canvas_->setConnectionBlocks(scenario_.control.connectionBlocks);
-    canvas_->setFrame(runner_.frame());
-    shell_->setCanvas(canvas_);
+    shell_->setCanvas(createRunCanvas());
     shell_->setReviewPanel(createRunPanel());
     shell_->setReviewPanelVisible(true);
     rootLayout->addWidget(shell_);
@@ -252,10 +307,9 @@ void ScenarioRunWidget::setupUi() {
             return;
         }
         if (!paused_) {
-            runner_.step(kSimulationDeltaSeconds);
-            canvas_->setFrame(runner_.frame());
+            batchRunner_.step(kSimulationDeltaSeconds);
             refreshStatus();
-            if (runner_.complete()) {
+            if (batchRunner_.complete()) {
                 timer_->stop();
             }
         }
@@ -268,8 +322,96 @@ const safecrowd::domain::ScenarioDraft& ScenarioRunWidget::scenario() const noex
     return scenario_;
 }
 
+const std::vector<safecrowd::domain::ScenarioDraft>& ScenarioRunWidget::scenarios() const noexcept {
+    return scenarios_;
+}
+
 const std::optional<ScenarioAuthoringWidget::InitialState>& ScenarioRunWidget::returnAuthoringState() const noexcept {
     return returnAuthoringState_;
+}
+
+bool ScenarioRunWidget::hasCachedResults() const noexcept {
+    return !cachedResults_.empty();
+}
+
+std::vector<SavedScenarioResultState> ScenarioRunWidget::completedResults() {
+    batchRunner_.syncResultArtifacts();
+
+    std::vector<SavedScenarioResultState> results;
+    results.reserve(batchRunner_.size());
+    for (const auto& run : batchRunner_.runs()) {
+        results.push_back({
+            .scenario = run.scenario,
+            .frame = run.frame,
+            .risk = run.resultRisk,
+            .artifacts = run.artifacts,
+        });
+    }
+    return results;
+}
+
+QWidget* ScenarioRunWidget::createRunCanvas() {
+    auto* container = new QWidget(shell_);
+    auto* layout = new QVBoxLayout(container);
+    layout->setContentsMargins(16, 16, 16, 16);
+    layout->setSpacing(12);
+
+    canvas_ = new SimulationCanvasWidget(layout_, container);
+    canvas_->setMinimumHeight(360);
+    if (!batchRunner_.empty()) {
+        const auto& run = batchRunner_.run(0);
+        canvas_->setConnectionBlocks(run.scenario.control.connectionBlocks);
+        canvas_->setFrame(run.frame);
+    }
+    layout->addWidget(canvas_, 1);
+
+    auto* cardGrid = new QGridLayout();
+    cardGrid->setContentsMargins(0, 0, 0, 0);
+    cardGrid->setSpacing(8);
+    const auto count = static_cast<int>(batchRunner_.size());
+    const auto columns = count <= 1 ? 1 : 2;
+    previewButtons_.clear();
+    previewStatusLabels_.clear();
+    previewProgressBars_.clear();
+    previewButtons_.reserve(static_cast<std::size_t>(count));
+    previewStatusLabels_.reserve(static_cast<std::size_t>(count));
+    previewProgressBars_.reserve(static_cast<std::size_t>(count));
+
+    for (int index = 0; index < count; ++index) {
+        const auto& run = batchRunner_.run(static_cast<std::size_t>(index));
+        auto* card = new QWidget(container);
+        card->setStyleSheet(ui::panelStyleSheet());
+        auto* cardLayout = new QVBoxLayout(card);
+        cardLayout->setContentsMargins(10, 10, 10, 10);
+        cardLayout->setSpacing(8);
+
+        auto* button = new QPushButton(QString::fromStdString(run.scenario.name), card);
+        button->setFont(ui::font(ui::FontRole::Body));
+        button->setStyleSheet(ui::secondaryButtonStyleSheet());
+        button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        cardLayout->addWidget(button);
+
+        auto* status = createLabel("Pending", card, ui::FontRole::Caption);
+        status->setStyleSheet(ui::mutedTextStyleSheet());
+        cardLayout->addWidget(status);
+
+        auto* progress = createProgressBar("Scenario progress against its time limit.", card);
+        cardLayout->addWidget(progress);
+
+        const int row = index / columns;
+        const int column = index % columns;
+        cardGrid->addWidget(card, row, column);
+        previewButtons_.push_back(button);
+        previewStatusLabels_.push_back(status);
+        previewProgressBars_.push_back(progress);
+
+        connect(button, &QPushButton::clicked, this, [this, index]() {
+            selectRun(index);
+        });
+    }
+
+    layout->addLayout(cardGrid);
+    return container;
 }
 
 QWidget* ScenarioRunWidget::createRunPanel() {
@@ -354,6 +496,7 @@ void ScenarioRunWidget::returnToAuthoring() {
     fastForwardingToResult_ = false;
     if (timer_ != nullptr) {
         timer_->stop();
+        timer_->setInterval(kPlaybackTimerIntervalMs);
     }
 
     auto* rootLayout = qobject_cast<QVBoxLayout*>(layout());
@@ -363,8 +506,10 @@ void ScenarioRunWidget::returnToAuthoring() {
 
     auto initial = returnAuthoringState_.value_or(ScenarioAuthoringWidget::InitialState{});
     if (initial.scenarios.empty()) {
-        initial.scenarios.push_back(scenarioStateFromDraft(scenario_, layout_));
-        initial.currentScenarioIndex = 0;
+        for (const auto& scenario : scenarios_) {
+            initial.scenarios.push_back(scenarioStateFromDraft(scenario, layout_));
+        }
+        initial.currentScenarioIndex = selectedRunIndex_;
         initial.navigationView = ScenarioAuthoringWidget::NavigationView::Layout;
     }
     initial.rightPanelMode = ScenarioAuthoringWidget::RightPanelMode::Scenario;
@@ -385,16 +530,46 @@ void ScenarioRunWidget::returnToAuthoring() {
     canvas_ = nullptr;
 }
 
-bool ScenarioRunWidget::hasCachedResult() const noexcept {
-    return cachedResultFrame_.has_value()
-        && cachedResultRisk_.has_value()
-        && cachedResultArtifacts_.has_value();
-}
-
 void ScenarioRunWidget::refreshStatus() {
-    const auto& frame = runner_.frame();
+    if (batchRunner_.empty()) {
+        return;
+    }
+    if (selectedRunIndex_ < 0 || selectedRunIndex_ >= static_cast<int>(batchRunner_.size())) {
+        selectedRunIndex_ = 0;
+    }
+    const auto& selectedRun = batchRunner_.run(static_cast<std::size_t>(selectedRunIndex_));
+    const auto& frame = selectedRun.frame;
+    if (canvas_ != nullptr) {
+        canvas_->setConnectionBlocks(selectedRun.scenario.control.connectionBlocks);
+        canvas_->setFrame(selectedRun.frame);
+    }
+    for (std::size_t index = 0; index < batchRunner_.size(); ++index) {
+        const auto& run = batchRunner_.run(index);
+        if (index < previewButtons_.size() && previewButtons_[index] != nullptr) {
+            previewButtons_[index]->setText(QString("%1%2")
+                .arg(QString::fromStdString(run.scenario.name))
+                .arg(run.complete ? "  -  Complete" : "  -  Running"));
+            previewButtons_[index]->setStyleSheet(index == static_cast<std::size_t>(selectedRunIndex_)
+                ? ui::primaryButtonStyleSheet()
+                : ui::secondaryButtonStyleSheet());
+        }
+        if (index < previewStatusLabels_.size() && previewStatusLabels_[index] != nullptr) {
+            previewStatusLabels_[index]->setText(QString("%1  -  %2 / %3 evacuated")
+                .arg(run.complete ? "Complete" : fastForwardingToResult_ ? "Fast forwarding" : paused_ ? "Paused" : "Running")
+                .arg(static_cast<int>(run.frame.evacuatedAgentCount))
+                .arg(static_cast<int>(run.frame.totalAgentCount)));
+        }
+        if (index < previewProgressBars_.size() && previewProgressBars_[index] != nullptr) {
+            previewProgressBars_[index]->setValue(percentValue(run.frame.elapsedSeconds, run.timeLimitSeconds));
+        }
+    }
     if (scenarioLabel_ != nullptr) {
-        scenarioLabel_->setText(QString("Scenario: %1").arg(QString::fromStdString(scenario_.name)));
+        scenarioLabel_->setText(QString("Scenario: %1\nBatch: %2 / %3 complete")
+            .arg(QString::fromStdString(selectedRun.scenario.name))
+            .arg(static_cast<int>(std::count_if(batchRunner_.runs().begin(), batchRunner_.runs().end(), [](const auto& run) {
+                return run.complete;
+            })))
+            .arg(static_cast<int>(batchRunner_.size())));
     }
     if (statusLabel_ != nullptr) {
         statusLabel_->setText(QString("Status: %1").arg(
@@ -405,10 +580,10 @@ void ScenarioRunWidget::refreshStatus() {
     if (elapsedLabel_ != nullptr) {
         elapsedLabel_->setText(QString("Elapsed: %1 / %2 sec")
             .arg(frame.elapsedSeconds, 0, 'f', 1)
-            .arg(runner_.timeLimitSeconds(), 0, 'f', 0));
+            .arg(selectedRun.timeLimitSeconds, 0, 'f', 0));
     }
     if (timeProgressBar_ != nullptr) {
-        timeProgressBar_->setValue(percentValue(frame.elapsedSeconds, runner_.timeLimitSeconds()));
+        timeProgressBar_->setValue(percentValue(frame.elapsedSeconds, selectedRun.timeLimitSeconds));
     }
     if (agentCountLabel_ != nullptr) {
         agentCountLabel_->setText(QString("Evacuated: %1 / %2\nActive Agents: %3")
@@ -421,7 +596,7 @@ void ScenarioRunWidget::refreshStatus() {
             static_cast<double>(frame.evacuatedAgentCount),
             static_cast<double>(frame.totalAgentCount)));
     }
-    const auto& risk = runner_.riskSnapshot();
+    const auto& risk = selectedRun.risk;
     if (riskLabel_ != nullptr) {
         riskLabel_->setText(QString("Completion Risk: %1\nStalled Agents: %2")
             .arg(safecrowd::domain::scenarioRiskLevelLabel(risk.completionRisk))
@@ -448,39 +623,52 @@ void ScenarioRunWidget::refreshStatus() {
         }
     }
     if (pauseButton_ != nullptr) {
-        pauseButton_->setIcon(makeTransportIcon(
+        setTransportIcon(
+            pauseButton_,
             paused_ ? TransportIconKind::Play : TransportIconKind::Pause,
-            QColor("#16202b")));
+            QColor("#16202b"));
         pauseButton_->setToolTip(paused_ ? "Resume simulation" : "Pause simulation");
         pauseButton_->setAccessibleName(paused_ ? "Resume simulation" : "Pause simulation");
-        pauseButton_->setEnabled(!frame.complete && !fastForwardingToResult_);
+        pauseButton_->setEnabled(!batchRunner_.complete() && !fastForwardingToResult_);
     }
     if (stopButton_ != nullptr) {
-        stopButton_->setEnabled(frame.totalAgentCount > 0);
+        stopButton_->setEnabled(frame.totalAgentCount > 0 || fastForwardingToResult_ || hasCachedResults());
     }
     if (fastForwardButton_ != nullptr) {
         fastForwardButton_->setEnabled(
-            frame.totalAgentCount > 0
-            && !frame.complete
-            && !hasCachedResult()
+            !batchRunner_.complete()
+            && !batchRunner_.empty()
+            && !hasCachedResults()
             && !fastForwardingToResult_);
     }
     if (resultButton_ != nullptr) {
-        const auto cachedAgentCount = hasCachedResult() ? cachedResultFrame_->totalAgentCount : 0;
         resultButton_->setEnabled(
             !fastForwardingToResult_
-            && ((frame.complete && frame.totalAgentCount > 0)
-                || cachedAgentCount > 0));
+            && ((batchRunner_.complete() && !batchRunner_.empty())
+                || hasCachedResults()));
     }
 }
 
+void ScenarioRunWidget::selectRun(int index) {
+    if (index < 0 || index >= static_cast<int>(batchRunner_.size())) {
+        return;
+    }
+    selectedRunIndex_ = index;
+    scenario_ = batchRunner_.run(static_cast<std::size_t>(selectedRunIndex_)).scenario;
+    refreshStatus();
+}
+
 void ScenarioRunWidget::startFastForwardToResult() {
-    if (runner_.complete()) {
-        storeResultCache(runner_);
+    if (batchRunner_.empty()) {
         refreshStatus();
         return;
     }
-    if (runner_.frame().totalAgentCount == 0 || hasCachedResult()) {
+    if (batchRunner_.complete()) {
+        batchRunner_.syncResultArtifacts();
+        refreshStatus();
+        return;
+    }
+    if (hasCachedResults()) {
         refreshStatus();
         return;
     }
@@ -503,48 +691,33 @@ void ScenarioRunWidget::advanceFastForwardToResult() {
     QElapsedTimer elapsed;
     elapsed.start();
     int steps = 0;
-    while (!runner_.complete()
+    while (!batchRunner_.complete()
            && steps < kFastForwardMaxStepsPerTick
            && elapsed.elapsed() < kFastForwardStepBudgetMs) {
-        runner_.step(kSimulationDeltaSeconds);
+        batchRunner_.step(kSimulationDeltaSeconds);
         ++steps;
     }
 
-    if (canvas_ != nullptr) {
-        canvas_->setFrame(runner_.frame());
-    }
-
-    if (runner_.complete()) {
+    if (batchRunner_.complete()) {
         fastForwardingToResult_ = false;
+        batchRunner_.syncResultArtifacts();
         if (timer_ != nullptr) {
             timer_->stop();
             timer_->setInterval(kPlaybackTimerIntervalMs);
         }
-        storeResultCache(runner_);
     }
     refreshStatus();
-}
-
-void ScenarioRunWidget::storeResultCache(const safecrowd::domain::ScenarioSimulationRunner& runner) {
-    cachedResultFrame_ = runner.frame();
-    cachedResultRisk_ = runner.resultRiskSnapshot();
-    cachedResultArtifacts_ = runner.resultArtifacts();
 }
 
 void ScenarioRunWidget::stopRun() {
     fastForwardingToResult_ = false;
     paused_ = true;
+    cachedResults_.clear();
     if (timer_ != nullptr) {
         timer_->stop();
         timer_->setInterval(kPlaybackTimerIntervalMs);
     }
-    runner_.reset(layout_, scenario_);
-    cachedResultFrame_.reset();
-    cachedResultRisk_.reset();
-    cachedResultArtifacts_.reset();
-    if (canvas_ != nullptr) {
-        canvas_->setFrame(runner_.frame());
-    }
+    batchRunner_.reset(layout_, scenarios_);
     refreshStatus();
     if (timer_ != nullptr) {
         timer_->start();
@@ -555,23 +728,14 @@ void ScenarioRunWidget::showResults() {
     if (fastForwardingToResult_) {
         return;
     }
-    if (runner_.frame().totalAgentCount == 0 && !hasCachedResult()) {
-        return;
-    }
 
-    const auto* resultFrame = &runner_.frame();
-    const auto* resultRisk = &runner_.resultRiskSnapshot();
-    const auto* resultArtifacts = &runner_.resultArtifacts();
-    if (!runner_.complete() && hasCachedResult()) {
-        resultFrame = &*cachedResultFrame_;
-        resultRisk = &*cachedResultRisk_;
-        resultArtifacts = &*cachedResultArtifacts_;
-    } else if (!runner_.complete()) {
-        return;
+    std::vector<SavedScenarioResultState> results;
+    if (batchRunner_.complete() && !batchRunner_.empty()) {
+        results = completedResults();
+    } else if (hasCachedResults()) {
+        results = cachedResults_;
     } else {
-        resultFrame = &runner_.frame();
-        resultRisk = &runner_.resultRiskSnapshot();
-        resultArtifacts = &runner_.resultArtifacts();
+        return;
     }
 
     if (timer_ != nullptr) {
@@ -583,26 +747,49 @@ void ScenarioRunWidget::showResults() {
         return;
     }
 
-    auto* resultWidget = new ScenarioResultWidget(
-        projectName_,
-        layout_,
-        scenario_,
-        *resultFrame,
-        *resultRisk,
-        *resultArtifacts,
-        [this]() {
-            if (saveProjectHandler_) {
-                saveProjectHandler_();
-            }
-        },
-        [this]() {
-            if (openProjectHandler_) {
-                openProjectHandler_();
-            }
-        },
-        backToLayoutReviewHandler_,
-        returnAuthoringState_,
-        this);
+    QWidget* resultWidget = nullptr;
+    if (results.size() == 1) {
+        const auto& result = results.front();
+        resultWidget = new ScenarioResultWidget(
+            projectName_,
+            layout_,
+            result.scenario,
+            result.frame,
+            result.risk,
+            result.artifacts,
+            [this]() {
+                if (saveProjectHandler_) {
+                    saveProjectHandler_();
+                }
+            },
+            [this]() {
+                if (openProjectHandler_) {
+                    openProjectHandler_();
+                }
+            },
+            backToLayoutReviewHandler_,
+            returnAuthoringState_,
+            this);
+    } else {
+        resultWidget = new ScenarioBatchResultWidget(
+            projectName_,
+            layout_,
+            std::move(results),
+            [this]() {
+                if (saveProjectHandler_) {
+                    saveProjectHandler_();
+                }
+            },
+            [this]() {
+                if (openProjectHandler_) {
+                    openProjectHandler_();
+                }
+            },
+            backToLayoutReviewHandler_,
+            returnAuthoringState_,
+            selectedRunIndex_,
+            this);
+    }
     rootLayout->replaceWidget(shell_, resultWidget);
     shell_->hide();
     shell_->deleteLater();
@@ -611,7 +798,7 @@ void ScenarioRunWidget::showResults() {
 }
 
 void ScenarioRunWidget::togglePaused() {
-    if (runner_.complete() || fastForwardingToResult_) {
+    if (batchRunner_.complete() || fastForwardingToResult_) {
         return;
     }
     paused_ = !paused_;

--- a/src/application/ScenarioRunWidget.h
+++ b/src/application/ScenarioRunWidget.h
@@ -2,14 +2,16 @@
 
 #include <functional>
 #include <optional>
+#include <vector>
 
 #include <QString>
 #include <QWidget>
 
+#include "application/ProjectWorkspaceState.h"
 #include "application/ScenarioAuthoringWidget.h"
 #include "domain/FacilityLayout2D.h"
 #include "domain/ScenarioAuthoring.h"
-#include "domain/ScenarioSimulationRunner.h"
+#include "domain/ScenarioBatchRunner.h"
 
 class QLabel;
 class QProgressBar;
@@ -32,6 +34,7 @@ public:
         std::function<void()> backToLayoutReviewHandler,
         QWidget* parent = nullptr,
         std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState = std::nullopt);
+
     explicit ScenarioRunWidget(
         const QString& projectName,
         const safecrowd::domain::FacilityLayout2D& layout,
@@ -45,35 +48,60 @@ public:
         QWidget* parent = nullptr,
         std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState = std::nullopt);
 
+    explicit ScenarioRunWidget(
+        const QString& projectName,
+        const safecrowd::domain::FacilityLayout2D& layout,
+        std::vector<safecrowd::domain::ScenarioDraft> scenarios,
+        std::function<void()> saveProjectHandler,
+        std::function<void()> openProjectHandler,
+        std::function<void()> backToLayoutReviewHandler,
+        std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState = std::nullopt,
+        QWidget* parent = nullptr);
+
+    explicit ScenarioRunWidget(
+        const QString& projectName,
+        const safecrowd::domain::FacilityLayout2D& layout,
+        std::vector<safecrowd::domain::ScenarioDraft> scenarios,
+        std::vector<SavedScenarioResultState> cachedResults,
+        std::function<void()> saveProjectHandler,
+        std::function<void()> openProjectHandler,
+        std::function<void()> backToLayoutReviewHandler,
+        std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState = std::nullopt,
+        QWidget* parent = nullptr);
+
     const safecrowd::domain::ScenarioDraft& scenario() const noexcept;
+    const std::vector<safecrowd::domain::ScenarioDraft>& scenarios() const noexcept;
     const std::optional<ScenarioAuthoringWidget::InitialState>& returnAuthoringState() const noexcept;
 
 private:
+    QWidget* createRunCanvas();
     QWidget* createRunPanel();
-    void returnToAuthoring();
-    bool hasCachedResult() const noexcept;
-    void refreshStatus();
+    bool hasCachedResults() const noexcept;
+    std::vector<SavedScenarioResultState> completedResults();
     void advanceFastForwardToResult();
-    void startFastForwardToResult();
-    void storeResultCache(const safecrowd::domain::ScenarioSimulationRunner& runner);
-    void setupUi();
+    void returnToAuthoring();
+    void refreshStatus();
+    void selectRun(int index);
     void showResults();
+    void startFastForwardToResult();
     void stopRun();
     void togglePaused();
 
     QString projectName_{};
     safecrowd::domain::FacilityLayout2D layout_{};
     safecrowd::domain::ScenarioDraft scenario_{};
-    safecrowd::domain::ScenarioSimulationRunner runner_{};
-    std::optional<safecrowd::domain::SimulationFrame> cachedResultFrame_{};
-    std::optional<safecrowd::domain::ScenarioRiskSnapshot> cachedResultRisk_{};
-    std::optional<safecrowd::domain::ScenarioResultArtifacts> cachedResultArtifacts_{};
+    std::vector<safecrowd::domain::ScenarioDraft> scenarios_{};
+    std::vector<SavedScenarioResultState> cachedResults_{};
+    safecrowd::domain::ScenarioBatchRunner batchRunner_{};
+    std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState_{};
     std::function<void()> saveProjectHandler_{};
     std::function<void()> openProjectHandler_{};
     std::function<void()> backToLayoutReviewHandler_{};
-    std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState_{};
     WorkspaceShell* shell_{nullptr};
     SimulationCanvasWidget* canvas_{nullptr};
+    std::vector<QPushButton*> previewButtons_{};
+    std::vector<QLabel*> previewStatusLabels_{};
+    std::vector<QProgressBar*> previewProgressBars_{};
     QTimer* timer_{nullptr};
     QLabel* scenarioLabel_{nullptr};
     QLabel* statusLabel_{nullptr};
@@ -88,6 +116,7 @@ private:
     QPushButton* stopButton_{nullptr};
     QPushButton* fastForwardButton_{nullptr};
     QPushButton* resultButton_{nullptr};
+    int selectedRunIndex_{0};
     bool fastForwardingToResult_{false};
     bool paused_{false};
 };

--- a/src/domain/ScenarioBatchRunner.cpp
+++ b/src/domain/ScenarioBatchRunner.cpp
@@ -1,0 +1,103 @@
+#include "domain/ScenarioBatchRunner.h"
+
+#include <stdexcept>
+#include <utility>
+
+namespace safecrowd::domain {
+
+ScenarioBatchRunner::ScenarioBatchRunner(FacilityLayout2D layout, std::vector<ScenarioDraft> scenarios) {
+    reset(std::move(layout), std::move(scenarios));
+}
+
+void ScenarioBatchRunner::reset(FacilityLayout2D layout, std::vector<ScenarioDraft> scenarios) {
+    layout_ = std::move(layout);
+    runners_.clear();
+    runs_.clear();
+    runners_.reserve(scenarios.size());
+    runs_.reserve(scenarios.size());
+
+    for (auto& scenario : scenarios) {
+        runners_.emplace_back(layout_, scenario);
+        runs_.push_back({
+            .scenario = std::move(scenario),
+        });
+    }
+    syncLiveRuns();
+}
+
+void ScenarioBatchRunner::step(double deltaSeconds) {
+    if (deltaSeconds <= 0.0) {
+        return;
+    }
+    for (auto& runner : runners_) {
+        if (!runner.complete()) {
+            runner.step(deltaSeconds);
+        }
+    }
+    syncLiveRuns();
+}
+
+const std::vector<ScenarioBatchRunState>& ScenarioBatchRunner::runs() const noexcept {
+    return runs_;
+}
+
+const ScenarioBatchRunState& ScenarioBatchRunner::run(std::size_t index) const {
+    if (index >= runs_.size()) {
+        throw std::out_of_range("ScenarioBatchRunner run index is out of range");
+    }
+    return runs_[index];
+}
+
+void ScenarioBatchRunner::syncResultArtifacts() {
+    syncLiveRuns();
+    for (std::size_t index = 0; index < runners_.size() && index < runs_.size(); ++index) {
+        syncResultRun(index);
+    }
+}
+
+bool ScenarioBatchRunner::empty() const noexcept {
+    return runs_.empty();
+}
+
+bool ScenarioBatchRunner::complete() const noexcept {
+    if (runs_.empty()) {
+        return false;
+    }
+    for (const auto& run : runs_) {
+        if (!run.complete) {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::size_t ScenarioBatchRunner::size() const noexcept {
+    return runs_.size();
+}
+
+void ScenarioBatchRunner::syncLiveRuns() {
+    for (std::size_t index = 0; index < runners_.size() && index < runs_.size(); ++index) {
+        const auto& runner = runners_[index];
+        auto& run = runs_[index];
+        run.frame = runner.frame();
+        run.risk = runner.riskSnapshot();
+        run.timeLimitSeconds = runner.timeLimitSeconds();
+        run.complete = runner.complete();
+        if (run.complete && !run.resultSynced) {
+            syncResultRun(index);
+        }
+    }
+}
+
+void ScenarioBatchRunner::syncResultRun(std::size_t index) {
+    if (index >= runners_.size() || index >= runs_.size()) {
+        return;
+    }
+    const auto& runner = runners_[index];
+    auto& run = runs_[index];
+    run.resultRisk = runner.resultRiskSnapshot();
+    run.artifacts = runner.resultArtifacts();
+    run.resultSynced = true;
+}
+
+}  // namespace safecrowd::domain

--- a/src/domain/ScenarioBatchRunner.h
+++ b/src/domain/ScenarioBatchRunner.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "domain/FacilityLayout2D.h"
+#include "domain/ScenarioAuthoring.h"
+#include "domain/ScenarioResultArtifacts.h"
+#include "domain/ScenarioRiskMetrics.h"
+#include "domain/ScenarioSimulationFrame.h"
+#include "domain/ScenarioSimulationRunner.h"
+
+namespace safecrowd::domain {
+
+struct ScenarioBatchRunState {
+    ScenarioDraft scenario{};
+    SimulationFrame frame{};
+    ScenarioRiskSnapshot risk{};
+    ScenarioRiskSnapshot resultRisk{};
+    ScenarioResultArtifacts artifacts{};
+    double timeLimitSeconds{0.0};
+    bool complete{false};
+    bool resultSynced{false};
+};
+
+class ScenarioBatchRunner {
+public:
+    ScenarioBatchRunner() = default;
+    ScenarioBatchRunner(FacilityLayout2D layout, std::vector<ScenarioDraft> scenarios);
+
+    void reset(FacilityLayout2D layout, std::vector<ScenarioDraft> scenarios);
+    void step(double deltaSeconds);
+
+    const std::vector<ScenarioBatchRunState>& runs() const noexcept;
+    const ScenarioBatchRunState& run(std::size_t index) const;
+    void syncResultArtifacts();
+    bool empty() const noexcept;
+    bool complete() const noexcept;
+    std::size_t size() const noexcept;
+
+private:
+    void syncLiveRuns();
+    void syncResultRun(std::size_t index);
+
+    FacilityLayout2D layout_{};
+    std::vector<ScenarioSimulationRunner> runners_{};
+    std::vector<ScenarioBatchRunState> runs_{};
+};
+
+}  // namespace safecrowd::domain

--- a/tests/ScenarioBatchRunnerTests.cpp
+++ b/tests/ScenarioBatchRunnerTests.cpp
@@ -1,0 +1,97 @@
+#include "TestSupport.h"
+
+#include "domain/ScenarioBatchRunner.h"
+
+namespace {
+
+safecrowd::domain::FacilityLayout2D twoRoomExitLayout() {
+    safecrowd::domain::FacilityLayout2D layout;
+    layout.zones.push_back({
+        .id = "room",
+        .kind = safecrowd::domain::ZoneKind::Room,
+        .label = "Room",
+        .area = {.outline = {{0.0, 0.0}, {2.0, 0.0}, {2.0, 2.0}, {0.0, 2.0}}},
+    });
+    layout.zones.push_back({
+        .id = "exit",
+        .kind = safecrowd::domain::ZoneKind::Exit,
+        .label = "Exit",
+        .area = {.outline = {{2.0, 0.0}, {4.0, 0.0}, {4.0, 2.0}, {2.0, 2.0}}},
+    });
+    layout.connections.push_back({
+        .id = "room-exit",
+        .kind = safecrowd::domain::ConnectionKind::Exit,
+        .fromZoneId = "room",
+        .toZoneId = "exit",
+        .effectiveWidth = 1.2,
+        .centerSpan = {{2.0, 0.5}, {2.0, 1.5}},
+    });
+    return layout;
+}
+
+safecrowd::domain::ScenarioDraft scenarioDraft(
+    std::string id,
+    std::string name,
+    double timeLimitSeconds,
+    double speed) {
+    safecrowd::domain::InitialPlacement2D placement;
+    placement.id = id + "-placement";
+    placement.zoneId = "room";
+    placement.targetAgentCount = 1;
+    placement.initialVelocity = {.x = speed, .y = 0.0};
+    placement.area.outline = {{.x = 0.5, .y = 1.0}};
+
+    safecrowd::domain::ScenarioDraft scenario;
+    scenario.scenarioId = std::move(id);
+    scenario.name = std::move(name);
+    scenario.population.initialPlacements.push_back(placement);
+    scenario.execution.timeLimitSeconds = timeLimitSeconds;
+    scenario.execution.sampleIntervalSeconds = 0.5;
+    return scenario;
+}
+
+}  // namespace
+
+SC_TEST(ScenarioBatchRunnerAdvancesMultipleScenariosOnSameTick) {
+    auto first = scenarioDraft("scenario-1", "Fast", 4.0, 2.0);
+    auto second = scenarioDraft("scenario-2", "Slow", 4.0, 0.8);
+
+    safecrowd::domain::ScenarioBatchRunner batch(twoRoomExitLayout(), {first, second});
+    batch.step(0.25);
+
+    SC_EXPECT_EQ(batch.size(), std::size_t{2});
+    SC_EXPECT_TRUE(batch.run(0).frame.elapsedSeconds > 0.0);
+    SC_EXPECT_TRUE(batch.run(1).frame.elapsedSeconds > 0.0);
+    SC_EXPECT_EQ(batch.run(0).scenario.scenarioId, std::string{"scenario-1"});
+    SC_EXPECT_EQ(batch.run(1).scenario.scenarioId, std::string{"scenario-2"});
+}
+
+SC_TEST(ScenarioBatchRunnerContinuesUnfinishedRunsAfterOneCompletes) {
+    auto shortRun = scenarioDraft("scenario-1", "Short", 0.2, 0.5);
+    auto longRun = scenarioDraft("scenario-2", "Long", 1.0, 0.5);
+
+    safecrowd::domain::ScenarioBatchRunner batch(twoRoomExitLayout(), {shortRun, longRun});
+    batch.step(0.3);
+
+    SC_EXPECT_TRUE(batch.run(0).complete);
+    SC_EXPECT_TRUE(!batch.run(1).complete);
+    const auto elapsedBefore = batch.run(1).frame.elapsedSeconds;
+
+    batch.step(0.3);
+
+    SC_EXPECT_TRUE(batch.run(1).frame.elapsedSeconds > elapsedBefore);
+}
+
+SC_TEST(ScenarioBatchRunnerKeepsResultArtifactsForCompletedRuns) {
+    auto first = scenarioDraft("scenario-1", "First", 1.0, 2.0);
+    auto second = scenarioDraft("scenario-2", "Second", 1.0, 1.5);
+
+    safecrowd::domain::ScenarioBatchRunner batch(twoRoomExitLayout(), {first, second});
+    for (int index = 0; index < 20 && !batch.complete(); ++index) {
+        batch.step(0.1);
+    }
+
+    SC_EXPECT_TRUE(batch.complete());
+    SC_EXPECT_TRUE(!batch.run(0).artifacts.evacuationProgress.empty());
+    SC_EXPECT_TRUE(!batch.run(1).artifacts.evacuationProgress.empty());
+}


### PR DESCRIPTION
## Summary

- Run all staged runnable scenarios as a domain-backed batch instead of selecting only the first staged baseline.
- Add batch run state persistence, a lightweight run workspace with selectable scenario cards, and a comparison result view.
- Add scenario diff/batch runner coverage and wire the new domain/application sources into CMake.

## Related Issue

- Closes #194

## Area

- [ ] Engine
- [x] Domain
- [x] Application
- [ ] Docs
- [x] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [ ] `cmake --preset windows-debug`
- [ ] `cmake --build --preset build-debug`
- [ ] `ctest --preset test-debug`
- [x] Not run (reason below)

`git diff --check origin/main...HEAD` passed. `cmake --preset windows-debug-no-app` was attempted, but local MSBuild/CMake configure fails before project generation because Windows SDK discovery cannot read `C:\Users\silve\AppData\Local\Microsoft SDKs`.

## Risks / Follow-up

- Batch execution is currently in-process and UI-driven; larger scenario counts may need future queue/progress virtualization.
- Full Qt build and CTest should be run in an environment with working Windows SDK access.