### PR TITLE
[Application] add run-screen execution controls

### DIFF
--- a/src/application/ScenarioRunWidget.cpp
+++ b/src/application/ScenarioRunWidget.cpp
@@ -18,6 +18,7 @@
 #include <QHBoxLayout>
 #include <QIcon>
 #include <QLabel>
+#include <QMessageBox>
 #include <QPainter>
 #include <QPaintEvent>
 #include <QPen>
@@ -1023,6 +1024,18 @@ void ScenarioRunWidget::applyRunSettings() {
 
     const auto sourceIndex = selectedSourceScenarioIndex();
     if (sourceIndex >= scenarios_.size()) {
+        return;
+    }
+
+    const bool wouldDiscardResults = hasCachedResults() || (batchRunner_.complete() && !batchRunner_.empty());
+    if (wouldDiscardResults
+        && QMessageBox::question(
+               this,
+               "Apply run settings",
+               "Re-running with the new settings discards the current simulation results.\n\nContinue?",
+               QMessageBox::Yes | QMessageBox::Cancel,
+               QMessageBox::Cancel)
+            != QMessageBox::Yes) {
         return;
     }
 

--- a/src/application/ScenarioRunWidget.cpp
+++ b/src/application/ScenarioRunWidget.cpp
@@ -43,6 +43,7 @@ namespace {
 constexpr double kSimulationDeltaSeconds = 1.0 / 30.0;
 constexpr double kResultCalculationChunkSeconds = 1.0;
 constexpr int kPlaybackTimerIntervalMs = 33;
+constexpr int kMaxUiSeed = 2147483647;
 
 int normalizedRunIndex(int index, std::size_t runCount) {
     if (runCount == 0) {
@@ -706,7 +707,7 @@ QWidget* ScenarioRunWidget::createRunPanel() {
     settingsForm->addRow("Repeats", repeatSpin_);
 
     seedSpin_ = new QSpinBox(settingsGroup);
-    seedSpin_->setRange(1, 1000000);
+    seedSpin_->setRange(1, kMaxUiSeed);
     seedSpin_->setToolTip("Base random seed");
     settingsForm->addRow("Seed", seedSpin_);
 
@@ -1009,7 +1010,9 @@ void ScenarioRunWidget::syncRunSettingsControls() {
     if (seedSpin_ != nullptr) {
         seedSpin_->setValue(execution.baseSeed == 0
             ? 1
-            : static_cast<int>(std::min<unsigned int>(execution.baseSeed, 1000000U)));
+            : static_cast<int>(std::min<std::uint32_t>(
+                  execution.baseSeed,
+                  static_cast<std::uint32_t>(kMaxUiSeed))));
     }
 }
 

--- a/src/application/ScenarioRunWidget.cpp
+++ b/src/application/ScenarioRunWidget.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <optional>
@@ -47,6 +48,18 @@ int normalizedRunIndex(int index, std::size_t runCount) {
         return 0;
     }
     return std::clamp(index, 0, static_cast<int>(runCount) - 1);
+}
+
+int firstRunIndexForSourceScenario(
+    const safecrowd::domain::ScenarioBatchRunner& batchRunner,
+    std::size_t sourceScenarioIndex,
+    int fallbackIndex) {
+    for (std::size_t index = 0; index < batchRunner.size(); ++index) {
+        if (batchRunner.run(index).sourceScenarioIndex == sourceScenarioIndex) {
+            return static_cast<int>(index);
+        }
+    }
+    return normalizedRunIndex(fallbackIndex, batchRunner.size());
 }
 
 enum class TransportIconKind {
@@ -696,7 +709,7 @@ QWidget* ScenarioRunWidget::createRunPanel() {
     seedSpin_->setToolTip("Base random seed");
     settingsForm->addRow("Seed", seedSpin_);
 
-    applySettingsButton_ = new QPushButton("Apply & restart", settingsGroup);
+    applySettingsButton_ = new QPushButton("Apply selected & restart", settingsGroup);
     applySettingsButton_->setFont(ui::font(ui::FontRole::Caption));
     applySettingsButton_->setStyleSheet(ui::secondaryButtonStyleSheet());
     settingsForm->addRow(applySettingsButton_);
@@ -1008,16 +1021,17 @@ void ScenarioRunWidget::applyRunSettings() {
         return;
     }
 
-    const auto timeLimitSeconds = timeLimitSpin_->value();
-    const auto sampleIntervalSeconds = sampleIntervalSpin_->value();
-    const auto repeatCount = static_cast<std::uint32_t>(repeatSpin_->value());
-    const auto baseSeed = static_cast<std::uint32_t>(seedSpin_->value());
-    for (auto& scenario : scenarios_) {
-        scenario.execution.timeLimitSeconds = timeLimitSeconds;
-        scenario.execution.sampleIntervalSeconds = sampleIntervalSeconds;
-        scenario.execution.repeatCount = repeatCount;
-        scenario.execution.baseSeed = baseSeed;
+    const auto sourceIndex = selectedSourceScenarioIndex();
+    if (sourceIndex >= scenarios_.size()) {
+        return;
     }
+
+    auto& execution = scenarios_[sourceIndex].execution;
+    execution.timeLimitSeconds = timeLimitSpin_->value();
+    execution.sampleIntervalSeconds = sampleIntervalSpin_->value();
+    execution.repeatCount = static_cast<std::uint32_t>(repeatSpin_->value());
+    execution.baseSeed = static_cast<std::uint32_t>(seedSpin_->value());
+    syncReturnAuthoringScenarioExecution(sourceIndex);
 
     playbackSpeedMultiplier_ = 1;
     paused_ = false;
@@ -1026,7 +1040,7 @@ void ScenarioRunWidget::applyRunSettings() {
         timer_->stop();
     }
     batchRunner_.reset(layout_, scenarios_);
-    selectedRunIndex_ = normalizedRunIndex(selectedRunIndex_, batchRunner_.size());
+    selectedRunIndex_ = firstRunIndexForSourceScenario(batchRunner_, sourceIndex, selectedRunIndex_);
     if (!batchRunner_.empty()) {
         scenario_ = batchRunner_.run(static_cast<std::size_t>(selectedRunIndex_)).scenario;
     }
@@ -1037,6 +1051,27 @@ void ScenarioRunWidget::applyRunSettings() {
     if (timer_ != nullptr) {
         timer_->start();
     }
+}
+
+void ScenarioRunWidget::syncReturnAuthoringScenarioExecution(std::size_t sourceIndex) {
+    if (!returnAuthoringState_.has_value() || sourceIndex >= scenarios_.size()) {
+        return;
+    }
+
+    const auto& sourceScenario = scenarios_[sourceIndex];
+    auto& authoringScenarios = returnAuthoringState_->scenarios;
+    auto it = std::find_if(authoringScenarios.begin(), authoringScenarios.end(), [&](const auto& scenario) {
+        return scenario.draft.scenarioId == sourceScenario.scenarioId;
+    });
+    if (it == authoringScenarios.end() && sourceIndex < authoringScenarios.size()) {
+        it = std::next(authoringScenarios.begin(), static_cast<std::ptrdiff_t>(sourceIndex));
+    }
+    if (it == authoringScenarios.end()) {
+        return;
+    }
+
+    it->draft.execution = sourceScenario.execution;
+    it->stagedForRun = true;
 }
 
 void ScenarioRunWidget::cycleFastForwardMode() {

--- a/src/application/ScenarioRunWidget.cpp
+++ b/src/application/ScenarioRunWidget.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <iterator>
 #include <optional>
 #include <utility>
@@ -9,7 +10,9 @@
 #include <QColor>
 #include <QCoreApplication>
 #include <QDialog>
+#include <QDoubleSpinBox>
 #include <QEventLoop>
+#include <QFormLayout>
 #include <QGridLayout>
 #include <QHBoxLayout>
 #include <QIcon>
@@ -20,6 +23,7 @@
 #include <QProgressBar>
 #include <QPushButton>
 #include <QSizePolicy>
+#include <QSpinBox>
 #include <QTimer>
 #include <QVariant>
 #include <QVBoxLayout>
@@ -657,6 +661,49 @@ QWidget* ScenarioRunWidget::createRunPanel() {
     layout->addWidget(congestionLabel_);
     layout->addWidget(bottleneckLabel_);
 
+    auto* settingsTitle = createLabel("Run settings", panel, ui::FontRole::Caption);
+    settingsTitle->setStyleSheet(ui::mutedTextStyleSheet());
+    layout->addWidget(settingsTitle);
+
+    auto* settingsGroup = new QWidget(panel);
+    auto* settingsForm = new QFormLayout(settingsGroup);
+    settingsForm->setContentsMargins(0, 4, 0, 0);
+    settingsForm->setSpacing(6);
+
+    timeLimitSpin_ = new QDoubleSpinBox(settingsGroup);
+    timeLimitSpin_->setRange(1.0, 3600.0);
+    timeLimitSpin_->setDecimals(0);
+    timeLimitSpin_->setSuffix(" s");
+    timeLimitSpin_->setToolTip("Simulation time limit");
+    settingsForm->addRow("Time limit", timeLimitSpin_);
+
+    sampleIntervalSpin_ = new QDoubleSpinBox(settingsGroup);
+    sampleIntervalSpin_->setRange(0.1, 10.0);
+    sampleIntervalSpin_->setSingleStep(0.1);
+    sampleIntervalSpin_->setDecimals(2);
+    sampleIntervalSpin_->setSuffix(" s");
+    sampleIntervalSpin_->setToolTip("Result sample interval");
+    settingsForm->addRow("Sample interval", sampleIntervalSpin_);
+
+    repeatSpin_ = new QSpinBox(settingsGroup);
+    repeatSpin_->setRange(1, static_cast<int>(safecrowd::domain::kScenarioExecutionMaxRepeatCount));
+    repeatSpin_->setSuffix(" runs");
+    repeatSpin_->setToolTip("Repeat count");
+    settingsForm->addRow("Repeats", repeatSpin_);
+
+    seedSpin_ = new QSpinBox(settingsGroup);
+    seedSpin_->setRange(1, 1000000);
+    seedSpin_->setToolTip("Base random seed");
+    settingsForm->addRow("Seed", seedSpin_);
+
+    applySettingsButton_ = new QPushButton("Apply & restart", settingsGroup);
+    applySettingsButton_->setFont(ui::font(ui::FontRole::Caption));
+    applySettingsButton_->setStyleSheet(ui::secondaryButtonStyleSheet());
+    settingsForm->addRow(applySettingsButton_);
+
+    layout->addWidget(settingsGroup);
+    syncRunSettingsControls();
+
     layout->addStretch(1);
 
     auto* transportLayout = new QHBoxLayout();
@@ -703,6 +750,9 @@ QWidget* ScenarioRunWidget::createRunPanel() {
     });
     connect(resultButton_, &QPushButton::clicked, this, [this]() {
         showResults();
+    });
+    connect(applySettingsButton_, &QPushButton::clicked, this, [this]() {
+        applyRunSettings();
     });
 
     return panel;
@@ -917,7 +967,76 @@ void ScenarioRunWidget::selectRun(int index) {
     }
     selectedRunIndex_ = index;
     scenario_ = batchRunner_.run(static_cast<std::size_t>(selectedRunIndex_)).scenario;
+    syncRunSettingsControls();
     refreshStatus();
+}
+
+void ScenarioRunWidget::syncRunSettingsControls() {
+    if (scenarios_.empty()) {
+        return;
+    }
+    const auto sourceIndex = selectedSourceScenarioIndex();
+    if (sourceIndex >= scenarios_.size()) {
+        return;
+    }
+    const auto& execution = scenarios_[sourceIndex].execution;
+    if (timeLimitSpin_ != nullptr) {
+        timeLimitSpin_->setValue(execution.timeLimitSeconds > 0.0 ? execution.timeLimitSeconds : 600.0);
+    }
+    if (sampleIntervalSpin_ != nullptr) {
+        sampleIntervalSpin_->setValue(execution.sampleIntervalSeconds > 0.0 ? execution.sampleIntervalSeconds : 0.5);
+    }
+    if (repeatSpin_ != nullptr) {
+        repeatSpin_->setValue(std::clamp<int>(
+            static_cast<int>(execution.repeatCount),
+            1,
+            static_cast<int>(safecrowd::domain::kScenarioExecutionMaxRepeatCount)));
+    }
+    if (seedSpin_ != nullptr) {
+        seedSpin_->setValue(execution.baseSeed == 0
+            ? 1
+            : static_cast<int>(std::min<unsigned int>(execution.baseSeed, 1000000U)));
+    }
+}
+
+void ScenarioRunWidget::applyRunSettings() {
+    if (scenarios_.empty()
+        || timeLimitSpin_ == nullptr
+        || sampleIntervalSpin_ == nullptr
+        || repeatSpin_ == nullptr
+        || seedSpin_ == nullptr) {
+        return;
+    }
+
+    const auto timeLimitSeconds = timeLimitSpin_->value();
+    const auto sampleIntervalSeconds = sampleIntervalSpin_->value();
+    const auto repeatCount = static_cast<std::uint32_t>(repeatSpin_->value());
+    const auto baseSeed = static_cast<std::uint32_t>(seedSpin_->value());
+    for (auto& scenario : scenarios_) {
+        scenario.execution.timeLimitSeconds = timeLimitSeconds;
+        scenario.execution.sampleIntervalSeconds = sampleIntervalSeconds;
+        scenario.execution.repeatCount = repeatCount;
+        scenario.execution.baseSeed = baseSeed;
+    }
+
+    playbackSpeedMultiplier_ = 1;
+    paused_ = false;
+    cachedResults_.clear();
+    if (timer_ != nullptr) {
+        timer_->stop();
+    }
+    batchRunner_.reset(layout_, scenarios_);
+    selectedRunIndex_ = normalizedRunIndex(selectedRunIndex_, batchRunner_.size());
+    if (!batchRunner_.empty()) {
+        scenario_ = batchRunner_.run(static_cast<std::size_t>(selectedRunIndex_)).scenario;
+    }
+    if (shell_ != nullptr) {
+        shell_->setCanvas(createRunCanvas());
+    }
+    refreshStatus();
+    if (timer_ != nullptr) {
+        timer_->start();
+    }
 }
 
 void ScenarioRunWidget::cycleFastForwardMode() {

--- a/src/application/ScenarioRunWidget.h
+++ b/src/application/ScenarioRunWidget.h
@@ -13,9 +13,11 @@
 #include "domain/ScenarioAuthoring.h"
 #include "domain/ScenarioBatchRunner.h"
 
+class QDoubleSpinBox;
 class QLabel;
 class QProgressBar;
 class QPushButton;
+class QSpinBox;
 class QTimer;
 
 namespace safecrowd::application {
@@ -89,6 +91,8 @@ private:
     void refreshStatus();
     void selectRun(int index);
     std::size_t selectedSourceScenarioIndex() const;
+    void applyRunSettings();
+    void syncRunSettingsControls();
     void showResults();
     void setPlaybackSpeedMultiplier(int multiplier);
     void stopRun();
@@ -126,6 +130,11 @@ private:
     QPushButton* speed3Button_{nullptr};
     QPushButton* speed5Button_{nullptr};
     QPushButton* resultButton_{nullptr};
+    QDoubleSpinBox* timeLimitSpin_{nullptr};
+    QDoubleSpinBox* sampleIntervalSpin_{nullptr};
+    QSpinBox* repeatSpin_{nullptr};
+    QSpinBox* seedSpin_{nullptr};
+    QPushButton* applySettingsButton_{nullptr};
     int selectedRunIndex_{0};
     int playbackSpeedMultiplier_{1};
     bool paused_{false};

--- a/src/application/ScenarioRunWidget.h
+++ b/src/application/ScenarioRunWidget.h
@@ -92,6 +92,7 @@ private:
     void selectRun(int index);
     std::size_t selectedSourceScenarioIndex() const;
     void applyRunSettings();
+    void syncReturnAuthoringScenarioExecution(std::size_t sourceIndex);
     void syncRunSettingsControls();
     void showResults();
     void setPlaybackSpeedMultiplier(int multiplier);


### PR DESCRIPTION
## Summary

- Add a "Run settings" group to the simulation run screen (`ScenarioRunWidget`) with Time limit, Sample interval, Repeats, and Seed controls plus an "Apply selected & restart" action, so run parameters can be set from the run screen as described in the project report (section 5.3).
- Apply writes the values into the **selected** scenario's execution config (not the whole batch), resets the batch runner, rebuilds the run canvas/cards, and re-selects the edited scenario's run. The change is also synced back to the return-to-authoring state.
- Apply asks for confirmation before discarding completed/cached simulation results, so a finished run is not lost by accident.
- Controls initialize from the selected scenario's execution config and update when the selected run changes.

## Area

- [ ] Engine
- [ ] Domain
- [x] Application

## Architecture Check

- [x] I kept the dependency direction `application -> domain -> engine`.
- [x] I did not add Qt UI code to `src/domain`.
- [x] I did not add `domain` or `application` dependencies to `src/engine`.
- [x] I used `src/` as the include root.

## Verification

- [ ] `cmake --preset windows-debug`
- [ ] `cmake --build --preset build-debug`
- [ ] `ctest --preset test-debug`
- [x] Not run (reason below)

Built the Qt app in release: `cmake --build --preset build-release --target safecrowd_app` -> succeeds. UI-only change driven through the existing domain execution config and batch runner reset.

## Risks / Follow-up

- Settings apply per selected scenario; "Apply selected & restart" restarts the batch and clears cached results after confirmation when a completed run would be discarded.
