### PR TITLE
[Domain] reduce simulation and replay overhead

### DIFF
--- a/src/application/ScenarioBatchResultWidget.cpp
+++ b/src/application/ScenarioBatchResultWidget.cpp
@@ -990,28 +990,12 @@ void ScenarioBatchResultWidget::applyReplayFrameData(const safecrowd::domain::Si
     if (results_.empty() || currentResultIndex_ < 0 || currentResultIndex_ >= static_cast<int>(results_.size())) {
         return;
     }
-    const auto& result = results_[static_cast<std::size_t>(currentResultIndex_)];
     replayFrameIndex_ = replayFrames_.empty()
         ? 0
         : std::clamp(sliderIndex, 0, static_cast<int>(replayFrames_.size()) - 1);
 
     if (canvas_ != nullptr) {
-        canvas_->setConnectionBlocks(result.scenario.control.connectionBlocks);
-        canvas_->setEnvironmentHazards(result.scenario.environment.hazards);
         canvas_->setFrame(frame);
-        canvas_->setHotspotOverlay(result.risk.hotspots);
-        canvas_->setBottleneckOverlay(result.risk.bottlenecks);
-        canvas_->setDensityOverlay(result.artifacts.densitySummary.peakField.cells.empty()
-            ? result.artifacts.densitySummary.peakCells
-            : result.artifacts.densitySummary.peakField.cells,
-            result.artifacts.densitySummary.highDensityThresholdPeoplePerSquareMeter);
-        canvas_->setPressureOverlay(result.artifacts.pressureSummary.peakField.cells.empty()
-            ? result.artifacts.pressureSummary.peakCells
-            : result.artifacts.pressureSummary.peakField.cells,
-            std::max(
-                result.artifacts.pressureSummary.hotspotScoreThreshold,
-                result.artifacts.pressureSummary.peakPressureScore));
-        applyOverlayModeToCanvas();
     }
     if (replaySlider_ != nullptr && replaySlider_->value() != replayFrameIndex_) {
         const QSignalBlocker blocker(replaySlider_);
@@ -1029,6 +1013,34 @@ void ScenarioBatchResultWidget::applyReplayFrameData(const safecrowd::domain::Si
             .arg(frame.elapsedSeconds, 0, 'f', 1)
             .arg(totalSeconds, 0, 'f', 1));
     }
+}
+
+void ScenarioBatchResultWidget::applySelectedResultStaticCanvasState() {
+    if (canvas_ == nullptr
+        || results_.empty()
+        || currentResultIndex_ < 0
+        || currentResultIndex_ >= static_cast<int>(results_.size())) {
+        return;
+    }
+
+    const auto& result = results_[static_cast<std::size_t>(currentResultIndex_)];
+    canvas_->setConnectionBlocks(result.scenario.control.connectionBlocks);
+    canvas_->setEnvironmentHazards(result.scenario.environment.hazards);
+    canvas_->setHotspotOverlay(result.risk.hotspots);
+    canvas_->setBottleneckOverlay(result.risk.bottlenecks);
+    canvas_->setDensityOverlay(
+        result.artifacts.densitySummary.peakField.cells.empty()
+            ? result.artifacts.densitySummary.peakCells
+            : result.artifacts.densitySummary.peakField.cells,
+        result.artifacts.densitySummary.highDensityThresholdPeoplePerSquareMeter);
+    canvas_->setPressureOverlay(
+        result.artifacts.pressureSummary.peakField.cells.empty()
+            ? result.artifacts.pressureSummary.peakCells
+            : result.artifacts.pressureSummary.peakField.cells,
+        std::max(
+            result.artifacts.pressureSummary.hotspotScoreThreshold,
+            result.artifacts.pressureSummary.peakPressureScore));
+    applyOverlayModeToCanvas();
 }
 
 void ScenarioBatchResultWidget::applyOverlayModeToCanvas() {
@@ -1125,6 +1137,7 @@ void ScenarioBatchResultWidget::loadReplayForSelectedResult() {
         replayFrames_.clear();
         return;
     }
+    applySelectedResultStaticCanvasState();
     replayFrames_ = replayFramesForResult(results_[static_cast<std::size_t>(currentResultIndex_)]);
     replayFrameIndex_ = replayFrames_.empty() ? 0 : static_cast<int>(replayFrames_.size()) - 1;
     if (replaySlider_ != nullptr) {

--- a/src/application/ScenarioBatchResultWidget.h
+++ b/src/application/ScenarioBatchResultWidget.h
@@ -59,6 +59,7 @@ private:
     void applyReplayFrame(int frameIndex);
     void applyReplayFrameData(const safecrowd::domain::SimulationFrame& frame, int sliderIndex);
     void applyOverlayModeToCanvas();
+    void applySelectedResultStaticCanvasState();
     void loadReplayForSelectedResult();
     int nearestReplayFrameIndex(double seconds) const;
     void navigateToAuthoring();

--- a/src/application/SimulationCanvasWidget.cpp
+++ b/src/application/SimulationCanvasWidget.cpp
@@ -544,6 +544,7 @@ void SimulationCanvasWidget::setDensityOverlay(
         std::isfinite(scaleMaxPeoplePerSquareMeter) && scaleMaxPeoplePerSquareMeter > 0.0
         ? scaleMaxPeoplePerSquareMeter
         : kDefaultDensityScaleMaxPeoplePerSquareMeter;
+    invalidateOverlayCache();
     update();
 }
 
@@ -555,6 +556,7 @@ void SimulationCanvasWidget::setPressureOverlay(
         std::isfinite(scaleMaxPressureScore) && scaleMaxPressureScore > 0.0
         ? scaleMaxPressureScore
         : kDefaultPressureScaleMaxScore;
+    invalidateOverlayCache();
     update();
 }
 
@@ -563,6 +565,7 @@ void SimulationCanvasWidget::setHotspotOverlay(std::vector<safecrowd::domain::Sc
     if (focusedHotspotIndex_.has_value() && *focusedHotspotIndex_ >= hotspotOverlay_.size()) {
         focusedHotspotIndex_.reset();
     }
+    invalidateOverlayCache();
     update();
 }
 
@@ -571,11 +574,16 @@ void SimulationCanvasWidget::setBottleneckOverlay(std::vector<safecrowd::domain:
     if (focusedBottleneckIndex_.has_value() && *focusedBottleneckIndex_ >= bottleneckOverlay_.size()) {
         focusedBottleneckIndex_.reset();
     }
+    invalidateOverlayCache();
     update();
 }
 
 void SimulationCanvasWidget::setResultOverlayMode(ResultOverlayMode mode) {
+    if (overlayMode_ == mode) {
+        return;
+    }
     overlayMode_ = mode;
+    invalidateOverlayCache();
     update();
 }
 
@@ -589,6 +597,7 @@ void SimulationCanvasWidget::focusHotspot(std::size_t index) {
     }
     focusedHotspotIndex_ = index;
     focusedBottleneckIndex_.reset();
+    invalidateOverlayCache();
     focusWorldPoint(hotspotOverlay_[index].center, std::max(camera_.zoom(), kHotspotFocusZoom));
 }
 
@@ -603,6 +612,7 @@ void SimulationCanvasWidget::focusBottleneck(std::size_t index) {
     }
     focusedBottleneckIndex_ = index;
     focusedHotspotIndex_.reset();
+    invalidateOverlayCache();
     focusWorldPoint(
         {.x = (passage.start.x + passage.end.x) / 2.0, .y = (passage.start.y + passage.end.y) / 2.0},
         std::max(camera_.zoom(), kBottleneckFocusZoom));
@@ -640,6 +650,7 @@ void SimulationCanvasWidget::mouseDoubleClickEvent(QMouseEvent* event) {
     if (event->button() == Qt::LeftButton) {
         camera_.reset();
         layoutCacheValid_ = false;
+        invalidateOverlayCache();
         update();
         event->accept();
         return;
@@ -658,6 +669,7 @@ void SimulationCanvasWidget::mouseMoveEvent(QMouseEvent* event) {
             QToolTip::hideText();
         }
         layoutCacheValid_ = false;
+        invalidateOverlayCache();
         update();
         return;
     }
@@ -807,14 +819,9 @@ void SimulationCanvasWidget::paintEvent(QPaintEvent* event) {
     painter.drawPixmap(0, 0, layoutCache_);
 
     const auto transform = currentTransform(*bounds);
-    if (overlayMode_ == ResultOverlayMode::Density) {
-        drawDensityOverlay(painter, transform);
-    } else if (overlayMode_ == ResultOverlayMode::Pressure) {
-        drawPressureOverlay(painter, transform);
-    } else if (overlayMode_ == ResultOverlayMode::Hotspots) {
-        drawHotspotOverlay(painter, transform);
-    } else if (overlayMode_ == ResultOverlayMode::Bottlenecks) {
-        drawBottleneckOverlay(painter, transform);
+    refreshOverlayCache(*bounds);
+    if (!overlayCache_.isNull()) {
+        painter.drawPixmap(0, 0, overlayCache_);
     }
     drawEnvironmentHazardOverlay(painter, transform);
     drawConnectionBlockOverlay(painter, transform);
@@ -847,6 +854,7 @@ void SimulationCanvasWidget::wheelEvent(QWheelEvent* event) {
     }
     if (camera_.zoomAt(event, *bounds, previewViewport())) {
         layoutCacheValid_ = false;
+        invalidateOverlayCache();
         update();
         return;
     }
@@ -901,6 +909,69 @@ void SimulationCanvasWidget::refreshLayoutCache(const LayoutCanvasBounds& bounds
     layoutCacheValid_ = true;
 }
 
+void SimulationCanvasWidget::refreshOverlayCache(const LayoutCanvasBounds& bounds) {
+    if (overlayMode_ == ResultOverlayMode::None) {
+        overlayCache_ = QPixmap();
+        overlayCacheValid_ = true;
+        overlayCacheMode_ = overlayMode_;
+        overlayCacheFloorId_ = currentFloorId_;
+        return;
+    }
+
+    const auto currentSize = size();
+    if (currentSize.isEmpty()) {
+        overlayCache_ = QPixmap();
+        overlayCacheSize_ = currentSize;
+        overlayCacheDevicePixelRatio_ = 0.0;
+        overlayCacheValid_ = false;
+        return;
+    }
+
+    const auto devicePixelRatio = devicePixelRatioF();
+    if (overlayCacheValid_
+        && overlayCacheSize_ == currentSize
+        && overlayCacheDevicePixelRatio_ == devicePixelRatio
+        && overlayCacheZoom_ == camera_.zoom()
+        && overlayCachePan_ == camera_.panOffset()
+        && overlayCacheMode_ == overlayMode_
+        && overlayCacheFloorId_ == currentFloorId_) {
+        return;
+    }
+
+    const QSize physicalSize{
+        std::max(1, static_cast<int>(std::ceil(currentSize.width() * devicePixelRatio))),
+        std::max(1, static_cast<int>(std::ceil(currentSize.height() * devicePixelRatio))),
+    };
+    overlayCache_ = QPixmap(physicalSize);
+    overlayCache_.setDevicePixelRatio(devicePixelRatio);
+    overlayCache_.fill(Qt::transparent);
+
+    QPainter painter(&overlayCache_);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    const auto transform = currentTransform(bounds);
+    if (overlayMode_ == ResultOverlayMode::Density) {
+        drawDensityOverlay(painter, transform);
+    } else if (overlayMode_ == ResultOverlayMode::Pressure) {
+        drawPressureOverlay(painter, transform);
+    } else if (overlayMode_ == ResultOverlayMode::Hotspots) {
+        drawHotspotOverlay(painter, transform);
+    } else if (overlayMode_ == ResultOverlayMode::Bottlenecks) {
+        drawBottleneckOverlay(painter, transform);
+    }
+
+    overlayCacheSize_ = currentSize;
+    overlayCacheZoom_ = camera_.zoom();
+    overlayCachePan_ = camera_.panOffset();
+    overlayCacheDevicePixelRatio_ = devicePixelRatio;
+    overlayCacheMode_ = overlayMode_;
+    overlayCacheFloorId_ = currentFloorId_;
+    overlayCacheValid_ = true;
+}
+
+void SimulationCanvasWidget::invalidateOverlayCache() {
+    overlayCacheValid_ = false;
+}
+
 QRectF SimulationCanvasWidget::previewViewport() const {
     return QRectF(rect()).adjusted(kViewportPadding, kViewportPadding, -kViewportPadding, -kViewportPadding);
 }
@@ -922,6 +993,7 @@ void SimulationCanvasWidget::focusWorldPoint(const safecrowd::domain::Point2D& p
     const LayoutCanvasTransform transform(*bounds, viewport, camera_.zoom(), {});
     camera_.setPanOffset(viewport.center() - transform.map(point));
     layoutCacheValid_ = false;
+    invalidateOverlayCache();
     update();
 }
 
@@ -1404,6 +1476,7 @@ void SimulationCanvasWidget::setCurrentFloorId(std::string floorId, bool manualS
     manualFloorSelection_ = manualSelection;
     layoutBounds_ = collectLayoutCanvasBounds(layout_, currentFloorId_);
     layoutCacheValid_ = false;
+    invalidateOverlayCache();
     camera_.reset();
 
     if (floorComboBox_ != nullptr) {

--- a/src/application/SimulationCanvasWidget.h
+++ b/src/application/SimulationCanvasWidget.h
@@ -73,6 +73,8 @@ private:
     std::optional<LayoutCanvasBounds> collectBounds() const;
     LayoutCanvasTransform currentTransform(const LayoutCanvasBounds& bounds) const;
     void refreshLayoutCache(const LayoutCanvasBounds& bounds);
+    void refreshOverlayCache(const LayoutCanvasBounds& bounds);
+    void invalidateOverlayCache();
     QRectF previewViewport() const;
     void focusWorldPoint(const safecrowd::domain::Point2D& point, double zoom);
     void drawConnectionBlockOverlay(QPainter& painter, const LayoutCanvasTransform& transform) const;
@@ -113,6 +115,14 @@ private:
     double layoutCacheZoom_{0.0};
     double layoutCacheDevicePixelRatio_{0.0};
     bool layoutCacheValid_{false};
+    QPixmap overlayCache_{};
+    QSize overlayCacheSize_{};
+    QPointF overlayCachePan_{};
+    double overlayCacheZoom_{0.0};
+    double overlayCacheDevicePixelRatio_{0.0};
+    ResultOverlayMode overlayCacheMode_{ResultOverlayMode::None};
+    std::string overlayCacheFloorId_{};
+    bool overlayCacheValid_{false};
 
     std::string hoveredConnectionBlockId_{};
     std::string hoveredEnvironmentHazardId_{};

--- a/src/domain/CompressionSystem.cpp
+++ b/src/domain/CompressionSystem.cpp
@@ -4,15 +4,24 @@
 #include "domain/FacilityLayout2D.h"
 #include "domain/Metrics.h"
 #include "domain/PressureTuning.h"
+#include "domain/ScenarioSimulationInternal.h"
+#include "domain/ScenarioSimulationSystems.h"
 
 #include <algorithm>
 #include <cmath>
+#include <unordered_map>
+#include <vector>
 
 namespace safecrowd::domain {
 namespace {
 
 constexpr double kPi = 3.14159265358979323846;
 constexpr double kReferenceDistanceMeters = kPressureReferenceDistanceMeters;
+
+struct SpatialCell {
+    int x{0};
+    int y{0};
+};
 
 double distanceBetween(const Point2D& lhs, const Point2D& rhs) {
     const double dx = lhs.x - rhs.x;
@@ -72,6 +81,18 @@ double localDensityRatio(std::size_t nearbyCount) {
     return densityPeoplePerSquareMeter / kPressureHighDensityThresholdPeoplePerSquareMeter;
 }
 
+long long spatialKey(const SpatialCell& cell) {
+    return (static_cast<long long>(cell.x) << 32)
+        ^ static_cast<unsigned int>(cell.y);
+}
+
+SpatialCell spatialCellFor(const Point2D& point, double cellSize) {
+    return {
+        .x = static_cast<int>(std::floor(point.x / cellSize)),
+        .y = static_cast<int>(std::floor(point.y / cellSize)),
+    };
+}
+
 }  // namespace
 
 CompressionSystem::CompressionSystem(double timeStepSeconds)
@@ -83,8 +104,20 @@ void CompressionSystem::update(engine::EngineWorld& world,
     (void)step;
 
     auto& query = world.query();
+    auto& resources = world.resources();
     const auto agentEntities = query.view<Position, Agent, CompressionData>();
     const auto barrierEntities = query.view<Barrier2D>();
+    const auto* spatialIndex = resources.contains<ScenarioAgentSpatialIndexResource>()
+        ? &resources.get<ScenarioAgentSpatialIndexResource>()
+        : nullptr;
+    std::unordered_map<long long, std::vector<engine::Entity>> agentCells;
+    if (spatialIndex == nullptr) {
+        agentCells.reserve(agentEntities.size());
+        for (const auto entity : agentEntities) {
+            const auto& position = query.get<Position>(entity);
+            agentCells[spatialKey(spatialCellFor(position.value, kReferenceDistanceMeters))].push_back(entity);
+        }
+    }
 
     for (const auto entity : agentEntities) {
         const auto& position = query.get<Position>(entity);
@@ -92,17 +125,52 @@ void CompressionSystem::update(engine::EngineWorld& world,
 
         std::size_t nearbyCount = 0;
         double proximityScore = 0.0;
+        if (spatialIndex != nullptr) {
+            const auto floorId = query.contains<EvacuationRoute>(entity)
+                ? simulation_internal::agentCollisionFloorId(query.get<EvacuationRoute>(entity))
+                : std::string{};
+            const auto nearbyAgents = scenarioNearbyAgents(
+                query,
+                *spatialIndex,
+                position.value,
+                floorId,
+                kReferenceDistanceMeters);
+            for (const auto otherEntity : nearbyAgents) {
+                if (otherEntity == entity) {
+                    continue;
+                }
 
-        for (const auto otherEntity : agentEntities) {
-            if (otherEntity == entity) {
-                continue;
+                const auto& otherPosition = query.get<Position>(otherEntity);
+                const double distance = distanceBetween(position.value, otherPosition.value);
+                if (distance < kReferenceDistanceMeters) {
+                    proximityScore += (kReferenceDistanceMeters - distance) / kReferenceDistanceMeters;
+                    ++nearbyCount;
+                }
             }
+        } else {
+            const auto centerCell = spatialCellFor(position.value, kReferenceDistanceMeters);
+            for (int dy = -1; dy <= 1; ++dy) {
+                for (int dx = -1; dx <= 1; ++dx) {
+                    const auto cellIt = agentCells.find(spatialKey({
+                        .x = centerCell.x + dx,
+                        .y = centerCell.y + dy,
+                    }));
+                    if (cellIt == agentCells.end()) {
+                        continue;
+                    }
+                    for (const auto otherEntity : cellIt->second) {
+                        if (otherEntity == entity) {
+                            continue;
+                        }
 
-            const auto& otherPosition = query.get<Position>(otherEntity);
-            const double distance = distanceBetween(position.value, otherPosition.value);
-            if (distance < kReferenceDistanceMeters) {
-                proximityScore += (kReferenceDistanceMeters - distance) / kReferenceDistanceMeters;
-                ++nearbyCount;
+                        const auto& otherPosition = query.get<Position>(otherEntity);
+                        const double distance = distanceBetween(position.value, otherPosition.value);
+                        if (distance < kReferenceDistanceMeters) {
+                            proximityScore += (kReferenceDistanceMeters - distance) / kReferenceDistanceMeters;
+                            ++nearbyCount;
+                        }
+                    }
+                }
             }
         }
 

--- a/src/domain/ScenarioRiskMetricsSystem.cpp
+++ b/src/domain/ScenarioRiskMetricsSystem.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -254,6 +255,63 @@ double barrierCompression(const Barrier2D& barrier, const Point2D& position, dou
         }
     }
     return force;
+}
+
+ScenarioAgentSpatialIndexResource buildDisplayFloorPressureIndex(
+    const std::vector<ActiveAgentContext>& activeAgents,
+    const FacilityLayout2D& layout) {
+    ScenarioAgentSpatialIndexResource index;
+    index.cellSize = kPressureReferenceDistanceMeters;
+    index.displayCellsByFloor.reserve(4);
+    for (const auto& agent : activeAgents) {
+        const auto cellKey = spatialKey(spatialCellFor(agent.position, index.cellSize));
+        index.displayCellsByFloor[agent.floorId][cellKey].push_back(agent.entity);
+    }
+    index.barrierIndicesByFloor.reserve(std::max<std::size_t>(1, layout.floors.size()));
+    for (std::size_t barrierIndex = 0; barrierIndex < layout.barriers.size(); ++barrierIndex) {
+        const auto& barrier = layout.barriers[barrierIndex];
+        if (!barrier.blocksMovement || barrier.geometry.vertices.size() < 2) {
+            continue;
+        }
+
+        const auto& vertices = barrier.geometry.vertices;
+        auto insertCoverage = [&](const Point2D& minPoint, const Point2D& maxPoint) {
+            const auto minCell = spatialCellFor(minPoint, index.cellSize);
+            const auto maxCell = spatialCellFor(maxPoint, index.cellSize);
+            auto& floorCells = index.barrierIndicesByFloor[barrier.floorId];
+            for (int y = minCell.y; y <= maxCell.y; ++y) {
+                for (int x = minCell.x; x <= maxCell.x; ++x) {
+                    floorCells[spatialKey({.x = x, .y = y})].push_back(barrierIndex);
+                }
+            }
+        };
+
+        for (std::size_t vertexIndex = 0; vertexIndex + 1 < vertices.size(); ++vertexIndex) {
+            insertCoverage(
+                {
+                    .x = std::min(vertices[vertexIndex].x, vertices[vertexIndex + 1].x),
+                    .y = std::min(vertices[vertexIndex].y, vertices[vertexIndex + 1].y),
+                },
+                {
+                    .x = std::max(vertices[vertexIndex].x, vertices[vertexIndex + 1].x),
+                    .y = std::max(vertices[vertexIndex].y, vertices[vertexIndex + 1].y),
+                });
+        }
+        if (barrier.geometry.closed) {
+            auto minX = vertices.front().x;
+            auto minY = vertices.front().y;
+            auto maxX = vertices.front().x;
+            auto maxY = vertices.front().y;
+            for (const auto& vertex : vertices) {
+                minX = std::min(minX, vertex.x);
+                minY = std::min(minY, vertex.y);
+                maxX = std::max(maxX, vertex.x);
+                maxY = std::max(maxY, vertex.y);
+            }
+            insertCoverage({.x = minX, .y = minY}, {.x = maxX, .y = maxY});
+        }
+    }
+    return index;
 }
 
 double localDensityRatio(std::size_t nearbyCount) {
@@ -533,12 +591,17 @@ public:
                     forces[index] += combinedRadius - distance;
                 }
 
-                for (const auto& barrier : activeLayout.barriers) {
-                    if (!barrierMatchesFloor(barrier, activeAgents[index].collisionFloorId)) {
+                for (const auto* barrier : scenarioNearbyBarriers(
+                         activeLayout,
+                         *spatialIndex,
+                         activeAgents[index].position,
+                         activeAgents[index].collisionFloorId,
+                         activeAgents[index].radius)) {
+                    if (barrier == nullptr) {
                         continue;
                     }
                     forces[index] += barrierCompression(
-                        barrier,
+                        *barrier,
                         activeAgents[index].position,
                         activeAgents[index].radius);
                 }
@@ -678,6 +741,15 @@ public:
             cell.entities.push_back(entity);
         }
 
+        std::optional<ScenarioAgentSpatialIndexResource> fallbackPressureIndex;
+        const auto* pressureIndex = resources.contains<ScenarioAgentSpatialIndexResource>()
+            ? &resources.get<ScenarioAgentSpatialIndexResource>()
+            : nullptr;
+        if (pressureIndex == nullptr) {
+            fallbackPressureIndex = buildDisplayFloorPressureIndex(activeAgents, activeLayout);
+            pressureIndex = &*fallbackPressureIndex;
+        }
+
         ScenarioSimulationClockResource clock;
         if (resources.contains<ScenarioSimulationClockResource>()) {
             clock = resources.get<ScenarioSimulationClockResource>();
@@ -687,6 +759,7 @@ public:
             snapshot,
             activeLayout,
             activeAgents,
+            *pressureIndex,
             clock.elapsedSeconds,
             pressureTracking);
 
@@ -773,6 +846,7 @@ private:
         ScenarioRiskSnapshot& snapshot,
         const FacilityLayout2D& layout,
         const std::vector<ActiveAgentContext>& activeAgents,
+        const ScenarioAgentSpatialIndexResource& spatialIndex,
         double elapsedSeconds,
         ScenarioPressureTrackingResource& tracking) const {
         const auto deltaSeconds = tracking.hasPreviousElapsedSeconds
@@ -781,38 +855,77 @@ private:
         tracking.previousElapsedSeconds = elapsedSeconds;
         tracking.hasPreviousElapsedSeconds = true;
 
+        std::unordered_map<std::uint64_t, std::size_t> activeAgentIndices;
+        activeAgentIndices.reserve(activeAgents.size());
+        for (std::size_t index = 0; index < activeAgents.size(); ++index) {
+            activeAgentIndices.emplace(activeAgents[index].agentId, index);
+        }
+
         std::vector<double> proximityForces(activeAgents.size(), 0.0);
         std::vector<std::size_t> nearbyCounts(activeAgents.size(), 0);
+        const auto probeRange = std::max(1, static_cast<int>(std::ceil(
+            kPressureReferenceDistanceMeters / std::max(0.1, spatialIndex.cellSize))));
         for (std::size_t lhsIndex = 0; lhsIndex < activeAgents.size(); ++lhsIndex) {
-            for (std::size_t rhsIndex = lhsIndex + 1; rhsIndex < activeAgents.size(); ++rhsIndex) {
-                if (activeAgents[lhsIndex].floorId != activeAgents[rhsIndex].floorId) {
-                    continue;
-                }
-                const auto distance = distanceBetween(activeAgents[lhsIndex].position, activeAgents[rhsIndex].position);
-                if (distance >= kPressureReferenceDistanceMeters) {
-                    continue;
-                }
+            const auto& lhsAgent = activeAgents[lhsIndex];
+            const auto floorIt = spatialIndex.displayCellsByFloor.find(lhsAgent.floorId);
+            if (floorIt == spatialIndex.displayCellsByFloor.end()) {
+                continue;
+            }
 
-                const auto proximityScore =
-                    (kPressureReferenceDistanceMeters - distance) / kPressureReferenceDistanceMeters;
-                proximityForces[lhsIndex] += proximityScore;
-                proximityForces[rhsIndex] += proximityScore;
-                ++nearbyCounts[lhsIndex];
-                ++nearbyCounts[rhsIndex];
+            const auto centerCell = spatialCellFor(lhsAgent.position, spatialIndex.cellSize);
+            for (int dy = -probeRange; dy <= probeRange; ++dy) {
+                for (int dx = -probeRange; dx <= probeRange; ++dx) {
+                    const auto cellIt = floorIt->second.find(spatialKey({
+                        .x = centerCell.x + dx,
+                        .y = centerCell.y + dy,
+                    }));
+                    if (cellIt == floorIt->second.end()) {
+                        continue;
+                    }
+
+                    for (const auto rhsEntity : cellIt->second) {
+                        const auto rhsIndexIt = activeAgentIndices.find(rhsEntity.index);
+                        if (rhsIndexIt == activeAgentIndices.end()) {
+                            continue;
+                        }
+                        const auto rhsIndex = rhsIndexIt->second;
+                        if (rhsIndex <= lhsIndex) {
+                            continue;
+                        }
+
+                        const auto& rhsAgent = activeAgents[rhsIndex];
+                        const auto distance = distanceBetween(lhsAgent.position, rhsAgent.position);
+                        if (distance >= kPressureReferenceDistanceMeters) {
+                            continue;
+                        }
+
+                        const auto proximityScore =
+                            (kPressureReferenceDistanceMeters - distance) / kPressureReferenceDistanceMeters;
+                        proximityForces[lhsIndex] += proximityScore;
+                        proximityForces[rhsIndex] += proximityScore;
+                        ++nearbyCounts[lhsIndex];
+                        ++nearbyCounts[rhsIndex];
+                    }
+                }
             }
         }
 
         std::vector<double> forces(activeAgents.size(), 0.0);
         for (std::size_t index = 0; index < activeAgents.size(); ++index) {
             forces[index] = std::max(proximityForces[index], localDensityRatio(nearbyCounts[index]));
-            for (const auto& barrier : layout.barriers) {
-                if (!barrierMatchesFloor(barrier, activeAgents[index].floorId)) {
+            for (const auto* barrier : scenarioNearbyBarriers(
+                     layout,
+                     spatialIndex,
+                     activeAgents[index].position,
+                     activeAgents[index].floorId,
+                     kPressureReferenceDistanceMeters)) {
+                if (barrier == nullptr) {
                     continue;
                 }
                 forces[index] = std::max(
                     forces[index],
                     proximityForces[index] + barrierCompression(
-                        barrier,
+                        *barrier,
                         activeAgents[index].position,
                         kPressureReferenceDistanceMeters));
             }

--- a/src/domain/ScenarioSimulationInternal.cpp
+++ b/src/domain/ScenarioSimulationInternal.cpp
@@ -1302,7 +1302,7 @@ Point2D forwardPreservingAgentAvoidanceVelocity(
 }
 
 Point2D barrierSeparationVelocity(
-    const FacilityLayout2D& layout,
+    const std::vector<const Barrier2D*>& barriers,
     const Position& position,
     const Agent& agent,
     double referenceSpeed) {
@@ -1310,12 +1310,12 @@ Point2D barrierSeparationVelocity(
     const auto keepoutDistance = static_cast<double>(agent.radius) + kBarrierAvoidanceBuffer;
     const auto separationSpeed = std::max(0.0, referenceSpeed);
 
-    for (const auto& barrier : layout.barriers) {
-        if (!barrier.blocksMovement || barrier.geometry.vertices.size() < 2) {
+    for (const auto* barrier : barriers) {
+        if (barrier == nullptr || !barrier->blocksMovement || barrier->geometry.vertices.size() < 2) {
             continue;
         }
 
-        const auto& vertices = barrier.geometry.vertices;
+        const auto& vertices = barrier->geometry.vertices;
         for (std::size_t index = 0; index + 1 < vertices.size(); ++index) {
             const auto closest = closestPointOnSegment(position.value, vertices[index], vertices[index + 1]);
             const auto delta = position.value - closest;
@@ -1327,7 +1327,7 @@ Point2D barrierSeparationVelocity(
             }
         }
 
-        if (barrier.geometry.closed) {
+        if (barrier->geometry.closed) {
             const auto closest = closestPointOnSegment(position.value, vertices.back(), vertices.front());
             const auto delta = position.value - closest;
             const auto distance = lengthOf(delta);
@@ -1340,6 +1340,19 @@ Point2D barrierSeparationVelocity(
     }
 
     return correction;
+}
+
+Point2D barrierSeparationVelocity(
+    const FacilityLayout2D& layout,
+    const Position& position,
+    const Agent& agent,
+    double referenceSpeed) {
+    std::vector<const Barrier2D*> barriers;
+    barriers.reserve(layout.barriers.size());
+    for (const auto& barrier : layout.barriers) {
+        barriers.push_back(&barrier);
+    }
+    return barrierSeparationVelocity(barriers, position, agent, referenceSpeed);
 }
 
 bool movementCrossesBarrier(const FacilityLayout2D& layout, const Point2D& from, const Point2D& to) {
@@ -1477,7 +1490,11 @@ bool nearlySamePoint(const Point2D& lhs, const Point2D& rhs) {
     return distanceBetween(lhs, rhs) <= 1e-6;
 }
 
-std::vector<Point2D> buildVisibilityPath(const FacilityLayout2D& layout, const Point2D& start, const Point2D& goal, double clearance) {
+std::vector<Point2D> buildVisibilityPath(
+    const FacilityLayout2D& layout,
+    const Point2D& start,
+    const Point2D& goal,
+    double clearance) {
     std::vector<VisibilityNode> nodes;
     nodes.push_back({.point = start});
     nodes.push_back({.point = goal});

--- a/src/domain/ScenarioSimulationInternal.h
+++ b/src/domain/ScenarioSimulationInternal.h
@@ -188,6 +188,11 @@ Point2D barrierSeparationVelocity(
     const Position& position,
     const Agent& agent,
     double referenceSpeed);
+Point2D barrierSeparationVelocity(
+    const std::vector<const Barrier2D*>& barriers,
+    const Position& position,
+    const Agent& agent,
+    double referenceSpeed);
 bool movementCrossesBarrier(const FacilityLayout2D& layout, const Point2D& from, const Point2D& to);
 bool lineOfSightClear(const FacilityLayout2D& layout, const Point2D& from, const Point2D& to, double clearance);
 std::vector<Point2D> buildPath(const FacilityLayout2D& layout, const Point2D& start, const Point2D& goal, double clearance);

--- a/src/domain/ScenarioSimulationMotionSystem.cpp
+++ b/src/domain/ScenarioSimulationMotionSystem.cpp
@@ -71,6 +71,9 @@ public:
         const auto* activeHazards = resources.contains<ScenarioActiveEnvironmentHazardsResource>()
             ? &resources.get<ScenarioActiveEnvironmentHazardsResource>()
             : nullptr;
+        const auto* sharedSpatialIndex = resources.contains<ScenarioAgentSpatialIndexResource>()
+            ? &resources.get<ScenarioAgentSpatialIndexResource>()
+            : nullptr;
 
         applyRouteGuidance(query, entities, layoutCache, clock.elapsedSeconds, step.derivedSeed);
         advanceRoutesForCurrentZones(query, entities, layoutCache);
@@ -79,7 +82,10 @@ public:
         replanBlockedRouteSegments(query, entities, layoutCache, clock.elapsedSeconds, layoutRevision);
         replanHazardAwareExitRoutes(query, entities, layoutCache, clock.elapsedSeconds, reactions, activeHazards);
         updateAgentPhysicsFloorIds(query, layoutCache, entities);
-        const auto localNeighborIndex = buildAgentSpatialIndex(query, entities, 1.0);
+        std::optional<AgentSpatialIndex> localNeighborIndex;
+        if (sharedSpatialIndex == nullptr) {
+            localNeighborIndex = buildAgentSpatialIndex(query, entities, 1.0);
+        }
         const auto* pressureFeedback = resources.contains<ScenarioPressureFeedbackResource>()
             ? &resources.get<ScenarioPressureFeedbackResource>()
             : nullptr;
@@ -234,8 +240,19 @@ public:
                 static_cast<double>(agent.radius) + kDefaultAgentRadius + kPersonalSpaceBuffer,
                 kHeadOnLookAheadDistance);
             const auto collisionFloorId = agentCollisionFloorId(route);
-            const auto neighborCandidates =
-                nearbyAgents(query, localNeighborIndex, position.value, collisionFloorId, neighborRadius);
+            const auto neighborCandidates = sharedSpatialIndex != nullptr
+                ? scenarioNearbyAgents(
+                    query,
+                    *sharedSpatialIndex,
+                    position.value,
+                    collisionFloorId,
+                    neighborRadius)
+                : nearbyAgents(
+                    query,
+                    *localNeighborIndex,
+                    position.value,
+                    collisionFloorId,
+                    neighborRadius);
             const auto avoidanceVelocity =
                 forwardPreservingAgentAvoidanceVelocity(
                     query,
@@ -248,14 +265,25 @@ public:
             const auto barrierReferenceSpeed = std::max(
                 adjustedHazardMaxSpeed,
                 (static_cast<double>(agent.maxSpeed) * 0.75) * pressureSpeedFactor);
-            const auto barrierVelocity =
-                barrierSeparationVelocity(floorLayout, position, agent, barrierReferenceSpeed)
-                * pressureBarrierScale;
+            const auto barrierVelocity = sharedSpatialIndex != nullptr
+                ? barrierSeparationVelocity(
+                    scenarioNearbyBarriers(
+                        layoutCache.layout,
+                        *sharedSpatialIndex,
+                        position.value,
+                        route.currentFloorId,
+                        static_cast<double>(agent.radius) + kBarrierAvoidanceBuffer),
+                    position,
+                    agent,
+                    barrierReferenceSpeed)
+                : barrierSeparationVelocity(floorLayout, position, agent, barrierReferenceSpeed);
+            const auto scaledBarrierVelocity = barrierVelocity * pressureBarrierScale;
             const auto hazardAvoidanceVelocity =
                 hazardState == nullptr
                 ? Point2D{}
                 : hazardAvoidanceVelocityFor(*hazardState, position.value, routeDirection, adjustedHazardMaxSpeed);
-            auto finalVelocity = (desiredVelocity * speedScale) + avoidanceVelocity + barrierVelocity + hazardAvoidanceVelocity;
+            auto finalVelocity =
+                (desiredVelocity * speedScale) + avoidanceVelocity + scaledBarrierVelocity + hazardAvoidanceVelocity;
             const auto lateral = perpendicularLeft(routeDirection);
             if (dot(finalVelocity, routeDirection) < 0.0) {
                 finalVelocity = (routeDirection * (adjustedHazardMaxSpeed * 0.15))
@@ -268,7 +296,7 @@ public:
                 finalVelocity = (routeDirection * std::max(0.0, forwardComponent))
                     + (lateral * std::clamp(lateralComponent, -maxLateralComponent, maxLateralComponent));
             }
-            finalVelocity = velocityWithBarrierEscape(finalVelocity, barrierVelocity, adjustedHazardMaxSpeed);
+            finalVelocity = velocityWithBarrierEscape(finalVelocity, scaledBarrierVelocity, adjustedHazardMaxSpeed);
             plans.push_back({
                 .entity = entity,
                 .velocity = clampedToLength(finalVelocity, adjustedHazardMaxSpeed),

--- a/src/domain/ScenarioSimulationSystems.cpp
+++ b/src/domain/ScenarioSimulationSystems.cpp
@@ -81,6 +81,127 @@ Point2D cellMax(const SpatialCell& cell, double cellSize) {
     };
 }
 
+void insertBarrierCoverageCells(
+    std::unordered_map<std::string, std::unordered_map<long long, std::vector<std::size_t>>>& cellsByFloor,
+    const std::string& floorId,
+    const Point2D& minPoint,
+    const Point2D& maxPoint,
+    double cellSize,
+    std::size_t barrierIndex) {
+    const auto minCell = spatialCellFor(minPoint, cellSize);
+    const auto maxCell = spatialCellFor(maxPoint, cellSize);
+    auto& floorCells = cellsByFloor[floorId];
+    for (int y = minCell.y; y <= maxCell.y; ++y) {
+        for (int x = minCell.x; x <= maxCell.x; ++x) {
+            floorCells[spatialKey({.x = x, .y = y})].push_back(barrierIndex);
+        }
+    }
+}
+
+void appendBarrierIndexCoverage(
+    std::unordered_map<std::string, std::unordered_map<long long, std::vector<std::size_t>>>& cellsByFloor,
+    const Barrier2D& barrier,
+    double cellSize,
+    std::size_t barrierIndex) {
+    const auto& vertices = barrier.geometry.vertices;
+    if (!barrier.blocksMovement || vertices.size() < 2) {
+        return;
+    }
+
+    for (std::size_t index = 0; index + 1 < vertices.size(); ++index) {
+        insertBarrierCoverageCells(
+            cellsByFloor,
+            barrier.floorId,
+            {
+                .x = std::min(vertices[index].x, vertices[index + 1].x),
+                .y = std::min(vertices[index].y, vertices[index + 1].y),
+            },
+            {
+                .x = std::max(vertices[index].x, vertices[index + 1].x),
+                .y = std::max(vertices[index].y, vertices[index + 1].y),
+            },
+            cellSize,
+            barrierIndex);
+    }
+
+    if (barrier.geometry.closed) {
+        insertBarrierCoverageCells(
+            cellsByFloor,
+            barrier.floorId,
+            {
+                .x = std::min(vertices.back().x, vertices.front().x),
+                .y = std::min(vertices.back().y, vertices.front().y),
+            },
+            {
+                .x = std::max(vertices.back().x, vertices.front().x),
+                .y = std::max(vertices.back().y, vertices.front().y),
+            },
+            cellSize,
+            barrierIndex);
+
+        auto minX = vertices.front().x;
+        auto minY = vertices.front().y;
+        auto maxX = vertices.front().x;
+        auto maxY = vertices.front().y;
+        for (const auto& vertex : vertices) {
+            minX = std::min(minX, vertex.x);
+            minY = std::min(minY, vertex.y);
+            maxX = std::max(maxX, vertex.x);
+            maxY = std::max(maxY, vertex.y);
+        }
+        insertBarrierCoverageCells(
+            cellsByFloor,
+            barrier.floorId,
+            {.x = minX, .y = minY},
+            {.x = maxX, .y = maxY},
+            cellSize,
+            barrierIndex);
+    }
+}
+
+bool barrierWithinRadius(const Barrier2D& barrier, const Point2D& point, double radius) {
+    if (!barrier.blocksMovement || barrier.geometry.vertices.size() < 2) {
+        return false;
+    }
+
+    const auto& vertices = barrier.geometry.vertices;
+    for (std::size_t index = 0; index + 1 < vertices.size(); ++index) {
+        const auto closest =
+            simulation_internal::closestPointOnSegment(point, vertices[index], vertices[index + 1]);
+        if (distanceBetween(point, closest) <= radius) {
+            return true;
+        }
+    }
+
+    if (barrier.geometry.closed) {
+        const auto closest =
+            simulation_internal::closestPointOnSegment(point, vertices.back(), vertices.front());
+        if (distanceBetween(point, closest) <= radius
+            || simulation_internal::pointInRing(vertices, point)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+template <typename TEntry>
+void appendSpatialBucketEntries(
+    const std::unordered_map<long long, std::vector<TEntry>>& floorCells,
+    const SpatialCell& center,
+    int range,
+    std::vector<TEntry>& entries) {
+    for (int dy = -range; dy <= range; ++dy) {
+        for (int dx = -range; dx <= range; ++dx) {
+            const auto it = floorCells.find(spatialKey({.x = center.x + dx, .y = center.y + dy}));
+            if (it == floorCells.end()) {
+                continue;
+            }
+            entries.insert(entries.end(), it->second.begin(), it->second.end());
+        }
+    }
+}
+
 void appendReplayFrame(
     ScenarioResultArtifactsResource& result,
     const SimulationFrame& frame) {
@@ -594,18 +715,59 @@ std::vector<engine::Entity> scenarioNearbyAgents(
 
     const auto center = spatialCellFor(point, index.cellSize);
     const auto range = std::max(1, static_cast<int>(std::ceil(radius / index.cellSize)));
-    for (int dy = -range; dy <= range; ++dy) {
-        for (int dx = -range; dx <= range; ++dx) {
-            const auto it = floorIt->second.find(spatialKey({.x = center.x + dx, .y = center.y + dy}));
-            if (it == floorIt->second.end()) {
-                continue;
-            }
-            for (const auto entity : it->second) {
-                const auto& otherPosition = query.get<Position>(entity);
-                if (distanceBetween(point, otherPosition.value) <= radius) {
-                    candidates.push_back(entity);
-                }
-            }
+    std::vector<engine::Entity> bucketEntries;
+    appendSpatialBucketEntries(floorIt->second, center, range, bucketEntries);
+    for (const auto entity : bucketEntries) {
+        const auto& otherPosition = query.get<Position>(entity);
+        if (distanceBetween(point, otherPosition.value) <= radius) {
+            candidates.push_back(entity);
+        }
+    }
+    return candidates;
+}
+
+std::vector<const Barrier2D*> scenarioNearbyBarriers(
+    const FacilityLayout2D& layout,
+    const ScenarioAgentSpatialIndexResource& index,
+    const Point2D& point,
+    const std::string& floorId,
+    double radius) {
+    std::vector<const Barrier2D*> candidates;
+    if (layout.barriers.empty()) {
+        return candidates;
+    }
+
+    const auto center = spatialCellFor(point, index.cellSize);
+    const auto range = std::max(1, static_cast<int>(std::ceil(radius / index.cellSize)));
+    std::unordered_set<std::size_t> barrierIndices;
+    barrierIndices.reserve(16);
+
+    auto appendFloorCandidates = [&](const std::string& candidateFloorId) {
+        const auto floorIt = index.barrierIndicesByFloor.find(candidateFloorId);
+        if (floorIt == index.barrierIndicesByFloor.end()) {
+            return;
+        }
+        std::vector<std::size_t> bucketEntries;
+        appendSpatialBucketEntries(floorIt->second, center, range, bucketEntries);
+        barrierIndices.insert(bucketEntries.begin(), bucketEntries.end());
+    };
+
+    if (floorId.empty()) {
+        for (const auto& [candidateFloorId, _] : index.barrierIndicesByFloor) {
+            appendFloorCandidates(candidateFloorId);
+        }
+    } else {
+        appendFloorCandidates(floorId);
+        appendFloorCandidates(std::string{});
+    }
+
+    for (const auto barrierIndex : barrierIndices) {
+        if (barrierIndex >= layout.barriers.size()) {
+            continue;
+        }
+        const auto& barrier = layout.barriers[barrierIndex];
+        if (barrierWithinRadius(barrier, point, radius)) {
+            candidates.push_back(&barrier);
         }
     }
     return candidates;
@@ -633,17 +795,34 @@ void ScenarioSpatialIndexSystem::update(engine::EngineWorld& world, const engine
 
     const auto entities = query.view<Position, Agent, EvacuationStatus>();
     index.cellsByFloor.reserve(4);
+    index.displayCellsByFloor.reserve(4);
     for (const auto entity : entities) {
         const auto& status = query.get<EvacuationStatus>(entity);
         if (status.evacuated) {
             continue;
         }
         const auto& position = query.get<Position>(entity);
-        const auto floorId = query.contains<EvacuationRoute>(entity)
+        const auto collisionFloorId = query.contains<EvacuationRoute>(entity)
             ? simulation_internal::agentCollisionFloorId(query.get<EvacuationRoute>(entity))
             : std::string{};
-        auto& floorCells = index.cellsByFloor[floorId];
-        floorCells[spatialKey(spatialCellFor(position.value, index.cellSize))].push_back(entity);
+        const auto displayFloorId = query.contains<EvacuationRoute>(entity)
+            ? simulation_internal::agentDisplayFloorId(query.get<EvacuationRoute>(entity))
+            : collisionFloorId;
+        const auto cellKey = spatialKey(spatialCellFor(position.value, index.cellSize));
+        index.cellsByFloor[collisionFloorId][cellKey].push_back(entity);
+        index.displayCellsByFloor[displayFloorId][cellKey].push_back(entity);
+    }
+
+    if (resources.contains<ScenarioLayoutCacheResource>()) {
+        const auto& layout = resources.get<ScenarioLayoutCacheResource>().layout;
+        index.barrierIndicesByFloor.reserve(std::max<std::size_t>(1, layout.floors.size()));
+        for (std::size_t barrierIndex = 0; barrierIndex < layout.barriers.size(); ++barrierIndex) {
+            appendBarrierIndexCoverage(
+                index.barrierIndicesByFloor,
+                layout.barriers[barrierIndex],
+                index.cellSize,
+                barrierIndex);
+        }
     }
 
     resources.set(std::move(index));

--- a/src/domain/ScenarioSimulationSystems.h
+++ b/src/domain/ScenarioSimulationSystems.h
@@ -35,6 +35,8 @@ struct ScenarioSimulationStepResource {
 struct ScenarioAgentSpatialIndexResource {
     double cellSize{1.0};
     std::unordered_map<std::string, std::unordered_map<long long, std::vector<engine::Entity>>> cellsByFloor{};
+    std::unordered_map<std::string, std::unordered_map<long long, std::vector<engine::Entity>>> displayCellsByFloor{};
+    std::unordered_map<std::string, std::unordered_map<long long, std::vector<std::size_t>>> barrierIndicesByFloor{};
 };
 
 struct ScenarioConnectionTraversal {
@@ -157,6 +159,12 @@ struct ScenarioAgentSeed {
 
 std::vector<engine::Entity> scenarioNearbyAgents(
     engine::WorldQuery& query,
+    const ScenarioAgentSpatialIndexResource& index,
+    const Point2D& point,
+    const std::string& floorId,
+    double radius);
+std::vector<const Barrier2D*> scenarioNearbyBarriers(
+    const FacilityLayout2D& layout,
     const ScenarioAgentSpatialIndexResource& index,
     const Point2D& point,
     const std::string& floorId,

--- a/tests/ScenarioSimulationSystemsTests.cpp
+++ b/tests/ScenarioSimulationSystemsTests.cpp
@@ -107,6 +107,28 @@ private:
     safecrowd::domain::Point2D position_{};
 };
 
+class ConfigureBarrierIndexedLayoutSystem final : public safecrowd::engine::EngineSystem {
+public:
+    explicit ConfigureBarrierIndexedLayoutSystem(safecrowd::domain::FacilityLayout2D layout)
+        : layout_(std::move(layout)) {
+    }
+
+    void configure(safecrowd::engine::EngineWorld& world) override {
+        world.resources().set(safecrowd::domain::ScenarioSimulationClockResource{
+            .elapsedSeconds = 0.0,
+            .timeLimitSeconds = 10.0,
+            .complete = false,
+        });
+        world.resources().set(safecrowd::domain::simulation_internal::buildScenarioLayoutCache(layout_));
+    }
+
+    void update(safecrowd::engine::EngineWorld&, const safecrowd::engine::EngineStepContext&) override {
+    }
+
+private:
+    safecrowd::domain::FacilityLayout2D layout_{};
+};
+
 class ConfigureEvacuatedAgentsSystem final : public safecrowd::engine::EngineSystem {
 public:
     void configure(safecrowd::engine::EngineWorld& world) override {
@@ -936,6 +958,61 @@ SC_TEST(ScenarioSpatialIndexSystem_SeparatesConnectedStairEndpointsAwayFromVerti
     SC_EXPECT_EQ(verticalNearby.size(), std::size_t{0});
     SC_EXPECT_EQ(l1Nearby.size(), std::size_t{1});
     SC_EXPECT_EQ(l2Nearby.size(), std::size_t{1});
+}
+
+SC_TEST(ScenarioSpatialIndexSystem_BuildsNearbyBarrierResourceByFloor) {
+    safecrowd::domain::FacilityLayout2D layout;
+    layout.floors = {
+        {.id = "L1"},
+        {.id = "L2"},
+    };
+    layout.barriers.push_back({
+        .id = "wall-l1",
+        .floorId = "L1",
+        .geometry = {.vertices = {{.x = -1.0, .y = 0.0}, {.x = 1.0, .y = 0.0}}},
+        .blocksMovement = true,
+    });
+    layout.barriers.push_back({
+        .id = "wall-l2",
+        .floorId = "L2",
+        .geometry = {.vertices = {{.x = -1.0, .y = 0.0}, {.x = 1.0, .y = 0.0}}},
+        .blocksMovement = true,
+    });
+
+    safecrowd::engine::EngineRuntime runtime({
+        .fixedDeltaTime = 1.0 / 30.0,
+        .maxCatchUpSteps = 1,
+        .baseSeed = 34,
+    });
+    runtime.addSystem(std::make_unique<ConfigureBarrierIndexedLayoutSystem>(layout));
+    runtime.addSystem(
+        std::make_unique<safecrowd::domain::ScenarioSpatialIndexSystem>(1.0),
+        {.phase = safecrowd::engine::UpdatePhase::PreSimulation,
+         .triggerPolicy = safecrowd::engine::TriggerPolicy::EveryFrame});
+
+    runtime.play();
+    runtime.stepFrame(1.0 / 30.0);
+
+    const auto& resources = runtime.world().resources();
+    const auto& index = resources.get<safecrowd::domain::ScenarioAgentSpatialIndexResource>();
+    const auto& activeLayout = resources.get<safecrowd::domain::ScenarioLayoutCacheResource>().layout;
+    const auto l1Barriers = safecrowd::domain::scenarioNearbyBarriers(
+        activeLayout,
+        index,
+        {.x = 0.0, .y = 0.15},
+        "L1",
+        0.4);
+    const auto l2Barriers = safecrowd::domain::scenarioNearbyBarriers(
+        activeLayout,
+        index,
+        {.x = 0.0, .y = 0.15},
+        "L2",
+        0.4);
+
+    SC_EXPECT_EQ(l1Barriers.size(), std::size_t{1});
+    SC_EXPECT_EQ(l2Barriers.size(), std::size_t{1});
+    SC_EXPECT_EQ(l1Barriers.front()->id, std::string{"wall-l1"});
+    SC_EXPECT_EQ(l2Barriers.front()->id, std::string{"wall-l2"});
 }
 
 SC_TEST(ScenarioClockSystem_AdvancesClockResourceOnFixedSteps) {


### PR DESCRIPTION
## Summary

- share scenario spatial index resources across compression, pressure/risk, and motion paths to cut repeated neighbor and barrier lookups
- add barrier-aware spatial indexing in domain systems and trim redundant replay overlay updates in the application layer
- cache static replay overlays so frame playback redraws only the time-varying state

## Related Issue

- Closes #238

## Area

- [x] Domain
- [ ] Application
- [ ] Engine
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [x] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug`
- [x] `ctest --preset test-debug`
- [ ] Not run (reason below)

## Risks / Follow-up

- This PR is stacked on top of #235 and should be retargeted to `main` after #235 merges.
- We should still profile real large scenarios to confirm where the next frame-time bottleneck sits.
