### PR TITLE
[Application] Improve project save/load result persistence

### DIFF
--- a/src/application/MainWindow.cpp
+++ b/src/application/MainWindow.cpp
@@ -81,6 +81,7 @@ ProjectWorkspaceState makeEvacuationScenarioDemoWorkspace() {
         .frame = std::move(fixture.frame),
         .risk = std::move(fixture.risk),
         .artifacts = std::move(fixture.artifacts),
+        .navigationView = SavedResultNavigationView::Bottleneck,
     };
     workspace.batchResult = SavedScenarioBatchResultState{
         .results = {*workspace.result},
@@ -454,6 +455,7 @@ void MainWindow::openProject(const ProjectMetadata& metadata) {
                 workspace.result->frame,
                 workspace.result->risk,
                 workspace.result->artifacts,
+                workspace.result->navigationView,
                 workspace.authoring.has_value()
                     ? std::make_optional(initialStateFromSaved(*workspace.authoring, *importResult.layout))
                     : std::nullopt);
@@ -500,16 +502,55 @@ void MainWindow::saveCurrentProject() {
         }
     }
 
-    if (auto* authoringWidget = visibleChild<ScenarioAuthoringWidget>(centralWidget())) {
+    auto* authoringWidget = visibleChild<ScenarioAuthoringWidget>(centralWidget());
+    auto* batchResultWidget = visibleChild<ScenarioBatchResultWidget>(centralWidget());
+    auto* resultWidget = visibleChild<ScenarioResultWidget>(centralWidget());
+    auto* runWidget = visibleChild<ScenarioRunWidget>(centralWidget());
+
+    const auto rootWidget = centralWidget();
+    const auto widgetDepth = [rootWidget](QWidget* widget) {
+        int depth = 0;
+        for (auto* current = widget; current != nullptr; current = current->parentWidget()) {
+            if (current == rootWidget) {
+                return depth;
+            }
+            ++depth;
+        }
+        return -1;
+    };
+
+    QWidget* activeWorkflowWidget = nullptr;
+    int activeWorkflowDepth = -1;
+    const auto chooseActiveWorkflowWidget = [&](QWidget* widget) {
+        const int depth = widgetDepth(widget);
+        if (depth > activeWorkflowDepth) {
+            activeWorkflowDepth = depth;
+            activeWorkflowWidget = widget;
+        }
+    };
+    chooseActiveWorkflowWidget(authoringWidget);
+    chooseActiveWorkflowWidget(batchResultWidget);
+    chooseActiveWorkflowWidget(resultWidget);
+    chooseActiveWorkflowWidget(runWidget);
+
+    if (activeWorkflowWidget == authoringWidget) {
         workspace.activeView = ProjectWorkspaceView::ScenarioAuthoring;
         workspace.authoring = authoringWidget->currentSavedState();
-    } else if (auto* batchResultWidget = visibleChild<ScenarioBatchResultWidget>(centralWidget())) {
+    } else if (activeWorkflowWidget == batchResultWidget) {
         workspace.activeView = ProjectWorkspaceView::ScenarioResult;
         if (auto authoring = batchResultWidget->returnAuthoringState(); authoring.has_value()) {
             workspace.authoring = savedStateFromInitial(*authoring);
         }
+        auto results = batchResultWidget->results();
+        if (!results.empty()) {
+            const auto index = std::clamp(
+                batchResultWidget->currentResultIndex(),
+                0,
+                static_cast<int>(results.size()) - 1);
+            results[static_cast<std::size_t>(index)].navigationView = batchResultWidget->currentSavedNavigationView();
+        }
         workspace.batchResult = SavedScenarioBatchResultState{
-            .results = batchResultWidget->results(),
+            .results = std::move(results),
             .currentResultIndex = batchResultWidget->currentResultIndex(),
         };
         if (!workspace.batchResult->results.empty()) {
@@ -519,7 +560,7 @@ void MainWindow::saveCurrentProject() {
                 static_cast<int>(workspace.batchResult->results.size()) - 1);
             workspace.result = workspace.batchResult->results[static_cast<std::size_t>(index)];
         }
-    } else if (auto* resultWidget = visibleChild<ScenarioResultWidget>(centralWidget())) {
+    } else if (activeWorkflowWidget == resultWidget) {
         workspace.activeView = ProjectWorkspaceView::ScenarioResult;
         if (resultWidget->returnAuthoringState().has_value()) {
             workspace.authoring = savedStateFromInitial(*resultWidget->returnAuthoringState());
@@ -529,8 +570,9 @@ void MainWindow::saveCurrentProject() {
             .frame = resultWidget->frame(),
             .risk = resultWidget->risk(),
             .artifacts = resultWidget->artifacts(),
+            .navigationView = resultWidget->currentSavedNavigationView(),
         };
-    } else if (auto* runWidget = visibleChild<ScenarioRunWidget>(centralWidget())) {
+    } else if (activeWorkflowWidget == runWidget) {
         if (runWidget->returnAuthoringState().has_value()) {
             workspace.authoring = savedStateFromInitial(*runWidget->returnAuthoringState());
         }
@@ -732,6 +774,7 @@ void MainWindow::showScenarioResult(
     const safecrowd::domain::SimulationFrame& frame,
     const safecrowd::domain::ScenarioRiskSnapshot& risk,
     const safecrowd::domain::ScenarioResultArtifacts& artifacts,
+    SavedResultNavigationView savedNavigationView,
     std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState) {
     setCentralWidget(new ScenarioResultWidget(
         currentProject_.name,
@@ -755,6 +798,7 @@ void MainWindow::showScenarioResult(
                 showLayoutReview(currentProject_);
             }
         },
+        savedNavigationView,
         std::move(returnAuthoringState),
         this));
 }

--- a/src/application/MainWindow.h
+++ b/src/application/MainWindow.h
@@ -58,6 +58,7 @@ private:
         const safecrowd::domain::SimulationFrame& frame,
         const safecrowd::domain::ScenarioRiskSnapshot& risk,
         const safecrowd::domain::ScenarioResultArtifacts& artifacts,
+        SavedResultNavigationView savedNavigationView = SavedResultNavigationView::Bottleneck,
         std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState = std::nullopt);
 
     safecrowd::domain::SafeCrowdDomain& domain_;

--- a/src/application/ProjectPersistence.cpp
+++ b/src/application/ProjectPersistence.cpp
@@ -1076,6 +1076,157 @@ safecrowd::domain::ScenarioRiskSnapshot riskSnapshotFromJson(const QJsonObject& 
     return risk;
 }
 
+QJsonObject densityCellMetricToJson(const safecrowd::domain::DensityCellMetric& cell) {
+    QJsonObject object;
+    object["center"] = pointArray(cell.center);
+    object["cellMin"] = pointArray(cell.cellMin);
+    object["cellMax"] = pointArray(cell.cellMax);
+    object["floorId"] = QString::fromStdString(cell.floorId);
+    object["agentCount"] = static_cast<qint64>(cell.agentCount);
+    object["densityPeoplePerSquareMeter"] = cell.densityPeoplePerSquareMeter;
+    return object;
+}
+
+safecrowd::domain::DensityCellMetric densityCellMetricFromJson(const QJsonObject& object) {
+    return {
+        .center = pointFromJson(object.value("center")),
+        .cellMin = pointFromJson(object.value("cellMin")),
+        .cellMax = pointFromJson(object.value("cellMax")),
+        .floorId = object.value("floorId").toString().toStdString(),
+        .agentCount = static_cast<std::size_t>(object.value("agentCount").toInteger()),
+        .densityPeoplePerSquareMeter = object.value("densityPeoplePerSquareMeter").toDouble(),
+    };
+}
+
+QJsonObject densityFieldSnapshotToJson(const safecrowd::domain::DensityFieldSnapshot& snapshot) {
+    QJsonObject object;
+    object["timeSeconds"] = snapshot.timeSeconds;
+    object["cellSizeMeters"] = snapshot.cellSizeMeters;
+    QJsonArray cells;
+    for (const auto& cell : snapshot.cells) {
+        cells.append(densityCellMetricToJson(cell));
+    }
+    object["cells"] = cells;
+    return object;
+}
+
+safecrowd::domain::DensityFieldSnapshot densityFieldSnapshotFromJson(const QJsonObject& object) {
+    safecrowd::domain::DensityFieldSnapshot snapshot;
+    snapshot.timeSeconds = object.value("timeSeconds").toDouble();
+    snapshot.cellSizeMeters = object.value("cellSizeMeters").toDouble();
+    for (const auto& value : object.value("cells").toArray()) {
+        snapshot.cells.push_back(densityCellMetricFromJson(value.toObject()));
+    }
+    return snapshot;
+}
+
+QJsonObject densitySummaryToJson(const safecrowd::domain::DensitySummary& summary) {
+    QJsonObject object;
+    object["cellSizeMeters"] = summary.cellSizeMeters;
+    object["highDensityThresholdPeoplePerSquareMeter"] = summary.highDensityThresholdPeoplePerSquareMeter;
+    object["peakDensityPeoplePerSquareMeter"] = summary.peakDensityPeoplePerSquareMeter;
+    object["peakAgentCount"] = static_cast<qint64>(summary.peakAgentCount);
+    object["peakAtSeconds"] = optionalDoubleToJson(summary.peakAtSeconds);
+    if (summary.peakCell.has_value()) {
+        object["peakCell"] = densityCellMetricToJson(*summary.peakCell);
+    }
+    object["highDensityDurationSeconds"] = summary.highDensityDurationSeconds;
+    QJsonArray peakCells;
+    for (const auto& cell : summary.peakCells) {
+        peakCells.append(densityCellMetricToJson(cell));
+    }
+    object["peakCells"] = peakCells;
+    object["peakField"] = densityFieldSnapshotToJson(summary.peakField);
+    return object;
+}
+
+safecrowd::domain::DensitySummary densitySummaryFromJson(const QJsonObject& object) {
+    safecrowd::domain::DensitySummary summary;
+    summary.cellSizeMeters = object.value("cellSizeMeters").toDouble();
+    summary.highDensityThresholdPeoplePerSquareMeter =
+        object.value("highDensityThresholdPeoplePerSquareMeter").toDouble(4.0);
+    summary.peakDensityPeoplePerSquareMeter = object.value("peakDensityPeoplePerSquareMeter").toDouble();
+    summary.peakAgentCount = static_cast<std::size_t>(object.value("peakAgentCount").toInteger());
+    summary.peakAtSeconds = optionalDoubleFromJson(object.value("peakAtSeconds"));
+    if (object.value("peakCell").isObject()) {
+        summary.peakCell = densityCellMetricFromJson(object.value("peakCell").toObject());
+    }
+    summary.highDensityDurationSeconds = object.value("highDensityDurationSeconds").toDouble();
+    for (const auto& value : object.value("peakCells").toArray()) {
+        summary.peakCells.push_back(densityCellMetricFromJson(value.toObject()));
+    }
+    if (object.value("peakField").isObject()) {
+        summary.peakField = densityFieldSnapshotFromJson(object.value("peakField").toObject());
+    }
+    return summary;
+}
+
+QJsonObject exitUsageMetricToJson(const safecrowd::domain::ExitUsageMetric& exit) {
+    QJsonObject object;
+    object["exitZoneId"] = QString::fromStdString(exit.exitZoneId);
+    object["exitLabel"] = QString::fromStdString(exit.exitLabel);
+    object["floorId"] = QString::fromStdString(exit.floorId);
+    object["evacuatedCount"] = static_cast<qint64>(exit.evacuatedCount);
+    object["usageRatio"] = exit.usageRatio;
+    object["lastExitTimeSeconds"] = optionalDoubleToJson(exit.lastExitTimeSeconds);
+    return object;
+}
+
+safecrowd::domain::ExitUsageMetric exitUsageMetricFromJson(const QJsonObject& object) {
+    safecrowd::domain::ExitUsageMetric exit;
+    exit.exitZoneId = object.value("exitZoneId").toString().toStdString();
+    exit.exitLabel = object.value("exitLabel").toString().toStdString();
+    exit.floorId = object.value("floorId").toString().toStdString();
+    exit.evacuatedCount = static_cast<std::size_t>(object.value("evacuatedCount").toInteger());
+    exit.usageRatio = object.value("usageRatio").toDouble();
+    exit.lastExitTimeSeconds = optionalDoubleFromJson(object.value("lastExitTimeSeconds"));
+    return exit;
+}
+
+QJsonObject zoneCompletionMetricToJson(const safecrowd::domain::ZoneCompletionMetric& zone) {
+    QJsonObject object;
+    object["zoneId"] = QString::fromStdString(zone.zoneId);
+    object["zoneLabel"] = QString::fromStdString(zone.zoneLabel);
+    object["floorId"] = QString::fromStdString(zone.floorId);
+    object["initialCount"] = static_cast<qint64>(zone.initialCount);
+    object["evacuatedCount"] = static_cast<qint64>(zone.evacuatedCount);
+    object["lastCompletionTimeSeconds"] = optionalDoubleToJson(zone.lastCompletionTimeSeconds);
+    return object;
+}
+
+safecrowd::domain::ZoneCompletionMetric zoneCompletionMetricFromJson(const QJsonObject& object) {
+    safecrowd::domain::ZoneCompletionMetric zone;
+    zone.zoneId = object.value("zoneId").toString().toStdString();
+    zone.zoneLabel = object.value("zoneLabel").toString().toStdString();
+    zone.floorId = object.value("floorId").toString().toStdString();
+    zone.initialCount = static_cast<std::size_t>(object.value("initialCount").toInteger());
+    zone.evacuatedCount = static_cast<std::size_t>(object.value("evacuatedCount").toInteger());
+    zone.lastCompletionTimeSeconds = optionalDoubleFromJson(object.value("lastCompletionTimeSeconds"));
+    return zone;
+}
+
+QJsonObject placementCompletionMetricToJson(const safecrowd::domain::PlacementCompletionMetric& placement) {
+    QJsonObject object;
+    object["placementId"] = QString::fromStdString(placement.placementId);
+    object["zoneId"] = QString::fromStdString(placement.zoneId);
+    object["floorId"] = QString::fromStdString(placement.floorId);
+    object["initialCount"] = static_cast<qint64>(placement.initialCount);
+    object["evacuatedCount"] = static_cast<qint64>(placement.evacuatedCount);
+    object["lastCompletionTimeSeconds"] = optionalDoubleToJson(placement.lastCompletionTimeSeconds);
+    return object;
+}
+
+safecrowd::domain::PlacementCompletionMetric placementCompletionMetricFromJson(const QJsonObject& object) {
+    safecrowd::domain::PlacementCompletionMetric placement;
+    placement.placementId = object.value("placementId").toString().toStdString();
+    placement.zoneId = object.value("zoneId").toString().toStdString();
+    placement.floorId = object.value("floorId").toString().toStdString();
+    placement.initialCount = static_cast<std::size_t>(object.value("initialCount").toInteger());
+    placement.evacuatedCount = static_cast<std::size_t>(object.value("evacuatedCount").toInteger());
+    placement.lastCompletionTimeSeconds = optionalDoubleFromJson(object.value("lastCompletionTimeSeconds"));
+    return placement;
+}
+
 QJsonObject resultArtifactsToJson(const safecrowd::domain::ScenarioResultArtifacts& artifacts) {
     QJsonObject object;
     QJsonArray progress;
@@ -1100,6 +1251,8 @@ QJsonObject resultArtifactsToJson(const safecrowd::domain::ScenarioResultArtifac
     timing["t90Seconds"] = optionalDoubleToJson(artifacts.timingSummary.t90Seconds);
     timing["t95Seconds"] = optionalDoubleToJson(artifacts.timingSummary.t95Seconds);
     timing["finalEvacuationTimeSeconds"] = optionalDoubleToJson(artifacts.timingSummary.finalEvacuationTimeSeconds);
+    timing["targetTimeSeconds"] = artifacts.timingSummary.targetTimeSeconds;
+    timing["marginSeconds"] = optionalDoubleToJson(artifacts.timingSummary.marginSeconds);
     if (artifacts.timingSummary.t90Frame.has_value()) {
         timing["t90Frame"] = simulationFrameToJson(*artifacts.timingSummary.t90Frame);
     }
@@ -1107,6 +1260,27 @@ QJsonObject resultArtifactsToJson(const safecrowd::domain::ScenarioResultArtifac
         timing["t95Frame"] = simulationFrameToJson(*artifacts.timingSummary.t95Frame);
     }
     object["timingSummary"] = timing;
+
+    object["densitySummary"] = densitySummaryToJson(artifacts.densitySummary);
+
+    QJsonArray exitUsage;
+    for (const auto& exit : artifacts.exitUsage) {
+        exitUsage.append(exitUsageMetricToJson(exit));
+    }
+    object["exitUsage"] = exitUsage;
+
+    QJsonArray zoneCompletion;
+    for (const auto& zone : artifacts.zoneCompletion) {
+        zoneCompletion.append(zoneCompletionMetricToJson(zone));
+    }
+    object["zoneCompletion"] = zoneCompletion;
+
+    QJsonArray placementCompletion;
+    for (const auto& placement : artifacts.placementCompletion) {
+        placementCompletion.append(placementCompletionMetricToJson(placement));
+    }
+    object["placementCompletion"] = placementCompletion;
+
     return object;
 }
 
@@ -1130,12 +1304,28 @@ safecrowd::domain::ScenarioResultArtifacts resultArtifactsFromJson(const QJsonOb
     artifacts.timingSummary.t90Seconds = optionalDoubleFromJson(timing.value("t90Seconds"));
     artifacts.timingSummary.t95Seconds = optionalDoubleFromJson(timing.value("t95Seconds"));
     artifacts.timingSummary.finalEvacuationTimeSeconds = optionalDoubleFromJson(timing.value("finalEvacuationTimeSeconds"));
+    artifacts.timingSummary.targetTimeSeconds = timing.value("targetTimeSeconds").toDouble();
+    artifacts.timingSummary.marginSeconds = optionalDoubleFromJson(timing.value("marginSeconds"));
     if (timing.value("t90Frame").isObject()) {
         artifacts.timingSummary.t90Frame = simulationFrameFromJson(timing.value("t90Frame").toObject());
     }
     if (timing.value("t95Frame").isObject()) {
         artifacts.timingSummary.t95Frame = simulationFrameFromJson(timing.value("t95Frame").toObject());
     }
+
+    if (object.value("densitySummary").isObject()) {
+        artifacts.densitySummary = densitySummaryFromJson(object.value("densitySummary").toObject());
+    }
+    for (const auto& value : object.value("exitUsage").toArray()) {
+        artifacts.exitUsage.push_back(exitUsageMetricFromJson(value.toObject()));
+    }
+    for (const auto& value : object.value("zoneCompletion").toArray()) {
+        artifacts.zoneCompletion.push_back(zoneCompletionMetricFromJson(value.toObject()));
+    }
+    for (const auto& value : object.value("placementCompletion").toArray()) {
+        artifacts.placementCompletion.push_back(placementCompletionMetricFromJson(value.toObject()));
+    }
+
     return artifacts;
 }
 
@@ -1185,6 +1375,7 @@ QJsonObject resultStateToJson(const SavedScenarioResultState& result) {
     object["frame"] = simulationFrameToJson(result.frame);
     object["risk"] = riskSnapshotToJson(result.risk);
     object["artifacts"] = resultArtifactsToJson(result.artifacts);
+    object["navigationView"] = static_cast<int>(result.navigationView);
     return object;
 }
 
@@ -1194,6 +1385,7 @@ SavedScenarioResultState resultStateFromJson(const QJsonObject& object) {
         .frame = simulationFrameFromJson(object.value("frame").toObject()),
         .risk = riskSnapshotFromJson(object.value("risk").toObject()),
         .artifacts = resultArtifactsFromJson(object.value("artifacts").toObject()),
+        .navigationView = static_cast<SavedResultNavigationView>(object.value("navigationView").toInt()),
     };
 }
 

--- a/src/application/ProjectWorkspaceState.h
+++ b/src/application/ProjectWorkspaceState.h
@@ -30,6 +30,13 @@ enum class SavedRightPanelMode {
     Run,
 };
 
+enum class SavedResultNavigationView {
+    Bottleneck,
+    Hotspot,
+    Zone,
+    Groups,
+};
+
 struct SavedScenarioState {
     safecrowd::domain::ScenarioDraft draft{};
     std::string baseScenarioId{};
@@ -48,6 +55,7 @@ struct SavedScenarioResultState {
     safecrowd::domain::SimulationFrame frame{};
     safecrowd::domain::ScenarioRiskSnapshot risk{};
     safecrowd::domain::ScenarioResultArtifacts artifacts{};
+    SavedResultNavigationView navigationView{SavedResultNavigationView::Bottleneck};
 };
 
 struct SavedScenarioBatchResultState {

--- a/src/application/ScenarioAuthoringWidget.cpp
+++ b/src/application/ScenarioAuthoringWidget.cpp
@@ -741,7 +741,6 @@ ScenarioAuthoringWidget::ScenarioAuthoringWidget(
             scenario.stagedForRun = false;
         }
     }
-    rightPanelMode_ = RightPanelMode::Scenario;
     initializeUi(false);
 }
 
@@ -772,7 +771,18 @@ SavedScenarioAuthoringState ScenarioAuthoringWidget::currentSavedState() const {
     SavedScenarioAuthoringState state;
     state.currentScenarioIndex = currentScenarioIndex_;
     state.navigationView = savedNavigationView(navigationView_);
-    state.rightPanelMode = SavedRightPanelMode::Scenario;
+    switch (rightPanelMode_) {
+    case RightPanelMode::None:
+        state.rightPanelMode = SavedRightPanelMode::None;
+        break;
+    case RightPanelMode::Run:
+        state.rightPanelMode = SavedRightPanelMode::Run;
+        break;
+    case RightPanelMode::Scenario:
+    default:
+        state.rightPanelMode = SavedRightPanelMode::Scenario;
+        break;
+    }
     state.scenarios.reserve(scenarios_.size());
     for (const auto& scenario : scenarios_) {
         auto draft = scenario.draft;
@@ -1251,9 +1261,18 @@ void ScenarioAuthoringWidget::refreshRightPanel() {
         return;
     }
 
-    rightPanelMode_ = RightPanelMode::Scenario;
+    if (rightPanelMode_ == RightPanelMode::None) {
+        shell_->setReviewPanelVisible(false);
+        return;
+    }
+
     shell_->setReviewPanelVisible(true);
-    shell_->setReviewPanel(createScenarioPanel());
+    if (rightPanelMode_ == RightPanelMode::Run) {
+        shell_->setReviewPanel(createRunPanel());
+    } else {
+        rightPanelMode_ = RightPanelMode::Scenario;
+        shell_->setReviewPanel(createScenarioPanel());
+    }
     refreshScenarioSwitcher();
     refreshInspector();
 }
@@ -1434,6 +1453,40 @@ void ScenarioAuthoringWidget::showScenarioNameDialog(int sourceIndex) {
     }
 
     createScenarioWithName(name, sourceIndex);
+}
+
+QWidget* ScenarioAuthoringWidget::createRunPanel() {
+    auto* panel = new QWidget(shell_);
+    auto* layout = new QVBoxLayout(panel);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(12);
+    layout->addWidget(createLabel("Run", panel, ui::FontRole::Title));
+
+    stagedScenariosLabel_ = createLabel("", panel);
+    stagedScenariosLabel_->setStyleSheet(ui::mutedTextStyleSheet());
+    layout->addWidget(stagedScenariosLabel_);
+
+    executeRunButton_ = new QPushButton("Run Staged Scenarios", panel);
+    executeRunButton_->setFont(ui::font(ui::FontRole::Body));
+    executeRunButton_->setStyleSheet(ui::primaryButtonStyleSheet());
+    executeRunButton_->setEnabled(false);
+    layout->addWidget(executeRunButton_);
+
+    auto* editButton = new QPushButton("Edit Scenario", panel);
+    editButton->setFont(ui::font(ui::FontRole::Body));
+    editButton->setStyleSheet(ui::secondaryButtonStyleSheet());
+    layout->addWidget(editButton);
+    layout->addStretch(1);
+
+    connect(executeRunButton_, &QPushButton::clicked, this, [this]() {
+        runStagedScenarios();
+    });
+    connect(editButton, &QPushButton::clicked, this, [this]() {
+        rightPanelMode_ = RightPanelMode::Scenario;
+        refreshRightPanel();
+    });
+
+    return panel;
 }
 
 QWidget* ScenarioAuthoringWidget::createScenarioPanel() {

--- a/src/application/ScenarioAuthoringWidget.h
+++ b/src/application/ScenarioAuthoringWidget.h
@@ -90,6 +90,7 @@ private:
     void updateCurrentScenarioPlacements(const std::vector<ScenarioCrowdPlacement>& placements);
     void showEmptyCanvas();
     void showScenarioNameDialog(int sourceIndex);
+    QWidget* createRunPanel();
     QWidget* createScenarioPanel();
     ScenarioState* currentScenario();
     const ScenarioState* currentScenario() const;

--- a/src/application/ScenarioBatchResultWidget.cpp
+++ b/src/application/ScenarioBatchResultWidget.cpp
@@ -546,6 +546,34 @@ ScenarioAuthoringWidget::ScenarioState scenarioStateFromDraft(
     return state;
 }
 
+ScenarioResultNavigationView resultNavigationViewFromSaved(SavedResultNavigationView view) {
+    switch (view) {
+    case SavedResultNavigationView::Hotspot:
+        return ScenarioResultNavigationView::Hotspot;
+    case SavedResultNavigationView::Zone:
+        return ScenarioResultNavigationView::Zone;
+    case SavedResultNavigationView::Groups:
+        return ScenarioResultNavigationView::Groups;
+    case SavedResultNavigationView::Bottleneck:
+    default:
+        return ScenarioResultNavigationView::Bottleneck;
+    }
+}
+
+SavedResultNavigationView savedResultNavigationView(ScenarioResultNavigationView view) {
+    switch (view) {
+    case ScenarioResultNavigationView::Hotspot:
+        return SavedResultNavigationView::Hotspot;
+    case ScenarioResultNavigationView::Zone:
+        return SavedResultNavigationView::Zone;
+    case ScenarioResultNavigationView::Groups:
+        return SavedResultNavigationView::Groups;
+    case ScenarioResultNavigationView::Bottleneck:
+    default:
+        return SavedResultNavigationView::Bottleneck;
+    }
+}
+
 }  // namespace
 
 ScenarioBatchResultWidget::ScenarioBatchResultWidget(
@@ -569,6 +597,9 @@ ScenarioBatchResultWidget::ScenarioBatchResultWidget(
       currentResultIndex_(currentResultIndex) {
     if (currentResultIndex_ < 0 || currentResultIndex_ >= static_cast<int>(results_.size())) {
         currentResultIndex_ = 0;
+    }
+    if (!results_.empty()) {
+        resultNavigationView_ = resultNavigationViewFromSaved(results_[static_cast<std::size_t>(currentResultIndex_)].navigationView);
     }
     const auto baselineIndex = baselineResultIndex();
     if (results_.size() <= 2) {
@@ -620,6 +651,10 @@ const std::vector<SavedScenarioResultState>& ScenarioBatchResultWidget::results(
 
 int ScenarioBatchResultWidget::currentResultIndex() const noexcept {
     return currentResultIndex_;
+}
+
+SavedResultNavigationView ScenarioBatchResultWidget::currentSavedNavigationView() const noexcept {
+    return savedResultNavigationView(resultNavigationView_);
 }
 
 std::optional<ScenarioAuthoringWidget::InitialState> ScenarioBatchResultWidget::returnAuthoringState() const {

--- a/src/application/ScenarioBatchResultWidget.h
+++ b/src/application/ScenarioBatchResultWidget.h
@@ -40,6 +40,7 @@ public:
 
     const std::vector<SavedScenarioResultState>& results() const noexcept;
     int currentResultIndex() const noexcept;
+    SavedResultNavigationView currentSavedNavigationView() const noexcept;
     std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState() const;
 
 private:

--- a/src/application/ScenarioResultWidget.cpp
+++ b/src/application/ScenarioResultWidget.cpp
@@ -971,6 +971,34 @@ QWidget* createResultPanel(
     return panel;
 }
 
+ScenarioResultNavigationView resultNavigationViewFromSaved(SavedResultNavigationView view) {
+    switch (view) {
+    case SavedResultNavigationView::Hotspot:
+        return ScenarioResultNavigationView::Hotspot;
+    case SavedResultNavigationView::Zone:
+        return ScenarioResultNavigationView::Zone;
+    case SavedResultNavigationView::Groups:
+        return ScenarioResultNavigationView::Groups;
+    case SavedResultNavigationView::Bottleneck:
+    default:
+        return ScenarioResultNavigationView::Bottleneck;
+    }
+}
+
+SavedResultNavigationView savedResultNavigationView(ScenarioResultNavigationView view) {
+    switch (view) {
+    case ScenarioResultNavigationView::Hotspot:
+        return SavedResultNavigationView::Hotspot;
+    case ScenarioResultNavigationView::Zone:
+        return SavedResultNavigationView::Zone;
+    case ScenarioResultNavigationView::Groups:
+        return SavedResultNavigationView::Groups;
+    case ScenarioResultNavigationView::Bottleneck:
+    default:
+        return SavedResultNavigationView::Bottleneck;
+    }
+}
+
 }  // namespace
 
 ScenarioResultWidget::ScenarioResultWidget(
@@ -983,6 +1011,7 @@ ScenarioResultWidget::ScenarioResultWidget(
     std::function<void()> saveProjectHandler,
     std::function<void()> openProjectHandler,
     std::function<void()> backToLayoutReviewHandler,
+    SavedResultNavigationView savedNavigationView,
     std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState,
     QWidget* parent)
     : QWidget(parent),
@@ -996,6 +1025,8 @@ ScenarioResultWidget::ScenarioResultWidget(
       saveProjectHandler_(std::move(saveProjectHandler)),
       openProjectHandler_(std::move(openProjectHandler)),
       backToLayoutReviewHandler_(std::move(backToLayoutReviewHandler)) {
+    resultNavigationView_ = resultNavigationViewFromSaved(savedNavigationView);
+
     auto* rootLayout = new QVBoxLayout(this);
     rootLayout->setContentsMargins(0, 0, 0, 0);
     rootLayout->setSpacing(0);
@@ -1097,6 +1128,10 @@ const safecrowd::domain::ScenarioRiskSnapshot& ScenarioResultWidget::risk() cons
 
 const safecrowd::domain::ScenarioResultArtifacts& ScenarioResultWidget::artifacts() const noexcept {
     return artifacts_;
+}
+
+SavedResultNavigationView ScenarioResultWidget::currentSavedNavigationView() const noexcept {
+    return savedResultNavigationView(resultNavigationView_);
 }
 
 const std::optional<ScenarioAuthoringWidget::InitialState>& ScenarioResultWidget::returnAuthoringState() const noexcept {

--- a/src/application/ScenarioResultWidget.h
+++ b/src/application/ScenarioResultWidget.h
@@ -31,6 +31,7 @@ public:
         std::function<void()> saveProjectHandler,
         std::function<void()> openProjectHandler,
         std::function<void()> backToLayoutReviewHandler,
+        SavedResultNavigationView savedNavigationView = SavedResultNavigationView::Bottleneck,
         std::optional<ScenarioAuthoringWidget::InitialState> returnAuthoringState = std::nullopt,
         QWidget* parent = nullptr);
 
@@ -38,6 +39,7 @@ public:
     const safecrowd::domain::SimulationFrame& frame() const noexcept;
     const safecrowd::domain::ScenarioRiskSnapshot& risk() const noexcept;
     const safecrowd::domain::ScenarioResultArtifacts& artifacts() const noexcept;
+    SavedResultNavigationView currentSavedNavigationView() const noexcept;
     const std::optional<ScenarioAuthoringWidget::InitialState>& returnAuthoringState() const noexcept;
 
 private:

--- a/src/application/ScenarioRunWidget.cpp
+++ b/src/application/ScenarioRunWidget.cpp
@@ -796,6 +796,7 @@ void ScenarioRunWidget::showResults() {
                 }
             },
             backToLayoutReviewHandler_,
+            SavedResultNavigationView::Bottleneck,
             returnAuthoringState_,
             this);
     } else {


### PR DESCRIPTION
## Summary

- 프로젝트 저장 시 결과 화면의 분석 아티팩트(`timingSummary` 추가 필드, `densitySummary`, `exitUsage`, `zoneCompletion`, `placementCompletion`)를 함께 저장/복원하도록 확장했습니다.
- 결과 화면에서 저장한 경우 다시 열 때 결과 화면으로 복원되도록 활성 화면 판별 순서를 수정했습니다.
- 결과 화면의 마지막 결과 탭(`Bottleneck`, `Hotspot`, `Zone`, `Groups`)과 authoring 우측 패널 모드를 저장/복원하도록 보강했습니다.

## Related Issue

- None (application-only PR)

## Area

- [ ] Engine
- [ ] Domain
- [x] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [x] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug`
- [x] `ctest --preset test-debug`
- [ ] Not run (reason below)

## Risks / Follow-up

- baseline/alternative 결과를 여러 개 저장하고 비교하는 기능은 아직 포함하지 않았습니다.
- authoring 우측 패널 상태는 저장되지만, run 전용 우측 패널 경험 자체는 별도 개선이 필요할 수 있습니다.
