### PR TITLE
[Application] Improve right panel toggles

### DIFF
--- a/src/application/MainWindow.cpp
+++ b/src/application/MainWindow.cpp
@@ -80,7 +80,7 @@ ProjectWorkspaceState makeEvacuationScenarioDemoWorkspace() {
     });
     authoring.currentScenarioIndex = 1;
     authoring.navigationView = SavedNavigationView::Events;
-    authoring.inspectorPanelVisible = true;
+    authoring.inspectorPanelVisible = false;
     authoring.scenarioPanelVisible = true;
     authoring.rightPanelMode = SavedRightPanelMode::Scenario;
 
@@ -122,7 +122,7 @@ ProjectWorkspaceState makeTwoFloorEvacuationDemoWorkspace() {
     });
     authoring.currentScenarioIndex = 1;
     authoring.navigationView = SavedNavigationView::Events;
-    authoring.inspectorPanelVisible = true;
+    authoring.inspectorPanelVisible = false;
     authoring.scenarioPanelVisible = true;
     authoring.rightPanelMode = SavedRightPanelMode::Scenario;
 

--- a/src/application/ScenarioAuthoringWidget.cpp
+++ b/src/application/ScenarioAuthoringWidget.cpp
@@ -1811,6 +1811,9 @@ ScenarioAuthoringWidget::ScenarioAuthoringWidget(
       navigationView_(initialState.navigationView),
       inspectorPanelVisible_(initialState.inspectorPanelVisible),
       scenarioPanelVisible_(initialState.scenarioPanelVisible) {
+    if (inspectorPanelVisible_ && scenarioPanelVisible_) {
+        inspectorPanelVisible_ = false;
+    }
     for (auto& scenario : scenarios_) {
         if (!scenarioHasOccupants(scenario)) {
             scenario.stagedForRun = false;
@@ -3663,8 +3666,7 @@ void ScenarioAuthoringWidget::refreshRightPanel() {
         return;
     }
 
-    const int panelCount = (inspectorPanelVisible_ ? 1 : 0) + (scenarioPanelVisible_ ? 1 : 0);
-    shell_->setReviewPanelWidth(panelCount > 1 ? 560 : 280);
+    shell_->setReviewPanelWidth(280);
     shell_->setReviewPanel(createRightPanelContainer());
     shell_->setReviewPanelVisible(true);
     refreshScenarioSwitcher();
@@ -4034,11 +4036,15 @@ QWidget* ScenarioAuthoringWidget::createPanelToggleBar() {
     layout->addWidget(scenarioPanelToggleButton_);
 
     connect(inspectorPanelToggleButton_, &QPushButton::clicked, this, [this]() {
-        inspectorPanelVisible_ = !inspectorPanelVisible_;
+        const bool showInspector = !inspectorPanelVisible_;
+        inspectorPanelVisible_ = showInspector;
+        scenarioPanelVisible_ = false;
         refreshRightPanel();
     });
     connect(scenarioPanelToggleButton_, &QPushButton::clicked, this, [this]() {
-        scenarioPanelVisible_ = !scenarioPanelVisible_;
+        const bool showScenario = !scenarioPanelVisible_;
+        scenarioPanelVisible_ = showScenario;
+        inspectorPanelVisible_ = false;
         refreshRightPanel();
     });
 

--- a/src/application/ScenarioAuthoringWidget.h
+++ b/src/application/ScenarioAuthoringWidget.h
@@ -55,7 +55,7 @@ public:
         std::vector<ScenarioState> scenarios{};
         int currentScenarioIndex{-1};
         NavigationView navigationView{NavigationView::Layout};
-        bool inspectorPanelVisible{true};
+        bool inspectorPanelVisible{false};
         bool scenarioPanelVisible{true};
         RightPanelMode rightPanelMode{RightPanelMode::Scenario};
     };
@@ -167,7 +167,7 @@ private:
     std::vector<ScenarioState> scenarios_{};
     int currentScenarioIndex_{-1};
     NavigationView navigationView_{NavigationView::Layout};
-    bool inspectorPanelVisible_{true};
+    bool inspectorPanelVisible_{false};
     bool scenarioPanelVisible_{true};
     QSet<QString> layoutExpandedNodeIds_{};
     QString selectedLayoutElementId_{};

--- a/src/application/ScenarioBatchResultWidget.cpp
+++ b/src/application/ScenarioBatchResultWidget.cpp
@@ -265,6 +265,10 @@ QString compareScenarioLabel(const SavedScenarioResultState& result) {
     return QString("%1\n%2").arg(name, meta);
 }
 
+QString exitUsageLabel(const safecrowd::domain::ExitUsageMetric& exit) {
+    return QString::fromStdString(exit.exitLabel.empty() ? exit.exitZoneId : exit.exitLabel);
+}
+
 std::vector<std::pair<double, double>> progressSeries(const SavedScenarioResultState& result) {
     std::vector<std::pair<double, double>> series;
     if (!result.artifacts.evacuationProgress.empty()) {
@@ -354,6 +358,10 @@ public:
         timingMarkerActivatedHandler_ = std::move(handler);
     }
 
+    void setExitUsageActivatedHandler(std::function<void(int, std::optional<double>)> handler) {
+        exitUsageActivatedHandler_ = std::move(handler);
+    }
+
 protected:
     void paintEvent(QPaintEvent* event) override {
         (void)event;
@@ -388,7 +396,18 @@ protected:
         if (event == nullptr) {
             return;
         }
-        const bool hover = timingMarkerHitSeconds(event->position()).has_value();
+        const auto exitHit = exitUsagePointHit(event->position());
+        if (exitHit.has_value()) {
+            setToolTip(QString("%1\nExit: %2\nUsage: %3 (%4 people)\nLast exit: %5")
+                .arg(QString::fromStdString((*results_)[static_cast<std::size_t>(exitHit->resultIndex)].scenario.name))
+                .arg(exitHit->exitLabel)
+                .arg(formatRatioPercent(exitHit->usageRatio))
+                .arg(static_cast<int>(exitHit->evacuatedCount))
+                .arg(formatSeconds(exitHit->lastExitTimeSeconds)));
+        } else {
+            setToolTip(QString{});
+        }
+        const bool hover = timingMarkerHitSeconds(event->position()).has_value() || exitHit.has_value();
         setCursor(hover ? Qt::PointingHandCursor : Qt::ArrowCursor);
         QWidget::mouseMoveEvent(event);
     }
@@ -405,7 +424,15 @@ protected:
         }
         const auto seconds = timingMarkerHitSeconds(event->position());
         if (!seconds.has_value()) {
-            QWidget::mousePressEvent(event);
+            const auto exitHit = exitUsagePointHit(event->position());
+            if (!exitHit.has_value()) {
+                QWidget::mousePressEvent(event);
+                return;
+            }
+            event->accept();
+            if (exitUsageActivatedHandler_) {
+                exitUsageActivatedHandler_(exitHit->resultIndex, exitHit->lastExitTimeSeconds);
+            }
             return;
         }
         event->accept();
@@ -415,6 +442,15 @@ protected:
     }
 
 private:
+    struct ExitUsagePointHit {
+        int resultIndex{0};
+        QString exitLabel{};
+        std::size_t evacuatedCount{0};
+        double usageRatio{0.0};
+        std::optional<double> lastExitTimeSeconds{};
+        double distance{0.0};
+    };
+
     QColor colorForSeries(int index) const {
         static const std::vector<QColor> colors{
             QColor("#2563eb"),
@@ -557,6 +593,85 @@ private:
         return best->seconds;
     }
 
+    std::vector<QString> exitLabels() const {
+        std::vector<QString> exits;
+        if (results_ == nullptr) {
+            return exits;
+        }
+        for (const auto index : selectedIndices_) {
+            if (!validIndex(index)) {
+                continue;
+            }
+            for (const auto& exit : (*results_)[static_cast<std::size_t>(index)].artifacts.exitUsage) {
+                const auto label = exitUsageLabel(exit);
+                if (std::find(exits.begin(), exits.end(), label) == exits.end()) {
+                    exits.push_back(label);
+                }
+            }
+        }
+        return exits;
+    }
+
+    const safecrowd::domain::ExitUsageMetric* exitUsageMetricForLabel(
+        const SavedScenarioResultState& result,
+        const QString& exitLabel) const {
+        const auto it = std::find_if(result.artifacts.exitUsage.begin(), result.artifacts.exitUsage.end(), [&](const auto& exit) {
+            return exitUsageLabel(exit) == exitLabel;
+        });
+        return it == result.artifacts.exitUsage.end() ? nullptr : &(*it);
+    }
+
+    std::optional<ExitUsagePointHit> exitUsagePointHit(const QPointF& position) const {
+        if (mode_ != ComparisonGraphMode::Exits || results_ == nullptr) {
+            return std::nullopt;
+        }
+        const QRectF plot = QRectF(rect()).adjusted(40, 16, -18, -68);
+        if (!plot.adjusted(-10.0, -10.0, 10.0, 10.0).contains(position)) {
+            return std::nullopt;
+        }
+
+        const auto exits = exitLabels();
+        if (exits.empty()) {
+            return std::nullopt;
+        }
+
+        constexpr double kHitRadiusPixels = 8.0;
+        std::optional<ExitUsagePointHit> best;
+        for (const auto index : selectedIndices_) {
+            if (!validIndex(index)) {
+                continue;
+            }
+            const auto& result = (*results_)[static_cast<std::size_t>(index)];
+            for (int exitIndex = 0; exitIndex < static_cast<int>(exits.size()); ++exitIndex) {
+                const auto& exitLabel = exits[static_cast<std::size_t>(exitIndex)];
+                const auto* exit = exitUsageMetricForLabel(result, exitLabel);
+                if (exit == nullptr) {
+                    continue;
+                }
+                const auto usageRatio = std::clamp(exit->usageRatio, 0.0, 1.0);
+                const auto x = exits.size() == 1
+                    ? plot.center().x()
+                    : plot.left() + (static_cast<double>(exitIndex) / static_cast<double>(exits.size() - 1)) * plot.width();
+                const auto y = plot.bottom() - usageRatio * plot.height();
+                const auto distance = std::hypot(position.x() - x, position.y() - y);
+                if (distance > kHitRadiusPixels) {
+                    continue;
+                }
+                if (!best.has_value() || distance < best->distance) {
+                    best = ExitUsagePointHit{
+                        .resultIndex = index,
+                        .exitLabel = exitLabel,
+                        .evacuatedCount = exit->evacuatedCount,
+                        .usageRatio = usageRatio,
+                        .lastExitTimeSeconds = exit->lastExitTimeSeconds,
+                        .distance = distance,
+                    };
+                }
+            }
+        }
+        return best;
+    }
+
     void drawRemaining(QPainter& painter, const QRectF& plot) {
         const auto maxTime = remainingMaxTimeSeconds();
 
@@ -608,18 +723,7 @@ private:
     }
 
     void drawExits(QPainter& painter, const QRectF& plot) {
-        std::vector<QString> exits;
-        for (const auto index : selectedIndices_) {
-            if (!validIndex(index)) {
-                continue;
-            }
-            for (const auto& exit : (*results_)[static_cast<std::size_t>(index)].artifacts.exitUsage) {
-                const auto label = QString::fromStdString(exit.exitLabel.empty() ? exit.exitZoneId : exit.exitLabel);
-                if (std::find(exits.begin(), exits.end(), label) == exits.end()) {
-                    exits.push_back(label);
-                }
-            }
-        }
+        const auto exits = exitLabels();
         if (exits.empty()) {
             painter.setPen(QColor("#6b7785"));
             painter.setFont(ui::font(ui::FontRole::Caption));
@@ -652,12 +756,8 @@ private:
             for (int exitIndex = 0; exitIndex < static_cast<int>(exits.size()); ++exitIndex) {
                 double usageRatio = 0.0;
                 const auto& exitLabel = exits[static_cast<std::size_t>(exitIndex)];
-                for (const auto& exit : result.artifacts.exitUsage) {
-                    const auto label = QString::fromStdString(exit.exitLabel.empty() ? exit.exitZoneId : exit.exitLabel);
-                    if (label == exitLabel) {
-                        usageRatio = std::clamp(exit.usageRatio, 0.0, 1.0);
-                        break;
-                    }
+                if (const auto* exit = exitUsageMetricForLabel(result, exitLabel); exit != nullptr) {
+                    usageRatio = std::clamp(exit->usageRatio, 0.0, 1.0);
                 }
                 const auto x = exits.size() == 1
                     ? plot.center().x()
@@ -675,12 +775,8 @@ private:
             for (int exitIndex = 0; exitIndex < static_cast<int>(exits.size()); ++exitIndex) {
                 double usageRatio = 0.0;
                 const auto& exitLabel = exits[static_cast<std::size_t>(exitIndex)];
-                for (const auto& exit : result.artifacts.exitUsage) {
-                    const auto label = QString::fromStdString(exit.exitLabel.empty() ? exit.exitZoneId : exit.exitLabel);
-                    if (label == exitLabel) {
-                        usageRatio = std::clamp(exit.usageRatio, 0.0, 1.0);
-                        break;
-                    }
+                if (const auto* exit = exitUsageMetricForLabel(result, exitLabel); exit != nullptr) {
+                    usageRatio = std::clamp(exit->usageRatio, 0.0, 1.0);
                 }
                 const auto x = exits.size() == 1
                     ? plot.center().x()
@@ -772,6 +868,7 @@ private:
     int displayIndex_{0};
     double currentTimeSeconds_{-1.0};
     std::function<void(double)> timingMarkerActivatedHandler_{};
+    std::function<void(int, std::optional<double>)> exitUsageActivatedHandler_{};
 };
 
 std::vector<safecrowd::domain::SimulationFrame> replayFramesForResult(const SavedScenarioResultState& result) {
@@ -1086,6 +1183,19 @@ QWidget* ScenarioBatchResultWidget::createCanvasPanel() {
     static_cast<ComparisonGraphWidget*>(exitsChart_)->setResults(results_, selectedCompareIndices_, currentResultIndex_);
     static_cast<ComparisonGraphWidget*>(remainingChart_)->setTimingMarkerActivatedHandler([this](double seconds) {
         seekToTimingMarkerSeconds(seconds);
+    });
+    static_cast<ComparisonGraphWidget*>(exitsChart_)->setExitUsageActivatedHandler([this](
+        int resultIndex,
+        std::optional<double> lastExitTimeSeconds) {
+        if (resultIndex < 0 || resultIndex >= static_cast<int>(results_.size())) {
+            return;
+        }
+        currentResultIndex_ = resultIndex;
+        clearDetailSelection();
+        refreshSelectedResult();
+        if (lastExitTimeSeconds.has_value()) {
+            showClosestReplayFrameAtSeconds(*lastExitTimeSeconds);
+        }
     });
     tabs->addTab(remainingChart_, "Remaining");
     tabs->addTab(exitsChart_, "Exits");
@@ -1579,6 +1689,7 @@ void ScenarioBatchResultWidget::applySelectedResultStaticCanvasState() {
     const auto& result = results_[static_cast<std::size_t>(currentResultIndex_)];
     canvas_->setConnectionBlocks(result.scenario.control.connectionBlocks);
     canvas_->setEnvironmentHazards(result.scenario.environment.hazards);
+    canvas_->setRouteGuidances(result.scenario.control.routeGuidances);
     canvas_->setHotspotOverlay(result.risk.hotspots);
     canvas_->setBottleneckOverlay(result.risk.bottlenecks);
     canvas_->setCrossFlowOverlay(result.risk.crossFlowCells);
@@ -2205,6 +2316,12 @@ void ScenarioBatchResultWidget::setDetailSelection(ScenarioResultNavigationView 
     detailSelectionView_ = view;
     detailSelectionIndex_ = index;
     detailSelectionResultIndex_ = currentResultIndex_;
+    if (!detailPanelVisible_ || overviewPanelVisible_) {
+        detailPanelVisible_ = true;
+        overviewPanelVisible_ = false;
+        refreshRightPanel();
+        return;
+    }
     refreshDetailPanel();
 }
 

--- a/src/application/ScenarioBatchResultWidget.cpp
+++ b/src/application/ScenarioBatchResultWidget.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include <QCheckBox>
+#include <QColor>
 #include <QComboBox>
 #include <QEvent>
 #include <QFrame>
@@ -25,6 +26,7 @@
 #include <QPushButton>
 #include <QScrollArea>
 #include <QSignalBlocker>
+#include <QSize>
 #include <QSizePolicy>
 #include <QSlider>
 #include <QStringList>
@@ -37,6 +39,7 @@
 #include "application/ScenarioResultNavigation.h"
 #include "application/ScenarioRunWidget.h"
 #include "application/SimulationCanvasWidget.h"
+#include "application/ToolIconResources.h"
 #include "application/UiStyle.h"
 #include "application/WorkspaceShell.h"
 #include "domain/AlternativeRecommendationService.h"
@@ -1346,6 +1349,11 @@ QWidget* ScenarioBatchResultWidget::createPanelToggleBar() {
     detailPanelToggleButton_ = new QPushButton(bar);
     detailPanelToggleButton_->setCheckable(true);
     detailPanelToggleButton_->setChecked(detailPanelVisible_);
+    detailPanelToggleButton_->setIcon(makeSvgToolIcon(
+        QStringLiteral(":/tool-icons/etc/inspector-panel.svg"),
+        QColor("#16202b"),
+        QSize(22, 22)));
+    detailPanelToggleButton_->setIconSize(QSize(22, 22));
     detailPanelToggleButton_->setFixedSize(36, 32);
     detailPanelToggleButton_->setCursor(Qt::PointingHandCursor);
     detailPanelToggleButton_->setFocusPolicy(Qt::NoFocus);
@@ -1357,6 +1365,11 @@ QWidget* ScenarioBatchResultWidget::createPanelToggleBar() {
     overviewPanelToggleButton_ = new QPushButton(bar);
     overviewPanelToggleButton_->setCheckable(true);
     overviewPanelToggleButton_->setChecked(overviewPanelVisible_);
+    overviewPanelToggleButton_->setIcon(makeSvgToolIcon(
+        QStringLiteral(":/tool-icons/scenario-authoring/scenario-panel.svg"),
+        QColor("#16202b"),
+        QSize(22, 22)));
+    overviewPanelToggleButton_->setIconSize(QSize(22, 22));
     overviewPanelToggleButton_->setFixedSize(36, 32);
     overviewPanelToggleButton_->setCursor(Qt::PointingHandCursor);
     overviewPanelToggleButton_->setFocusPolicy(Qt::NoFocus);
@@ -1366,11 +1379,15 @@ QWidget* ScenarioBatchResultWidget::createPanelToggleBar() {
     layout->addWidget(overviewPanelToggleButton_);
 
     connect(detailPanelToggleButton_, &QPushButton::clicked, this, [this]() {
-        detailPanelVisible_ = !detailPanelVisible_;
+        const bool showDetail = !detailPanelVisible_;
+        detailPanelVisible_ = showDetail;
+        overviewPanelVisible_ = false;
         refreshRightPanel();
     });
     connect(overviewPanelToggleButton_, &QPushButton::clicked, this, [this]() {
-        overviewPanelVisible_ = !overviewPanelVisible_;
+        const bool showOverview = !overviewPanelVisible_;
+        overviewPanelVisible_ = showOverview;
+        detailPanelVisible_ = false;
         refreshRightPanel();
     });
 
@@ -1398,7 +1415,7 @@ void ScenarioBatchResultWidget::navigateToAuthoring() {
         }
     }
     initial.rightPanelMode = ScenarioAuthoringWidget::RightPanelMode::Scenario;
-    initial.inspectorPanelVisible = true;
+    initial.inspectorPanelVisible = false;
     initial.scenarioPanelVisible = true;
     showAuthoring(std::move(initial));
 }
@@ -1439,7 +1456,7 @@ void ScenarioBatchResultWidget::createRecommendedScenario(
         existingIndex.has_value()) {
         initial.currentScenarioIndex = *existingIndex;
         initial.rightPanelMode = ScenarioAuthoringWidget::RightPanelMode::Scenario;
-        initial.inspectorPanelVisible = true;
+        initial.inspectorPanelVisible = false;
         initial.scenarioPanelVisible = true;
         showAuthoring(std::move(initial));
         return;
@@ -1484,7 +1501,7 @@ void ScenarioBatchResultWidget::createRecommendedScenario(
     initial.scenarios.push_back(std::move(state));
     initial.currentScenarioIndex = static_cast<int>(initial.scenarios.size()) - 1;
     initial.rightPanelMode = ScenarioAuthoringWidget::RightPanelMode::Scenario;
-    initial.inspectorPanelVisible = true;
+    initial.inspectorPanelVisible = false;
     initial.scenarioPanelVisible = true;
     showAuthoring(std::move(initial));
 }
@@ -2157,8 +2174,7 @@ void ScenarioBatchResultWidget::refreshRightPanel() {
         return;
     }
 
-    const int panelCount = (detailPanelVisible_ ? 1 : 0) + (overviewPanelVisible_ ? 1 : 0);
-    shell_->setReviewPanelWidth(panelCount > 1 ? 560 : 280);
+    shell_->setReviewPanelWidth(280);
     shell_->setReviewPanel(createRightPanelContainer());
     shell_->setReviewPanelVisible(true);
     refreshComparisonCountLabel();

--- a/src/application/ScenarioBatchResultWidget.h
+++ b/src/application/ScenarioBatchResultWidget.h
@@ -133,7 +133,7 @@ private:
     std::optional<ScenarioResultNavigationView> detailSelectionView_{};
     std::optional<std::size_t> detailSelectionIndex_{};
     int detailSelectionResultIndex_{-1};
-    bool detailPanelVisible_{true};
+    bool detailPanelVisible_{false};
     bool overviewPanelVisible_{true};
 };
 


### PR DESCRIPTION
## Summary

- Make the scenario authoring right panel show only one of Inspector or Scenario at a time.
- Make the result view right panel show only one of Detail or Overview at a time, with Overview visible by default.
- Add icons to the result Detail and Overview panel toggle buttons and align demo/return states with the single-panel behavior.

## Area

- [ ] Engine
- [ ] Domain
- [x] Application
- [ ] Docs
- [ ] Build
- [ ] Analysis
- [ ] Chore

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [ ] `cmake --preset windows-debug`
- [x] `cmake --build --preset build-debug` (`--target safecrowd_app`)
- [ ] `ctest --preset test-debug`
- [ ] Not run (reason below)

## Risks / Follow-up

- Full CTest was not run because this is an application-only panel state/UI change; the app target build passed.
