### PR TITLE
[Domain] Add fire and smoke scenario hazards

### DIFF
--- a/src/application/ProjectPersistence.cpp
+++ b/src/application/ProjectPersistence.cpp
@@ -720,20 +720,104 @@ safecrowd::domain::PopulationSpec populationFromJson(const QJsonObject& object) 
     return population;
 }
 
+QString hazardKindToJson(safecrowd::domain::EnvironmentHazardKind kind) {
+    switch (kind) {
+    case safecrowd::domain::EnvironmentHazardKind::Smoke:
+        return "Smoke";
+    case safecrowd::domain::EnvironmentHazardKind::Fire:
+    default:
+        return "Fire";
+    }
+}
+
+safecrowd::domain::EnvironmentHazardKind hazardKindFromJson(const QJsonValue& value) {
+    if (value.isDouble()) {
+        return static_cast<safecrowd::domain::EnvironmentHazardKind>(value.toInt());
+    }
+
+    const auto raw = value.toString().toLower();
+    if (raw == "smoke") {
+        return safecrowd::domain::EnvironmentHazardKind::Smoke;
+    }
+    return safecrowd::domain::EnvironmentHazardKind::Fire;
+}
+
+QString severityToJson(safecrowd::domain::ScenarioElementSeverity severity) {
+    switch (severity) {
+    case safecrowd::domain::ScenarioElementSeverity::Low:
+        return "Low";
+    case safecrowd::domain::ScenarioElementSeverity::High:
+        return "High";
+    case safecrowd::domain::ScenarioElementSeverity::Medium:
+    default:
+        return "Medium";
+    }
+}
+
+safecrowd::domain::ScenarioElementSeverity severityFromJson(const QJsonValue& value) {
+    if (value.isDouble()) {
+        return static_cast<safecrowd::domain::ScenarioElementSeverity>(value.toInt());
+    }
+
+    const auto raw = value.toString().toLower();
+    if (raw == "low") {
+        return safecrowd::domain::ScenarioElementSeverity::Low;
+    }
+    if (raw == "high") {
+        return safecrowd::domain::ScenarioElementSeverity::High;
+    }
+    return safecrowd::domain::ScenarioElementSeverity::Medium;
+}
+
+QJsonObject hazardToJson(const safecrowd::domain::EnvironmentHazardDraft& hazard) {
+    QJsonObject object;
+    object["id"] = QString::fromStdString(hazard.id);
+    object["kind"] = hazardKindToJson(hazard.kind);
+    object["name"] = QString::fromStdString(hazard.name);
+    object["affectedZoneId"] = QString::fromStdString(hazard.affectedZoneId);
+    object["startSeconds"] = hazard.startSeconds;
+    object["endSeconds"] = hazard.endSeconds;
+    object["severity"] = severityToJson(hazard.severity);
+    object["note"] = QString::fromStdString(hazard.note);
+    return object;
+}
+
+safecrowd::domain::EnvironmentHazardDraft hazardFromJson(const QJsonObject& object) {
+    return {
+        .id = object.value("id").toString().toStdString(),
+        .kind = hazardKindFromJson(object.value("kind")),
+        .name = object.value("name").toString().toStdString(),
+        .affectedZoneId = object.value("affectedZoneId").toString().toStdString(),
+        .startSeconds = object.value("startSeconds").toDouble(0.0),
+        .endSeconds = object.value("endSeconds").toDouble(0.0),
+        .severity = severityFromJson(object.value("severity")),
+        .note = object.value("note").toString().toStdString(),
+    };
+}
+
 QJsonObject environmentToJson(const safecrowd::domain::EnvironmentState& environment) {
     QJsonObject object;
     object["reducedVisibility"] = environment.reducedVisibility;
     object["familiarityProfile"] = QString::fromStdString(environment.familiarityProfile);
     object["guidanceProfile"] = QString::fromStdString(environment.guidanceProfile);
+    QJsonArray hazards;
+    for (const auto& hazard : environment.hazards) {
+        hazards.append(hazardToJson(hazard));
+    }
+    object["hazards"] = hazards;
     return object;
 }
 
 safecrowd::domain::EnvironmentState environmentFromJson(const QJsonObject& object) {
-    return {
+    safecrowd::domain::EnvironmentState environment{
         .reducedVisibility = object.value("reducedVisibility").toBool(false),
         .familiarityProfile = object.value("familiarityProfile").toString().toStdString(),
         .guidanceProfile = object.value("guidanceProfile").toString().toStdString(),
     };
+    for (const auto& value : object.value("hazards").toArray()) {
+        environment.hazards.push_back(hazardFromJson(value.toObject()));
+    }
+    return environment;
 }
 
 QJsonObject eventToJson(const safecrowd::domain::OperationalEventDraft& event) {

--- a/src/application/ScenarioAuthoringWidget.cpp
+++ b/src/application/ScenarioAuthoringWidget.cpp
@@ -281,18 +281,6 @@ bool hasSmokeHazard(const safecrowd::domain::EnvironmentState& environment) {
     });
 }
 
-QString nextHazardId(const std::vector<safecrowd::domain::EnvironmentHazardDraft>& hazards) {
-    for (int index = static_cast<int>(hazards.size()) + 1;; ++index) {
-        const auto candidate = QString("hazard-%1").arg(index);
-        const auto exists = std::any_of(hazards.begin(), hazards.end(), [&](const auto& hazard) {
-            return QString::fromStdString(hazard.id) == candidate;
-        });
-        if (!exists) {
-            return candidate;
-        }
-    }
-}
-
 int draftOccupantCount(const safecrowd::domain::ScenarioDraft& scenario) {
     int total = 0;
     for (const auto& placement : scenario.population.initialPlacements) {
@@ -896,34 +884,15 @@ QWidget* createEventsPanel(
     const safecrowd::domain::FacilityLayout2D& layout,
     const ScenarioAuthoringWidget::ScenarioState* scenario,
     QWidget* parent,
-    std::function<void()> addHazardHandler,
     std::function<void(const QString&)> deleteItemHandler,
     std::function<void(const QString&)> settingsItemHandler) {
-    auto* header = new QWidget(parent);
-    auto* headerLayout = new QHBoxLayout(header);
-    headerLayout->setContentsMargins(0, 0, 0, 0);
-    headerLayout->setSpacing(8);
-    auto* title = createLabel("Events / Hazards", header, ui::FontRole::Title);
-    title->setWordWrap(false);
-    headerLayout->addWidget(title, 1, Qt::AlignVCenter);
-    auto* addButton = new QPushButton("Add Hazard", header);
-    addButton->setFont(ui::font(ui::FontRole::Body));
-    addButton->setStyleSheet(ui::secondaryButtonStyleSheet());
-    addButton->setEnabled(static_cast<bool>(addHazardHandler));
-    QObject::connect(addButton, &QPushButton::clicked, header, [addHazardHandler = std::move(addHazardHandler)]() {
-        if (addHazardHandler) {
-            addHazardHandler();
-        }
-    });
-    headerLayout->addWidget(addButton, 0, Qt::AlignVCenter);
-
     return new NavigationTreeWidget(
         "Events / Hazards",
         buildEventsTree(layout, scenario),
         "No operational events, hazards, or blocked exits yet",
         {},
         parent,
-        header,
+        createLabel("Events / Hazards", parent, ui::FontRole::Title),
         {},
         {},
         std::move(deleteItemHandler),
@@ -1192,6 +1161,17 @@ void ScenarioAuthoringWidget::refreshCanvas() {
         refreshNavigationPanel();
         refreshInspector();
     });
+    canvas_->setEnvironmentHazards(scenario->draft.environment.hazards);
+    canvas_->setEnvironmentHazardsChangedHandler([this](const std::vector<safecrowd::domain::EnvironmentHazardDraft>& hazards) {
+        auto* current = currentScenario();
+        if (current == nullptr) {
+            return;
+        }
+        current->draft.environment.hazards = hazards;
+        recomputeDiffKeysAfterScenarioChanged(*current);
+        refreshNavigationPanel();
+        refreshInspector();
+    });
     if (!selectedLayoutElementId_.isEmpty()) {
         canvas_->focusLayoutElement(selectedLayoutElementId_);
     } else if (!selectedCrowdElementId_.isEmpty()) {
@@ -1417,31 +1397,6 @@ void ScenarioAuthoringWidget::refreshNavigationPanel() {
         layout_,
         currentScenario(),
         shell_,
-        [this]() {
-            auto* scenario = currentScenario();
-            if (scenario == nullptr) {
-                return;
-            }
-
-            auto& hazards = scenario->draft.environment.hazards;
-            safecrowd::domain::EnvironmentHazardDraft hazard{
-                .id = nextHazardId(hazards).toStdString(),
-                .kind = safecrowd::domain::EnvironmentHazardKind::Fire,
-                .name = QString("Fire hazard %1").arg(static_cast<int>(hazards.size()) + 1).toStdString(),
-                .affectedZoneId = {},
-                .startSeconds = 0.0,
-                .endSeconds = 60.0,
-                .severity = safecrowd::domain::ScenarioElementSeverity::Medium,
-            };
-            if (!editEnvironmentHazard(&hazard, layout_, this)) {
-                return;
-            }
-
-            hazards.push_back(std::move(hazard));
-            recomputeDiffKeysAfterScenarioChanged(*scenario);
-            refreshNavigationPanel();
-            refreshInspector();
-        },
         [this](const QString& rawId) {
             auto* scenario = currentScenario();
             if (scenario == nullptr || rawId.isEmpty()) {

--- a/src/application/ScenarioAuthoringWidget.cpp
+++ b/src/application/ScenarioAuthoringWidget.cpp
@@ -6,6 +6,7 @@
 #include <QComboBox>
 #include <QDialog>
 #include <QDialogButtonBox>
+#include <QDoubleSpinBox>
 #include <QFormLayout>
 #include <QFrame>
 #include <QHBoxLayout>
@@ -39,6 +40,8 @@ QLabel* createLabel(const QString& text, QWidget* parent, ui::FontRole role = ui
     label->setWordWrap(true);
     return label;
 }
+
+QString zoneLabel(const safecrowd::domain::Zone2D& zone);
 
 bool editOperationalEvent(
     safecrowd::domain::OperationalEventDraft* event,
@@ -92,6 +95,123 @@ bool editOperationalEvent(
     return true;
 }
 
+QString hazardKindLabel(safecrowd::domain::EnvironmentHazardKind kind) {
+    switch (kind) {
+    case safecrowd::domain::EnvironmentHazardKind::Smoke:
+        return "Smoke";
+    case safecrowd::domain::EnvironmentHazardKind::Fire:
+    default:
+        return "Fire";
+    }
+}
+
+QString severityLabel(safecrowd::domain::ScenarioElementSeverity severity) {
+    switch (severity) {
+    case safecrowd::domain::ScenarioElementSeverity::Low:
+        return "Low";
+    case safecrowd::domain::ScenarioElementSeverity::High:
+        return "High";
+    case safecrowd::domain::ScenarioElementSeverity::Medium:
+    default:
+        return "Medium";
+    }
+}
+
+bool editEnvironmentHazard(
+    safecrowd::domain::EnvironmentHazardDraft* hazard,
+    const safecrowd::domain::FacilityLayout2D& layout,
+    QWidget* parent) {
+    if (hazard == nullptr) {
+        return false;
+    }
+
+    QDialog dialog(parent);
+    dialog.setWindowTitle("Edit hazard");
+
+    auto* root = new QVBoxLayout(&dialog);
+    root->setContentsMargins(16, 16, 16, 16);
+    root->setSpacing(12);
+
+    auto* form = new QFormLayout();
+    form->setContentsMargins(0, 0, 0, 0);
+    form->setSpacing(8);
+
+    auto* kindCombo = new QComboBox(&dialog);
+    kindCombo->addItem("Fire", static_cast<int>(safecrowd::domain::EnvironmentHazardKind::Fire));
+    kindCombo->addItem("Smoke", static_cast<int>(safecrowd::domain::EnvironmentHazardKind::Smoke));
+    kindCombo->setCurrentIndex(std::max(0, kindCombo->findData(static_cast<int>(hazard->kind))));
+
+    auto* nameEdit = new QLineEdit(&dialog);
+    nameEdit->setText(QString::fromStdString(hazard->name));
+
+    auto* zoneCombo = new QComboBox(&dialog);
+    zoneCombo->addItem("Unassigned zone", QString{});
+    for (const auto& zone : layout.zones) {
+        zoneCombo->addItem(zoneLabel(zone), QString::fromStdString(zone.id));
+    }
+    zoneCombo->setCurrentIndex(std::max(0, zoneCombo->findData(QString::fromStdString(hazard->affectedZoneId))));
+
+    auto* startSpin = new QDoubleSpinBox(&dialog);
+    startSpin->setRange(0.0, 86400.0);
+    startSpin->setDecimals(1);
+    startSpin->setSuffix(" s");
+    startSpin->setValue(std::max(0.0, hazard->startSeconds));
+
+    auto* endSpin = new QDoubleSpinBox(&dialog);
+    endSpin->setRange(0.0, 86400.0);
+    endSpin->setDecimals(1);
+    endSpin->setSuffix(" s");
+    endSpin->setValue(std::max(0.0, hazard->endSeconds));
+
+    auto* severityCombo = new QComboBox(&dialog);
+    severityCombo->addItem("Low", static_cast<int>(safecrowd::domain::ScenarioElementSeverity::Low));
+    severityCombo->addItem("Medium", static_cast<int>(safecrowd::domain::ScenarioElementSeverity::Medium));
+    severityCombo->addItem("High", static_cast<int>(safecrowd::domain::ScenarioElementSeverity::High));
+    severityCombo->setCurrentIndex(std::max(0, severityCombo->findData(static_cast<int>(hazard->severity))));
+
+    auto* noteEdit = new QPlainTextEdit(&dialog);
+    noteEdit->setPlainText(QString::fromStdString(hazard->note));
+    noteEdit->setMinimumHeight(72);
+
+    auto* visibilityHint = createLabel(
+        "Smoke hazards are scenario inputs linked to reduced visibility concepts. No fire spread, smoke concentration, FED, or FDS runtime effect is calculated in v1.",
+        &dialog);
+    visibilityHint->setStyleSheet(ui::mutedTextStyleSheet());
+
+    form->addRow("Kind", kindCombo);
+    form->addRow("Name", nameEdit);
+    form->addRow("Affected zone", zoneCombo);
+    form->addRow("Start", startSpin);
+    form->addRow("End", endSpin);
+    form->addRow("Severity", severityCombo);
+    form->addRow("Note", noteEdit);
+    root->addLayout(form);
+    root->addWidget(visibilityHint);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
+    QObject::connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    QObject::connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+    root->addWidget(buttons);
+
+    if (dialog.exec() != QDialog::Accepted) {
+        return false;
+    }
+
+    const auto name = nameEdit->text().trimmed();
+    if (name.isEmpty()) {
+        return false;
+    }
+
+    hazard->kind = static_cast<safecrowd::domain::EnvironmentHazardKind>(kindCombo->currentData().toInt());
+    hazard->name = name.toStdString();
+    hazard->affectedZoneId = zoneCombo->currentData().toString().toStdString();
+    hazard->startSeconds = startSpin->value();
+    hazard->endSeconds = std::max(hazard->startSeconds, endSpin->value());
+    hazard->severity = static_cast<safecrowd::domain::ScenarioElementSeverity>(severityCombo->currentData().toInt());
+    hazard->note = noteEdit->toPlainText().trimmed().toStdString();
+    return true;
+}
+
 QString zoneLabel(const safecrowd::domain::Zone2D& zone) {
     const auto id = QString::fromStdString(zone.id);
     const auto label = QString::fromStdString(zone.label);
@@ -140,6 +260,37 @@ QString blockScheduleSummary(const safecrowd::domain::ConnectionBlockDraft& bloc
         intervals << QString("%1s - %2s").arg(interval.startSeconds, 0, 'f', 1).arg(interval.endSeconds, 0, 'f', 1);
     }
     return intervals.join(", ");
+}
+
+QString hazardScheduleSummary(const safecrowd::domain::EnvironmentHazardDraft& hazard) {
+    return QString("%1s - %2s").arg(hazard.startSeconds, 0, 'f', 1).arg(hazard.endSeconds, 0, 'f', 1);
+}
+
+QString hazardZoneSummary(
+    const safecrowd::domain::FacilityLayout2D& layout,
+    const safecrowd::domain::EnvironmentHazardDraft& hazard) {
+    if (hazard.affectedZoneId.empty()) {
+        return "Unassigned zone";
+    }
+    return zoneName(layout, hazard.affectedZoneId);
+}
+
+bool hasSmokeHazard(const safecrowd::domain::EnvironmentState& environment) {
+    return std::any_of(environment.hazards.begin(), environment.hazards.end(), [](const auto& hazard) {
+        return hazard.kind == safecrowd::domain::EnvironmentHazardKind::Smoke;
+    });
+}
+
+QString nextHazardId(const std::vector<safecrowd::domain::EnvironmentHazardDraft>& hazards) {
+    for (int index = static_cast<int>(hazards.size()) + 1;; ++index) {
+        const auto candidate = QString("hazard-%1").arg(index);
+        const auto exists = std::any_of(hazards.begin(), hazards.end(), [&](const auto& hazard) {
+            return QString::fromStdString(hazard.id) == candidate;
+        });
+        if (!exists) {
+            return candidate;
+        }
+    }
 }
 
 int draftOccupantCount(const safecrowd::domain::ScenarioDraft& scenario) {
@@ -200,6 +351,15 @@ QString buildChangeSummaryLine(
             .arg(QString::fromStdString(baseline.environment.guidanceProfile),
                  QString::fromStdString(variant.environment.guidanceProfile));
     }
+    if (key == "environment.hazards") {
+        QString summary = countChangeSummary("hazards",
+                                             static_cast<int>(baseline.environment.hazards.size()),
+                                             static_cast<int>(variant.environment.hazards.size()));
+        if (hasSmokeHazard(variant.environment)) {
+            summary += ", smoke linked to reduced visibility concept";
+        }
+        return QString("environment.hazards (%1)").arg(summary);
+    }
     if (key == "control.events") {
         return QString("control.events (%1)")
             .arg(countChangeSummary("events", static_cast<int>(baseline.control.events.size()),
@@ -247,6 +407,9 @@ QString changeCategoryLabel(const std::string& key) {
     if (key.rfind("population.", 0) == 0) {
         return "Crowd";
     }
+    if (key == "environment.hazards") {
+        return "Hazards";
+    }
     if (key.rfind("environment.", 0) == 0) {
         return "Layout";
     }
@@ -265,6 +428,7 @@ QString compactChangeSummary(const QString& summary) {
     compact.replace("environment.reducedVisibility", "layout visibility");
     compact.replace("environment.familiarityProfile", "layout familiarity");
     compact.replace("environment.guidanceProfile", "layout guidance");
+    compact.replace("environment.hazards", "hazards");
     compact.replace("control.events", "events");
     compact.replace("control.connectionBlocks", "blocked events");
     compact.replace("control.routeGuidances", "route guidance");
@@ -568,6 +732,67 @@ std::vector<NavigationTreeNode> buildEventsTree(
         });
     }
 
+    const auto& hazards = scenario->draft.environment.hazards;
+    if (!hazards.empty()) {
+        std::vector<NavigationTreeNode> nodes;
+        nodes.reserve(hazards.size());
+        for (const auto& hazard : hazards) {
+            const auto hazardId = QString::fromStdString(hazard.id);
+            const auto kind = hazardKindLabel(hazard.kind);
+            const auto zone = hazardZoneSummary(layout, hazard);
+            const auto schedule = hazardScheduleSummary(hazard);
+            const auto severity = severityLabel(hazard.severity);
+            QStringList details;
+            details << QString("Zone: %1").arg(zone)
+                    << QString("Period: %1").arg(schedule)
+                    << QString("Severity: %1").arg(severity);
+            if (hazard.kind == safecrowd::domain::EnvironmentHazardKind::Smoke) {
+                details << "Visibility: reduced visibility concept";
+            }
+
+            std::vector<NavigationTreeNode> children{
+                {
+                    .label = QString("Kind  -  %1").arg(kind),
+                    .id = QString("%1/kind").arg(hazardId),
+                },
+                {
+                    .label = QString("Zone  -  %1").arg(zone),
+                    .id = QString("%1/zone").arg(hazardId),
+                },
+                {
+                    .label = QString("Period  -  %1").arg(schedule),
+                    .id = QString("%1/period").arg(hazardId),
+                },
+                {
+                    .label = QString("Severity  -  %1").arg(severity),
+                    .id = QString("%1/severity").arg(hazardId),
+                },
+            };
+            if (!hazard.note.empty()) {
+                children.push_back({
+                    .label = QString("Note  -  %1").arg(QString::fromStdString(hazard.note)),
+                    .id = QString("%1/note").arg(hazardId),
+                });
+            }
+
+            const auto hazardName = QString::fromStdString(hazard.name);
+            nodes.push_back({
+                .label = QString("Hazard  -  %1: %2").arg(kind, hazardName),
+                .id = hazardId,
+                .detail = details.join(" / "),
+                .children = std::move(children),
+                .expanded = true,
+            });
+        }
+
+        sections.push_back({
+            .label = QString("Hazards (%1)").arg(static_cast<int>(hazards.size())),
+            .children = std::move(nodes),
+            .expanded = true,
+            .selectable = false,
+        });
+    }
+
     const auto& routeGuidances = scenario->draft.control.routeGuidances;
     if (!routeGuidances.empty()) {
         std::vector<NavigationTreeNode> nodes;
@@ -670,17 +895,35 @@ std::vector<NavigationTreeNode> buildEventsTree(
 QWidget* createEventsPanel(
     const safecrowd::domain::FacilityLayout2D& layout,
     const ScenarioAuthoringWidget::ScenarioState* scenario,
-    const WorkspaceShell* shell,
     QWidget* parent,
+    std::function<void()> addHazardHandler,
     std::function<void(const QString&)> deleteItemHandler,
     std::function<void(const QString&)> settingsItemHandler) {
+    auto* header = new QWidget(parent);
+    auto* headerLayout = new QHBoxLayout(header);
+    headerLayout->setContentsMargins(0, 0, 0, 0);
+    headerLayout->setSpacing(8);
+    auto* title = createLabel("Events / Hazards", header, ui::FontRole::Title);
+    title->setWordWrap(false);
+    headerLayout->addWidget(title, 1, Qt::AlignVCenter);
+    auto* addButton = new QPushButton("Add Hazard", header);
+    addButton->setFont(ui::font(ui::FontRole::Body));
+    addButton->setStyleSheet(ui::secondaryButtonStyleSheet());
+    addButton->setEnabled(static_cast<bool>(addHazardHandler));
+    QObject::connect(addButton, &QPushButton::clicked, header, [addHazardHandler = std::move(addHazardHandler)]() {
+        if (addHazardHandler) {
+            addHazardHandler();
+        }
+    });
+    headerLayout->addWidget(addButton, 0, Qt::AlignVCenter);
+
     return new NavigationTreeWidget(
-        "Events",
+        "Events / Hazards",
         buildEventsTree(layout, scenario),
-        "No operational events or blocked exits yet",
+        "No operational events, hazards, or blocked exits yet",
         {},
         parent,
-        shell != nullptr ? shell->createPanelHeader("Events", parent, false) : nullptr,
+        header,
         {},
         {},
         std::move(deleteItemHandler),
@@ -984,6 +1227,7 @@ void ScenarioAuthoringWidget::refreshInspector() {
 
                 addMetaRow(panelLayout, "Population", QString::number(totalOccupantCount(*scenario)), scenarioOverviewPanel_);
                 addMetaRow(panelLayout, "Events", QString::number(static_cast<int>(scenario->events.size())), scenarioOverviewPanel_);
+                addMetaRow(panelLayout, "Hazards", QString::number(static_cast<int>(scenario->draft.environment.hazards.size())), scenarioOverviewPanel_);
                 addMetaRow(panelLayout, "Guidance", QString::number(static_cast<int>(scenario->draft.control.routeGuidances.size())), scenarioOverviewPanel_);
                 addMetaRow(panelLayout, "Blocked", QString::number(static_cast<int>(scenario->draft.control.connectionBlocks.size())), scenarioOverviewPanel_);
                 addMetaRow(panelLayout, "Start", scenario->startText, scenarioOverviewPanel_);
@@ -1104,7 +1348,7 @@ void ScenarioAuthoringWidget::refreshNavigationPanel() {
             },
             {
                 .id = "events",
-                .label = "Events",
+                .label = "Events / Hazards",
                 .icon = makeEventsIcon(QColor("#1f5fae")),
             },
         },
@@ -1173,7 +1417,31 @@ void ScenarioAuthoringWidget::refreshNavigationPanel() {
         layout_,
         currentScenario(),
         shell_,
-        shell_,
+        [this]() {
+            auto* scenario = currentScenario();
+            if (scenario == nullptr) {
+                return;
+            }
+
+            auto& hazards = scenario->draft.environment.hazards;
+            safecrowd::domain::EnvironmentHazardDraft hazard{
+                .id = nextHazardId(hazards).toStdString(),
+                .kind = safecrowd::domain::EnvironmentHazardKind::Fire,
+                .name = QString("Fire hazard %1").arg(static_cast<int>(hazards.size()) + 1).toStdString(),
+                .affectedZoneId = {},
+                .startSeconds = 0.0,
+                .endSeconds = 60.0,
+                .severity = safecrowd::domain::ScenarioElementSeverity::Medium,
+            };
+            if (!editEnvironmentHazard(&hazard, layout_, this)) {
+                return;
+            }
+
+            hazards.push_back(std::move(hazard));
+            recomputeDiffKeysAfterScenarioChanged(*scenario);
+            refreshNavigationPanel();
+            refreshInspector();
+        },
         [this](const QString& rawId) {
             auto* scenario = currentScenario();
             if (scenario == nullptr || rawId.isEmpty()) {
@@ -1193,25 +1461,38 @@ void ScenarioAuthoringWidget::refreshNavigationPanel() {
             const auto it = std::remove_if(events.begin(), events.end(), [&](const auto& event) {
                 return event.id == eventId;
             });
-            if (it == events.end()) {
+            if (it != events.end()) {
+                events.erase(it, events.end());
+                scenario->draft.control.events = scenario->events;
+                recomputeDiffKeysAfterScenarioChanged(*scenario);
+                refreshNavigationPanel();
+                refreshInspector();
                 return;
             }
-            events.erase(it, events.end());
-            scenario->draft.control.events = scenario->events;
+
+            auto& hazards = scenario->draft.environment.hazards;
+            const auto hazardId = id.toStdString();
+            const auto hazardIt = std::remove_if(hazards.begin(), hazards.end(), [&](const auto& hazard) {
+                return hazard.id == hazardId;
+            });
+            if (hazardIt == hazards.end()) {
+                return;
+            }
+            hazards.erase(hazardIt, hazards.end());
             recomputeDiffKeysAfterScenarioChanged(*scenario);
             refreshNavigationPanel();
             refreshInspector();
         },
         [this](const QString& rawId) {
-            if (canvas_ == nullptr || rawId.isEmpty()) {
+            if (rawId.isEmpty()) {
                 return;
             }
 
             const auto id = rawId.section('/', 0, 0);
-            if (canvas_->editConnectionBlockScheduleById(id)) {
+            if (canvas_ != nullptr && canvas_->editConnectionBlockScheduleById(id)) {
                 return;
             }
-            if (canvas_->editRouteGuidanceById(id)) {
+            if (canvas_ != nullptr && canvas_->editRouteGuidanceById(id)) {
                 return;
             }
 
@@ -1225,13 +1506,25 @@ void ScenarioAuthoringWidget::refreshNavigationPanel() {
             const auto it = std::find_if(events.begin(), events.end(), [&](auto& event) {
                 return event.id == eventId;
             });
-            if (it == events.end()) {
+            if (it != events.end()) {
+                if (!editOperationalEvent(&(*it), this)) {
+                    return;
+                }
+                scenario->draft.control.events = scenario->events;
+                recomputeDiffKeysAfterScenarioChanged(*scenario);
+                refreshNavigationPanel();
+                refreshInspector();
                 return;
             }
-            if (!editOperationalEvent(&(*it), this)) {
+
+            auto& hazards = scenario->draft.environment.hazards;
+            const auto hazardId = id.toStdString();
+            const auto hazardIt = std::find_if(hazards.begin(), hazards.end(), [&](auto& hazard) {
+                return hazard.id == hazardId;
+            });
+            if (hazardIt == hazards.end() || !editEnvironmentHazard(&(*hazardIt), layout_, this)) {
                 return;
             }
-            scenario->draft.control.events = scenario->events;
             recomputeDiffKeysAfterScenarioChanged(*scenario);
             refreshNavigationPanel();
             refreshInspector();

--- a/src/application/ScenarioCanvasWidget.cpp
+++ b/src/application/ScenarioCanvasWidget.cpp
@@ -663,6 +663,35 @@ QIcon makeToolIcon(const QString& type, const QColor& color) {
         return QIcon(pixmap);
     }
 
+    if (type == "fire") {
+        QPainterPath flame;
+        flame.moveTo(QPointF(22, 35));
+        flame.cubicTo(QPointF(11, 29), QPointF(14, 18), QPointF(20, 13));
+        flame.cubicTo(QPointF(22, 10), QPointF(23, 7), QPointF(22, 4));
+        flame.cubicTo(QPointF(31, 10), QPointF(36, 19), QPointF(31, 28));
+        flame.cubicTo(QPointF(29, 32), QPointF(26, 34), QPointF(22, 35));
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(color);
+        painter.drawPath(flame);
+        painter.setBrush(QColor("#fff4d6"));
+        QPainterPath inner;
+        inner.moveTo(QPointF(22, 31));
+        inner.cubicTo(QPointF(17, 27), QPointF(19, 20), QPointF(23, 16));
+        inner.cubicTo(QPointF(28, 22), QPointF(28, 28), QPointF(22, 31));
+        painter.drawPath(inner);
+        return QIcon(pixmap);
+    }
+
+    if (type == "smoke") {
+        painter.setPen(QPen(color, 3.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+        painter.drawArc(QRectF(9, 24, 14, 10), 20 * 16, 220 * 16);
+        painter.drawArc(QRectF(19, 22, 16, 12), 20 * 16, 220 * 16);
+        painter.drawArc(QRectF(12, 14, 13, 10), 20 * 16, 220 * 16);
+        painter.drawArc(QRectF(24, 11, 12, 10), 20 * 16, 220 * 16);
+        painter.drawLine(QPointF(13, 36), QPointF(34, 36));
+        return QIcon(pixmap);
+    }
+
     if (type != "group") {
         return QIcon(pixmap);
     }
@@ -1255,6 +1284,16 @@ void ScenarioCanvasWidget::setRouteGuidancesChangedHandler(
     routeGuidancesChangedHandler_ = std::move(handler);
 }
 
+void ScenarioCanvasWidget::setEnvironmentHazards(std::vector<safecrowd::domain::EnvironmentHazardDraft> hazards) {
+    environmentHazards_ = std::move(hazards);
+    update();
+}
+
+void ScenarioCanvasWidget::setEnvironmentHazardsChangedHandler(
+    std::function<void(const std::vector<safecrowd::domain::EnvironmentHazardDraft>&)> handler) {
+    environmentHazardsChangedHandler_ = std::move(handler);
+}
+
 void ScenarioCanvasWidget::setLayoutElementActivatedHandler(std::function<void(const QString&)> handler) {
     layoutElementActivatedHandler_ = std::move(handler);
 }
@@ -1315,6 +1354,20 @@ void ScenarioCanvasWidget::activateLayoutElement(const QString& elementId) {
             return;
         }
         addRouteGuidanceForConnection(*connectionIt);
+        return;
+    }
+
+    if (toolMode_ == ToolMode::FireHazard || toolMode_ == ToolMode::SmokeHazard) {
+        const auto targetId = elementId.toStdString();
+        const auto it = std::find_if(layout_.zones.begin(), layout_.zones.end(), [&](const auto& zone) {
+            return zone.id == targetId;
+        });
+        if (it == layout_.zones.end()) {
+            return;
+        }
+        addEnvironmentHazardForZone(*it, toolMode_ == ToolMode::FireHazard
+            ? safecrowd::domain::EnvironmentHazardKind::Fire
+            : safecrowd::domain::EnvironmentHazardKind::Smoke);
     }
 }
 
@@ -1623,6 +1676,14 @@ void ScenarioCanvasWidget::mousePressEvent(QMouseEvent* event) {
         return;
     }
 
+    if (toolMode_ == ToolMode::FireHazard || toolMode_ == ToolMode::SmokeHazard) {
+        addEnvironmentHazard(event->position(), toolMode_ == ToolMode::FireHazard
+            ? safecrowd::domain::EnvironmentHazardKind::Fire
+            : safecrowd::domain::EnvironmentHazardKind::Smoke);
+        event->accept();
+        return;
+    }
+
     if (toolMode_ == ToolMode::Select) {
         selectionDragging_ = true;
         selectionDragStart_ = event->position();
@@ -1734,6 +1795,7 @@ void ScenarioCanvasWidget::paintEvent(QPaintEvent* event) {
     drawFocusedPlacement(painter, transform);
     drawConnectionBlocks(painter, transform);
     drawRouteGuidances(painter, transform);
+    drawEnvironmentHazards(painter, transform);
 
     if (dragging_ || selectionDragging_) {
         const auto start = dragging_ ? dragStart_ : selectionDragStart_;
@@ -1940,6 +2002,42 @@ void ScenarioCanvasWidget::drawRouteGuidances(QPainter& painter, const LayoutCan
         painter.drawLine(QPointF(markerCenter.x() + 6.3, markerCenter.y() - 2.0), QPointF(markerCenter.x() + 9.2, markerCenter.y() - 2.8));
         painter.drawLine(QPointF(markerCenter.x() + 3.7, markerCenter.y() - 7.2), QPointF(markerCenter.x() + 4.8, markerCenter.y() - 9.8));
         painter.setPen(Qt::NoPen);
+    }
+}
+
+void ScenarioCanvasWidget::drawEnvironmentHazards(QPainter& painter, const LayoutCanvasTransform& transform) const {
+    for (const auto& hazard : environmentHazards_) {
+        if (hazard.affectedZoneId.empty()) {
+            continue;
+        }
+        const auto zoneIt = std::find_if(layout_.zones.begin(), layout_.zones.end(), [&](const auto& zone) {
+            return zone.id == hazard.affectedZoneId;
+        });
+        if (zoneIt == layout_.zones.end() || !matchesFloor(zoneIt->floorId, currentFloorId_)) {
+            continue;
+        }
+
+        const auto center = transform.map(polygonCenter(zoneIt->area));
+        const QColor fill = hazard.kind == safecrowd::domain::EnvironmentHazardKind::Fire
+            ? QColor("#c2410c")
+            : QColor("#64748b");
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(fill);
+        painter.drawEllipse(center, 11.0, 11.0);
+
+        painter.setPen(QPen(Qt::white, 2.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+        painter.setBrush(Qt::NoBrush);
+        if (hazard.kind == safecrowd::domain::EnvironmentHazardKind::Fire) {
+            QPainterPath flame;
+            flame.moveTo(center + QPointF(0.0, 6.0));
+            flame.cubicTo(center + QPointF(-5.0, 2.0), center + QPointF(-3.5, -4.0), center + QPointF(-0.5, -7.0));
+            flame.cubicTo(center + QPointF(4.0, -3.0), center + QPointF(4.0, 3.0), center + QPointF(0.0, 6.0));
+            painter.drawPath(flame);
+        } else {
+            painter.drawArc(QRectF(center.x() - 7.0, center.y() - 1.0, 9.0, 7.0), 20 * 16, 220 * 16);
+            painter.drawArc(QRectF(center.x() - 1.0, center.y() - 3.0, 10.0, 7.0), 20 * 16, 220 * 16);
+            painter.drawArc(QRectF(center.x() - 5.0, center.y() - 8.0, 8.0, 6.0), 20 * 16, 220 * 16);
+        }
     }
 }
 
@@ -2288,6 +2386,18 @@ QString ScenarioCanvasWidget::nextRouteGuidanceId() const {
     return QString("guidance-%1").arg(static_cast<int>(routeGuidances_.size()) + 1);
 }
 
+QString ScenarioCanvasWidget::nextEnvironmentHazardId() const {
+    for (int index = static_cast<int>(environmentHazards_.size()) + 1;; ++index) {
+        const auto candidate = QString("hazard-%1").arg(index);
+        const auto exists = std::any_of(environmentHazards_.begin(), environmentHazards_.end(), [&](const auto& hazard) {
+            return QString::fromStdString(hazard.id) == candidate;
+        });
+        if (!exists) {
+            return candidate;
+        }
+    }
+}
+
 void ScenarioCanvasWidget::addGroupPlacement(const QPointF& start, const QPointF& end) {
     if ((QLineF(start, end).length()) < 8.0) {
         return;
@@ -2557,6 +2667,49 @@ void ScenarioCanvasWidget::addRouteGuidanceForConnection(const safecrowd::domain
     update();
 }
 
+void ScenarioCanvasWidget::addEnvironmentHazard(
+    const QPointF& position,
+    safecrowd::domain::EnvironmentHazardKind kind) {
+    const auto point = unmapPoint(position);
+    const auto zoneId = zoneAt(point);
+    if (zoneId.isEmpty()) {
+        QMessageBox::information(this, "Hazard", "Click inside a zone to place a fire or smoke hazard.");
+        return;
+    }
+
+    const auto zoneIdStd = zoneId.toStdString();
+    const auto it = std::find_if(layout_.zones.begin(), layout_.zones.end(), [&](const auto& zone) {
+        return zone.id == zoneIdStd;
+    });
+    if (it == layout_.zones.end()) {
+        return;
+    }
+    addEnvironmentHazardForZone(*it, kind);
+}
+
+void ScenarioCanvasWidget::addEnvironmentHazardForZone(
+    const safecrowd::domain::Zone2D& zone,
+    safecrowd::domain::EnvironmentHazardKind kind) {
+    if (!matchesFloor(zone.floorId, currentFloorId_)) {
+        return;
+    }
+
+    safecrowd::domain::EnvironmentHazardDraft draft;
+    draft.id = nextEnvironmentHazardId().toStdString();
+    draft.kind = kind;
+    draft.name = QString("%1 hazard %2")
+        .arg(kind == safecrowd::domain::EnvironmentHazardKind::Fire ? "Fire" : "Smoke")
+        .arg(static_cast<int>(environmentHazards_.size()) + 1)
+        .toStdString();
+    draft.affectedZoneId = zone.id;
+    draft.startSeconds = 0.0;
+    draft.endSeconds = 60.0;
+    draft.severity = safecrowd::domain::ScenarioElementSeverity::Medium;
+    environmentHazards_.push_back(std::move(draft));
+    emitEnvironmentHazardsChanged();
+    update();
+}
+
 void ScenarioCanvasWidget::selectSingleAt(const QPointF& position, const LayoutCanvasTransform& transform) {
     const auto crowdElementId = placementAt(position, transform);
     if (!crowdElementId.isEmpty()) {
@@ -2813,6 +2966,12 @@ void ScenarioCanvasWidget::emitRouteGuidancesChanged() {
     }
 }
 
+void ScenarioCanvasWidget::emitEnvironmentHazardsChanged() {
+    if (environmentHazardsChangedHandler_) {
+        environmentHazardsChangedHandler_(environmentHazards_);
+    }
+}
+
 void ScenarioCanvasWidget::repositionToolbars() {
     if (topToolbar_ != nullptr) {
         topToolbar_->setGeometry(0, 0, width(), kTopToolbarHeight);
@@ -2840,6 +2999,12 @@ void ScenarioCanvasWidget::setToolMode(ToolMode mode) {
     }
     if (routeGuidanceToolButton_ != nullptr) {
         routeGuidanceToolButton_->setChecked(mode == ToolMode::RouteGuidance);
+    }
+    if (fireHazardToolButton_ != nullptr) {
+        fireHazardToolButton_->setChecked(mode == ToolMode::FireHazard);
+    }
+    if (smokeHazardToolButton_ != nullptr) {
+        smokeHazardToolButton_->setChecked(mode == ToolMode::SmokeHazard);
     }
     if (groupCountLabel_ != nullptr) {
         groupCountLabel_->setVisible(mode == ToolMode::GroupPlacement);
@@ -2893,6 +3058,8 @@ void ScenarioCanvasWidget::setupToolbars() {
     groupToolButton_ = makeButton(makeToolIcon("group", QColor("#1f5fae")), "Add Occupant Group");
     blockDoorToolButton_ = makeButton(makeToolIcon("block", QColor("#c0392b")), "block door");
     routeGuidanceToolButton_ = makeButton(makeToolIcon("guidance", QColor("#1f5fae")), "Route guidance");
+    fireHazardToolButton_ = makeButton(makeToolIcon("fire", QColor("#c2410c")), "Add Fire Hazard");
+    smokeHazardToolButton_ = makeButton(makeToolIcon("smoke", QColor("#64748b")), "Add Smoke Hazard");
     topLayout->addStretch(1);
 
     groupCountLabel_ = new QLabel("Group count", propertyPanel_);
@@ -2917,6 +3084,8 @@ void ScenarioCanvasWidget::setupToolbars() {
     connect(groupToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::GroupPlacement); });
     connect(blockDoorToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::BlockDoor); });
     connect(routeGuidanceToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::RouteGuidance); });
+    connect(fireHazardToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::FireHazard); });
+    connect(smokeHazardToolButton_, &QToolButton::clicked, this, [this]() { setToolMode(ToolMode::SmokeHazard); });
 
     setToolMode(ToolMode::Select);
     repositionToolbars();

--- a/src/application/ScenarioCanvasWidget.h
+++ b/src/application/ScenarioCanvasWidget.h
@@ -59,6 +59,8 @@ public:
     void setConnectionBlocksChangedHandler(std::function<void(const std::vector<safecrowd::domain::ConnectionBlockDraft>&)> handler);
     void setRouteGuidances(std::vector<safecrowd::domain::RouteGuidanceDraft> guidances);
     void setRouteGuidancesChangedHandler(std::function<void(const std::vector<safecrowd::domain::RouteGuidanceDraft>&)> handler);
+    void setEnvironmentHazards(std::vector<safecrowd::domain::EnvironmentHazardDraft> hazards);
+    void setEnvironmentHazardsChangedHandler(std::function<void(const std::vector<safecrowd::domain::EnvironmentHazardDraft>&)> handler);
     void setLayoutElementActivatedHandler(std::function<void(const QString&)> handler);
     void setCrowdSelectionChangedHandler(std::function<void(const QString&)> handler);
     void focusLayoutElement(const QString& elementId);
@@ -90,6 +92,8 @@ private:
         GroupPlacement,
         BlockDoor,
         RouteGuidance,
+        FireHazard,
+        SmokeHazard,
     };
 
     std::optional<LayoutCanvasBounds> collectBounds() const;
@@ -110,6 +114,7 @@ private:
     QString nextPlacementId(ScenarioCrowdPlacementKind kind) const;
     QString nextConnectionBlockId() const;
     QString nextRouteGuidanceId() const;
+    QString nextEnvironmentHazardId() const;
     void addGroupPlacement(const QPointF& start, const QPointF& end);
     void addIndividualPlacement(const QPointF& position);
     void addConnectionBlock(const QPointF& position);
@@ -117,6 +122,8 @@ private:
     void addRouteGuidance(const QPointF& position);
     void addRouteGuidanceForExitZone(const safecrowd::domain::Zone2D& zone);
     void addRouteGuidanceForConnection(const safecrowd::domain::Connection2D& connection);
+    void addEnvironmentHazard(const QPointF& position, safecrowd::domain::EnvironmentHazardKind kind);
+    void addEnvironmentHazardForZone(const safecrowd::domain::Zone2D& zone, safecrowd::domain::EnvironmentHazardKind kind);
     void openRouteGuidanceEditor(const QString& guidanceId, const QPoint& screenPosition);
     void selectSingleAt(const QPointF& position, const LayoutCanvasTransform& transform);
     void selectPlacementsInRect(const QRectF& screenRect, const LayoutCanvasTransform& transform);
@@ -128,9 +135,11 @@ private:
     void drawFocusedPlacement(QPainter& painter, const LayoutCanvasTransform& transform) const;
     void drawConnectionBlocks(QPainter& painter, const LayoutCanvasTransform& transform) const;
     void drawRouteGuidances(QPainter& painter, const LayoutCanvasTransform& transform) const;
+    void drawEnvironmentHazards(QPainter& painter, const LayoutCanvasTransform& transform) const;
     void emitPlacementsChanged();
     void emitConnectionBlocksChanged();
     void emitRouteGuidancesChanged();
+    void emitEnvironmentHazardsChanged();
     void repositionToolbars();
     void setToolMode(ToolMode mode);
     void setupToolbars();
@@ -139,6 +148,7 @@ private:
     std::vector<ScenarioCrowdPlacement> placements_{};
     std::vector<safecrowd::domain::ConnectionBlockDraft> connectionBlocks_{};
     std::vector<safecrowd::domain::RouteGuidanceDraft> routeGuidances_{};
+    std::vector<safecrowd::domain::EnvironmentHazardDraft> environmentHazards_{};
     QString currentFloorId_{};
     QString focusedLayoutElementId_{};
     QString focusedCrowdElementId_{};
@@ -159,6 +169,8 @@ private:
     QToolButton* groupToolButton_{nullptr};
     QToolButton* blockDoorToolButton_{nullptr};
     QToolButton* routeGuidanceToolButton_{nullptr};
+    QToolButton* fireHazardToolButton_{nullptr};
+    QToolButton* smokeHazardToolButton_{nullptr};
     QLabel* groupCountLabel_{nullptr};
     QSpinBox* groupCountSpinBox_{nullptr};
     QLabel* groupDistributionLabel_{nullptr};
@@ -170,6 +182,7 @@ private:
     std::function<void(const std::vector<ScenarioCrowdPlacement>&)> placementsChangedHandler_{};
     std::function<void(const std::vector<safecrowd::domain::ConnectionBlockDraft>&)> connectionBlocksChangedHandler_{};
     std::function<void(const std::vector<safecrowd::domain::RouteGuidanceDraft>&)> routeGuidancesChangedHandler_{};
+    std::function<void(const std::vector<safecrowd::domain::EnvironmentHazardDraft>&)> environmentHazardsChangedHandler_{};
 };
 
 }  // namespace safecrowd::application

--- a/src/domain/ScenarioAuthoring.cpp
+++ b/src/domain/ScenarioAuthoring.cpp
@@ -58,6 +58,26 @@ bool populationsEqual(const PopulationSpec& lhs, const PopulationSpec& rhs) {
     return true;
 }
 
+bool hazardsEqual(const std::vector<EnvironmentHazardDraft>& lhs,
+                  const std::vector<EnvironmentHazardDraft>& rhs) {
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+    for (std::size_t i = 0; i < lhs.size(); ++i) {
+        if (lhs[i].id != rhs[i].id
+            || lhs[i].kind != rhs[i].kind
+            || lhs[i].name != rhs[i].name
+            || lhs[i].affectedZoneId != rhs[i].affectedZoneId
+            || lhs[i].startSeconds != rhs[i].startSeconds
+            || lhs[i].endSeconds != rhs[i].endSeconds
+            || lhs[i].severity != rhs[i].severity
+            || lhs[i].note != rhs[i].note) {
+            return false;
+        }
+    }
+    return true;
+}
+
 bool eventsEqual(const std::vector<OperationalEventDraft>& lhs,
                  const std::vector<OperationalEventDraft>& rhs) {
     if (lhs.size() != rhs.size()) {
@@ -159,6 +179,9 @@ std::vector<std::string> computeScenarioDiffKeys(const ScenarioDraft& baseline,
     }
     if (baseline.environment.guidanceProfile != variant.environment.guidanceProfile) {
         keys.emplace_back("environment.guidanceProfile");
+    }
+    if (!hazardsEqual(baseline.environment.hazards, variant.environment.hazards)) {
+        keys.emplace_back("environment.hazards");
     }
     if (!eventsEqual(baseline.control.events, variant.control.events)) {
         keys.emplace_back("control.events");

--- a/src/domain/ScenarioAuthoring.h
+++ b/src/domain/ScenarioAuthoring.h
@@ -15,10 +15,33 @@ enum class ScenarioRole {
     Recommended,
 };
 
+enum class EnvironmentHazardKind {
+    Fire,
+    Smoke,
+};
+
+enum class ScenarioElementSeverity {
+    Low,
+    Medium,
+    High,
+};
+
+struct EnvironmentHazardDraft {
+    std::string id{};
+    EnvironmentHazardKind kind{EnvironmentHazardKind::Fire};
+    std::string name{};
+    std::string affectedZoneId{};
+    double startSeconds{0.0};
+    double endSeconds{0.0};
+    ScenarioElementSeverity severity{ScenarioElementSeverity::Medium};
+    std::string note{};
+};
+
 struct EnvironmentState {
     bool reducedVisibility{false};
     std::string familiarityProfile{};
     std::string guidanceProfile{};
+    std::vector<EnvironmentHazardDraft> hazards{};
 };
 
 struct OperationalEventDraft {


### PR DESCRIPTION
## Summary

- Add fire/smoke hazards as v1 scenario input elements on EnvironmentState.
- Persist hazards in project workspace JSON and include them in scenario diff keys.
- Expose Hazards in scenario authoring with canvas toolbar Fire/Smoke tools that place hazards at specific clicked locations, list edit/delete support, and Smoke visibility-context copy.

## Related Issue

- Closes #207

## Area

- [ ] Engine
- [x] Domain
- [x] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction application -> domain -> engine.
- [x] I did not add Qt UI code to src/domain.
- [x] I did not add domain or application dependencies to src/engine.
- [x] I used src/ as the include root.

## Verification

- [x] cmake --preset windows-debug
- [x] cmake --build --preset build-debug
- [x] ctest --preset test-debug
- [ ] Not run (reason below)

All verification commands passed using the Visual Studio bundled CMake/CTest executables because cmake was not on PATH.

## Risks / Follow-up

- Hazards are authoring/persistence inputs only in v1; no fire spread, smoke concentration, FED/FDS, or runtime physics effect is implemented.
