### PR TITLE
[Application] default result overlay to peak density

### DIFF
--- a/src/application/ScenarioBatchResultWidget.cpp
+++ b/src/application/ScenarioBatchResultWidget.cpp
@@ -1124,14 +1124,14 @@ QWidget* ScenarioBatchResultWidget::createCanvasPanel() {
     selectorLayout->addWidget(overlayLabel);
 
     overlayCombo_ = new QComboBox(selectorBar);
+    overlayCombo_->addItem("Peak Density", static_cast<int>(OverlayMode::Density));
     overlayCombo_->addItem("Occupancy", static_cast<int>(OverlayMode::Occupancy));
-    overlayCombo_->addItem("Density", static_cast<int>(OverlayMode::Density));
     overlayCombo_->addItem("Pressure", static_cast<int>(OverlayMode::Pressure));
     overlayCombo_->addItem("Hotspots", static_cast<int>(OverlayMode::Hotspots));
     overlayCombo_->addItem("Bottlenecks", static_cast<int>(OverlayMode::Bottlenecks));
     overlayCombo_->addItem("Cross Flow", static_cast<int>(OverlayMode::CrossFlow));
     overlayCombo_->addItem("None", static_cast<int>(OverlayMode::None));
-    overlayCombo_->setCurrentIndex(0);
+    overlayCombo_->setCurrentIndex(overlayCombo_->findData(static_cast<int>(overlayMode_)));
     selectorLayout->addWidget(overlayCombo_);
     layout->addWidget(selectorBar);
 

--- a/src/application/ScenarioBatchResultWidget.h
+++ b/src/application/ScenarioBatchResultWidget.h
@@ -128,7 +128,7 @@ private:
     QWidget* remainingChart_{nullptr};
     QWidget* exitsChart_{nullptr};
     QTimer* replayTimer_{nullptr};
-    OverlayMode overlayMode_{OverlayMode::Occupancy};
+    OverlayMode overlayMode_{OverlayMode::Density};
     ScenarioResultNavigationView resultNavigationView_{ScenarioResultNavigationView::Bottleneck};
     std::optional<ScenarioResultNavigationView> detailSelectionView_{};
     std::optional<std::size_t> detailSelectionIndex_{};


### PR DESCRIPTION
## Summary

- Default the results screen map overlay to Peak Density (previously Occupancy) and relabel the option "Peak Density", so the first results view matches the documented behavior.
- The remaining overlay options (Occupancy, Pressure, Hotspots, Bottlenecks, Cross Flow, None) are unchanged.

## Area

- [ ] Engine
- [ ] Domain
- [x] Application

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [ ] `cmake --preset windows-debug`
- [ ] `cmake --build --preset build-debug`
- [ ] `ctest --preset test-debug`
- [x] Not run (reason below)

Built the Qt app in release: `cmake --preset windows-release` + `cmake --build --preset build-release --target safecrowd_app` -> succeeds. The change is a default selection and a label only.

## Risks / Follow-up

- UI default only; no change to overlay computation or logic.
