### PR TITLE
[Application] Left navigation tree context menu actions

### DIFF
--- a/src/application/LayoutNavigationPanelWidget.cpp
+++ b/src/application/LayoutNavigationPanelWidget.cpp
@@ -374,7 +374,8 @@ LayoutNavigationPanelWidget::LayoutNavigationPanelWidget(
     QWidget* parent,
     QWidget* headerWidget,
     NavigationTreeState navigationState,
-    std::function<void(const QSet<QString>&)> expandedStateChangedHandler)
+    std::function<void(const QSet<QString>&)> expandedStateChangedHandler,
+    std::function<void(const QString&)> deleteElementHandler)
     : QWidget(parent) {
     auto* layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -387,7 +388,10 @@ LayoutNavigationPanelWidget::LayoutNavigationPanelWidget(
         this,
         headerWidget,
         std::move(navigationState),
-        std::move(expandedStateChangedHandler)));
+        std::move(expandedStateChangedHandler),
+        std::move(deleteElementHandler),
+        {},
+        QString("Settings...")));
 }
 
 }  // namespace safecrowd::application

--- a/src/application/LayoutNavigationPanelWidget.h
+++ b/src/application/LayoutNavigationPanelWidget.h
@@ -19,7 +19,8 @@ public:
         QWidget* parent = nullptr,
         QWidget* headerWidget = nullptr,
         NavigationTreeState navigationState = {},
-        std::function<void(const QSet<QString>&)> expandedStateChangedHandler = {});
+        std::function<void(const QSet<QString>&)> expandedStateChangedHandler = {},
+        std::function<void(const QString&)> deleteElementHandler = {});
 };
 
 }  // namespace safecrowd::application

--- a/src/application/LayoutPreviewWidget.cpp
+++ b/src/application/LayoutPreviewWidget.cpp
@@ -2992,6 +2992,33 @@ void LayoutPreviewWidget::focusElement(const QString& elementId) {
     focusIssueTarget(elementId);
 }
 
+bool LayoutPreviewWidget::deleteElement(const QString& elementId) {
+    if (!importResult_.layout.has_value() || elementId.isEmpty() || elementId.startsWith("floor:")) {
+        return false;
+    }
+
+    if (containsConnection(*importResult_.layout, elementId)) {
+        deleteConnection(elementId);
+        return true;
+    }
+    if (containsBarrier(*importResult_.layout, elementId)) {
+        deleteBarrier(elementId);
+        return true;
+    }
+    if (containsZone(*importResult_.layout, elementId)) {
+        selectedBarrierId_.clear();
+        selectedBarrierIds_.clear();
+        selectedConnectionId_.clear();
+        selectedConnectionIds_.clear();
+        selectedZoneId_ = elementId;
+        selectedZoneIds_ = QStringList{elementId};
+        deleteSelectedElements();
+        return true;
+    }
+
+    return false;
+}
+
 void LayoutPreviewWidget::focusIssueTarget(const QString& targetId) {
     selectedZoneId_.clear();
     selectedZoneIds_.clear();

--- a/src/application/LayoutPreviewWidget.h
+++ b/src/application/LayoutPreviewWidget.h
@@ -52,6 +52,7 @@ public:
 
     void focusElement(const QString& elementId);
     void focusIssueTarget(const QString& targetId);
+    bool deleteElement(const QString& elementId);
     void resetView();
     void setImportResult(safecrowd::domain::ImportResult importResult);
     void setSelectionChangedHandler(std::function<void(const PreviewSelection&)> handler);

--- a/src/application/LayoutReviewWidget.cpp
+++ b/src/application/LayoutReviewWidget.cpp
@@ -157,6 +157,7 @@ QWidget* createNavigationPanel(
     bool showIssues,
     std::function<void(const safecrowd::domain::ImportIssue&)> selectIssueHandler,
     std::function<void(const QString&)> selectLayoutElementHandler,
+    std::function<void(const QString&)> deleteLayoutElementHandler,
     NavigationTreeState layoutNavigationState,
     std::function<void(const QSet<QString>&)> layoutExpandedStateChangedHandler,
     const WorkspaceShell* shell,
@@ -173,7 +174,8 @@ QWidget* createNavigationPanel(
             content,
             shell != nullptr ? shell->createPanelHeader("Layout", content, false) : nullptr,
             std::move(layoutNavigationState),
-            std::move(layoutExpandedStateChangedHandler)));
+            std::move(layoutExpandedStateChangedHandler),
+            std::move(deleteLayoutElementHandler)));
         return content;
     }
 
@@ -502,6 +504,11 @@ void LayoutReviewWidget::refreshNavigationPanel() {
         },
         [this](const QString& elementId) {
             handleLayoutElementSelected(elementId);
+        },
+        [this](const QString& elementId) {
+            if (preview_ != nullptr) {
+                preview_->deleteElement(elementId);
+            }
         },
         NavigationTreeState{
             .expandedNodeIds = layoutExpandedNodeIds_,

--- a/src/application/NavigationTreeWidget.cpp
+++ b/src/application/NavigationTreeWidget.cpp
@@ -4,6 +4,7 @@
 #include <QColor>
 #include <QFrame>
 #include <QLabel>
+#include <QMenu>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QSet>
@@ -274,7 +275,10 @@ NavigationTreeWidget::NavigationTreeWidget(
     QWidget* parent,
     QWidget* headerWidget,
     NavigationTreeState state,
-    std::function<void(const QSet<QString>&)> expandedStateChangedHandler)
+    std::function<void(const QSet<QString>&)> expandedStateChangedHandler,
+    std::function<void(const QString&)> deleteItemHandler,
+    std::function<void(const QString&)> settingsItemHandler,
+    const QString& settingsLabel)
     : QWidget(parent) {
     auto* layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -356,6 +360,57 @@ NavigationTreeWidget::NavigationTreeWidget(
         QObject::connect(tree, &QTreeWidget::itemCollapsed, tree, [notifyExpandedStateChanged](QTreeWidgetItem*) {
             notifyExpandedStateChanged();
         });
+    }
+
+    if (deleteItemHandler || settingsItemHandler) {
+        auto* viewport = tree->viewport();
+        if (viewport != nullptr) {
+            tree->setContextMenuPolicy(Qt::CustomContextMenu);
+            viewport->setContextMenuPolicy(Qt::CustomContextMenu);
+
+            const auto showMenu = [tree, viewport, deleteItemHandler, settingsItemHandler, settingsLabel](const QPoint& pos, QWidget* source) {
+                auto* item = tree->itemAt(pos);
+                if (item == nullptr) {
+                    return;
+                }
+
+                const auto selectable = item->data(0, kSelectableRole).toBool();
+                const auto id = item->data(0, kIdRole).toString();
+                if (!selectable || id.isEmpty()) {
+                    return;
+                }
+
+                QMenu menu;
+                QAction* settingsAction = nullptr;
+                if (settingsItemHandler) {
+                    settingsAction = menu.addAction(settingsLabel);
+                }
+                QAction* deleteAction = nullptr;
+                if (deleteItemHandler) {
+                    deleteAction = menu.addAction("Delete");
+                    if (id.startsWith("floor:")) {
+                        deleteAction->setEnabled(false);
+                    }
+                }
+
+                const auto* selectedAction = menu.exec(source->mapToGlobal(pos));
+                if (selectedAction == nullptr) {
+                    return;
+                }
+                if (selectedAction == settingsAction && settingsItemHandler) {
+                    settingsItemHandler(id);
+                } else if (selectedAction == deleteAction && deleteItemHandler) {
+                    deleteItemHandler(id);
+                }
+            };
+
+            QObject::connect(viewport, &QWidget::customContextMenuRequested, tree, [showMenu, viewport](const QPoint& pos) {
+                showMenu(pos, viewport);
+            });
+            QObject::connect(tree, &QWidget::customContextMenuRequested, tree, [showMenu, tree](const QPoint& pos) {
+                showMenu(pos, tree);
+            });
+        }
     }
 
     layout->addWidget(tree, 1);

--- a/src/application/NavigationTreeWidget.h
+++ b/src/application/NavigationTreeWidget.h
@@ -36,7 +36,10 @@ public:
         QWidget* parent = nullptr,
         QWidget* headerWidget = nullptr,
         NavigationTreeState state = {},
-        std::function<void(const QSet<QString>&)> expandedStateChangedHandler = {});
+        std::function<void(const QSet<QString>&)> expandedStateChangedHandler = {},
+        std::function<void(const QString&)> deleteItemHandler = {},
+        std::function<void(const QString&)> settingsItemHandler = {},
+        const QString& settingsLabel = QString("Settings..."));
 };
 
 }  // namespace safecrowd::application

--- a/src/application/ScenarioAuthoringWidget.cpp
+++ b/src/application/ScenarioAuthoringWidget.cpp
@@ -1184,6 +1184,9 @@ void ScenarioAuthoringWidget::refreshNavigationPanel() {
             if (canvas_ != nullptr && canvas_->deleteConnectionBlockById(id)) {
                 return;
             }
+            if (canvas_ != nullptr && canvas_->deleteRouteGuidanceById(id)) {
+                return;
+            }
 
             const auto eventId = id.toStdString();
             auto& events = scenario->events;
@@ -1195,6 +1198,7 @@ void ScenarioAuthoringWidget::refreshNavigationPanel() {
             }
             events.erase(it, events.end());
             scenario->draft.control.events = scenario->events;
+            recomputeDiffKeysAfterScenarioChanged(*scenario);
             refreshNavigationPanel();
             refreshInspector();
         },
@@ -1205,6 +1209,9 @@ void ScenarioAuthoringWidget::refreshNavigationPanel() {
 
             const auto id = rawId.section('/', 0, 0);
             if (canvas_->editConnectionBlockScheduleById(id)) {
+                return;
+            }
+            if (canvas_->editRouteGuidanceById(id)) {
                 return;
             }
 
@@ -1225,6 +1232,7 @@ void ScenarioAuthoringWidget::refreshNavigationPanel() {
                 return;
             }
             scenario->draft.control.events = scenario->events;
+            recomputeDiffKeysAfterScenarioChanged(*scenario);
             refreshNavigationPanel();
             refreshInspector();
         }));

--- a/src/application/ScenarioAuthoringWidget.cpp
+++ b/src/application/ScenarioAuthoringWidget.cpp
@@ -4,6 +4,9 @@
 #include <utility>
 
 #include <QComboBox>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QFormLayout>
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QInputDialog>
@@ -12,6 +15,7 @@
 #include <QLayoutItem>
 #include <QMessageBox>
 #include <QPainter>
+#include <QPlainTextEdit>
 #include <QPushButton>
 #include <QScrollArea>
 #include <QSizePolicy>
@@ -34,6 +38,58 @@ QLabel* createLabel(const QString& text, QWidget* parent, ui::FontRole role = ui
     label->setFont(ui::font(role));
     label->setWordWrap(true);
     return label;
+}
+
+bool editOperationalEvent(
+    safecrowd::domain::OperationalEventDraft* event,
+    QWidget* parent) {
+    if (event == nullptr) {
+        return false;
+    }
+
+    QDialog dialog(parent);
+    dialog.setWindowTitle("Edit event");
+
+    auto* root = new QVBoxLayout(&dialog);
+    root->setContentsMargins(16, 16, 16, 16);
+    root->setSpacing(12);
+
+    auto* form = new QFormLayout();
+    form->setContentsMargins(0, 0, 0, 0);
+    form->setSpacing(8);
+
+    auto* nameEdit = new QLineEdit(&dialog);
+    nameEdit->setText(QString::fromStdString(event->name));
+    auto* triggerEdit = new QPlainTextEdit(&dialog);
+    triggerEdit->setPlainText(QString::fromStdString(event->triggerSummary));
+    triggerEdit->setMinimumHeight(72);
+    auto* targetEdit = new QPlainTextEdit(&dialog);
+    targetEdit->setPlainText(QString::fromStdString(event->targetSummary));
+    targetEdit->setMinimumHeight(72);
+
+    form->addRow("Name", nameEdit);
+    form->addRow("Trigger", triggerEdit);
+    form->addRow("Target", targetEdit);
+    root->addLayout(form);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
+    QObject::connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    QObject::connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+    root->addWidget(buttons);
+
+    if (dialog.exec() != QDialog::Accepted) {
+        return false;
+    }
+
+    const auto name = nameEdit->text().trimmed();
+    if (name.isEmpty()) {
+        return false;
+    }
+
+    event->name = name.toStdString();
+    event->triggerSummary = triggerEdit->toPlainText().trimmed().toStdString();
+    event->targetSummary = targetEdit->toPlainText().trimmed().toStdString();
+    return true;
 }
 
 QString zoneLabel(const safecrowd::domain::Zone2D& zone) {
@@ -459,6 +515,7 @@ QWidget* createCrowdPanel(
     std::function<void(const QString&)> selectPlacementHandler,
     NavigationTreeState navigationState,
     std::function<void(const QSet<QString>&)> expandedStateChangedHandler,
+    std::function<void(const QString&)> deletePlacementHandler,
     const WorkspaceShell* shell,
     QWidget* parent) {
     return new NavigationTreeWidget(
@@ -469,7 +526,8 @@ QWidget* createCrowdPanel(
         parent,
         shell != nullptr ? shell->createPanelHeader("Crowd", parent, false) : nullptr,
         std::move(navigationState),
-        std::move(expandedStateChangedHandler));
+        std::move(expandedStateChangedHandler),
+        std::move(deletePlacementHandler));
 }
 
 std::vector<NavigationTreeNode> buildEventsTree(
@@ -613,14 +671,21 @@ QWidget* createEventsPanel(
     const safecrowd::domain::FacilityLayout2D& layout,
     const ScenarioAuthoringWidget::ScenarioState* scenario,
     const WorkspaceShell* shell,
-    QWidget* parent) {
+    QWidget* parent,
+    std::function<void(const QString&)> deleteItemHandler,
+    std::function<void(const QString&)> settingsItemHandler) {
     return new NavigationTreeWidget(
         "Events",
         buildEventsTree(layout, scenario),
         "No operational events or blocked exits yet",
         {},
         parent,
-        shell != nullptr ? shell->createPanelHeader("Events", parent, false) : nullptr);
+        shell != nullptr ? shell->createPanelHeader("Events", parent, false) : nullptr,
+        {},
+        {},
+        std::move(deleteItemHandler),
+        std::move(settingsItemHandler),
+        QString("Settings..."));
 }
 
 SavedNavigationView savedNavigationView(ScenarioAuthoringWidget::NavigationView view) {
@@ -1095,11 +1160,74 @@ void ScenarioAuthoringWidget::refreshNavigationPanel() {
             [this](const QSet<QString>& expandedNodeIds) {
                 crowdExpandedNodeIds_ = expandedNodeIds;
             },
+            [this](const QString& crowdElementId) {
+                if (canvas_ != nullptr) {
+                    canvas_->deleteCrowdElementById(crowdElementId);
+                }
+            },
             shell_,
             shell_));
         return;
     }
-    shell_->setNavigationPanel(createEventsPanel(layout_, currentScenario(), shell_, shell_));
+    shell_->setNavigationPanel(createEventsPanel(
+        layout_,
+        currentScenario(),
+        shell_,
+        shell_,
+        [this](const QString& rawId) {
+            auto* scenario = currentScenario();
+            if (scenario == nullptr || rawId.isEmpty()) {
+                return;
+            }
+
+            const auto id = rawId.section('/', 0, 0);
+            if (canvas_ != nullptr && canvas_->deleteConnectionBlockById(id)) {
+                return;
+            }
+
+            const auto eventId = id.toStdString();
+            auto& events = scenario->events;
+            const auto it = std::remove_if(events.begin(), events.end(), [&](const auto& event) {
+                return event.id == eventId;
+            });
+            if (it == events.end()) {
+                return;
+            }
+            events.erase(it, events.end());
+            scenario->draft.control.events = scenario->events;
+            refreshNavigationPanel();
+            refreshInspector();
+        },
+        [this](const QString& rawId) {
+            if (canvas_ == nullptr || rawId.isEmpty()) {
+                return;
+            }
+
+            const auto id = rawId.section('/', 0, 0);
+            if (canvas_->editConnectionBlockScheduleById(id)) {
+                return;
+            }
+
+            auto* scenario = currentScenario();
+            if (scenario == nullptr) {
+                return;
+            }
+
+            const auto eventId = id.toStdString();
+            auto& events = scenario->events;
+            const auto it = std::find_if(events.begin(), events.end(), [&](auto& event) {
+                return event.id == eventId;
+            });
+            if (it == events.end()) {
+                return;
+            }
+            if (!editOperationalEvent(&(*it), this)) {
+                return;
+            }
+            scenario->draft.control.events = scenario->events;
+            refreshNavigationPanel();
+            refreshInspector();
+        }));
 }
 
 void ScenarioAuthoringWidget::refreshRightPanel() {

--- a/src/application/ScenarioCanvasWidget.cpp
+++ b/src/application/ScenarioCanvasWidget.cpp
@@ -1370,6 +1370,39 @@ bool ScenarioCanvasWidget::editConnectionBlockScheduleById(const QString& blockI
     return true;
 }
 
+bool ScenarioCanvasWidget::deleteRouteGuidanceById(const QString& guidanceId) {
+    auto it = std::find_if(routeGuidances_.begin(), routeGuidances_.end(), [&](const auto& guidance) {
+        return QString::fromStdString(guidance.id) == guidanceId;
+    });
+    if (it == routeGuidances_.end()) {
+        return false;
+    }
+
+    routeGuidances_.erase(it);
+    emitRouteGuidancesChanged();
+    update();
+    return true;
+}
+
+bool ScenarioCanvasWidget::editRouteGuidanceById(const QString& guidanceId) {
+    auto it = std::find_if(routeGuidances_.begin(), routeGuidances_.end(), [&](const auto& guidance) {
+        return QString::fromStdString(guidance.id) == guidanceId;
+    });
+    if (it == routeGuidances_.end()) {
+        return false;
+    }
+
+    RouteGuidanceSettingsDialog dialog(*it, this);
+    if (dialog.exec() != QDialog::Accepted) {
+        return false;
+    }
+
+    *it = dialog.guidance();
+    emitRouteGuidancesChanged();
+    update();
+    return true;
+}
+
 bool ScenarioCanvasWidget::eventFilter(QObject* watched, QEvent* event) {
     (void)watched;
     camera_.handleGlobalKeyEvent(event);
@@ -2667,9 +2700,7 @@ void ScenarioCanvasWidget::openRouteGuidanceEditor(const QString& guidanceId, co
     }
 
     if (selected == deleteAction) {
-        routeGuidances_.erase(it);
-        emitRouteGuidancesChanged();
-        update();
+        deleteRouteGuidanceById(guidanceId);
         return;
     }
 

--- a/src/application/ScenarioCanvasWidget.cpp
+++ b/src/application/ScenarioCanvasWidget.cpp
@@ -1333,6 +1333,43 @@ void ScenarioCanvasWidget::focusPlacement(const QString& placementId) {
     update();
 }
 
+bool ScenarioCanvasWidget::deleteCrowdElementById(const QString& crowdElementId) {
+    return deleteCrowdElement(crowdElementId);
+}
+
+bool ScenarioCanvasWidget::deleteConnectionBlockById(const QString& blockId) {
+    auto it = std::find_if(connectionBlocks_.begin(), connectionBlocks_.end(), [&](const auto& block) {
+        return QString::fromStdString(block.id) == blockId;
+    });
+    if (it == connectionBlocks_.end()) {
+        return false;
+    }
+
+    connectionBlocks_.erase(it);
+    emitConnectionBlocksChanged();
+    update();
+    return true;
+}
+
+bool ScenarioCanvasWidget::editConnectionBlockScheduleById(const QString& blockId) {
+    auto it = std::find_if(connectionBlocks_.begin(), connectionBlocks_.end(), [&](const auto& block) {
+        return QString::fromStdString(block.id) == blockId;
+    });
+    if (it == connectionBlocks_.end()) {
+        return false;
+    }
+
+    ConnectionBlockScheduleDialog dialog(it->intervals, this);
+    if (dialog.exec() != QDialog::Accepted) {
+        return false;
+    }
+
+    it->intervals = dialog.intervals();
+    emitConnectionBlocksChanged();
+    update();
+    return true;
+}
+
 bool ScenarioCanvasWidget::eventFilter(QObject* watched, QEvent* event) {
     (void)watched;
     camera_.handleGlobalKeyEvent(event);

--- a/src/application/ScenarioCanvasWidget.h
+++ b/src/application/ScenarioCanvasWidget.h
@@ -67,6 +67,8 @@ public:
     bool deleteCrowdElementById(const QString& crowdElementId);
     bool deleteConnectionBlockById(const QString& blockId);
     bool editConnectionBlockScheduleById(const QString& blockId);
+    bool deleteRouteGuidanceById(const QString& guidanceId);
+    bool editRouteGuidanceById(const QString& guidanceId);
 
 protected:
     bool eventFilter(QObject* watched, QEvent* event) override;

--- a/src/application/ScenarioCanvasWidget.h
+++ b/src/application/ScenarioCanvasWidget.h
@@ -64,6 +64,9 @@ public:
     void focusLayoutElement(const QString& elementId);
     void activateLayoutElement(const QString& elementId);
     void focusPlacement(const QString& placementId);
+    bool deleteCrowdElementById(const QString& crowdElementId);
+    bool deleteConnectionBlockById(const QString& blockId);
+    bool editConnectionBlockScheduleById(const QString& blockId);
 
 protected:
     bool eventFilter(QObject* watched, QEvent* event) override;


### PR DESCRIPTION
## Summary

- Adds right-click context menus to left navigation trees (Layout/Crowd/Events) to allow Delete, plus Settings where applicable.
- Fixes a crash caused by parenting a stack-allocated `QMenu` to the tree while the navigation panel is being replaced.

## Related Issue

- None (application-only PR)

## Area

- [ ] Engine
- [ ] Domain
- [x] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [x] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug`
- [x] `ctest --preset test-debug`
- [ ] Not run (reason below)

## Risks / Follow-up

- Operational event Settings currently edits the name/trigger/target summaries via a simple dialog; future work may replace this with a richer inspector UI.
